### PR TITLE
Migrate episodic to femtologging v0.1.0 (ExecPlan + code + tests)

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -515,6 +515,14 @@ normalizer.
 
 ## Logging
 
-Structured logging uses femtologging. Import `get_logger` from
-`episodic.logging` and emit messages via `log_info`, `log_warning`, or
-`log_error` to keep log levels consistent.
+Structured logging uses femtologging v0.1.0-style logger methods. Import
+`get_logger` (or `getLogger` when matching stdlib naming) from
+`episodic.logging`, then emit via `logger.info(...)`, `logger.warning(...)`,
+`logger.error(...)`, or `logger.exception(...)`.
+
+Keep `episodic.logging.configure_logging(...)` as the local configuration seam.
+The legacy `log_info`, `log_warning`, and `log_error` helpers remain available
+for compatibility, but new code should prefer calling the logger methods
+directly. Femtologging still expects pre-formatted messages rather than stdlib
+`logger.info("%s", value)` lazy formatting, so build the final string before
+calling the method.

--- a/docs/execplans/femtologging-april-2026-migration.md
+++ b/docs/execplans/femtologging-april-2026-migration.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision log`, and `Outcomes & retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
 ## Purpose and big picture
 
@@ -131,12 +131,19 @@ Success is observable in six ways:
   the target femtologging revision `691a73962df8f99308a82348d99c4f707c245e63`
   directly.
 - [x] (2026-04-08 00:00Z) Drafted this ExecPlan.
-- [ ] Stage A: add fail-first logging regression tests.
-- [ ] Stage B: update the femtologging pin and refresh `uv.lock`.
-- [ ] Stage C: align `episodic` call sites and compatibility helpers with the
-  stdlib-like API.
-- [ ] Stage D: update maintainer documentation and local femtologging guide.
-- [ ] Stage E: run full validation and capture evidence.
+- [x] (2026-04-08 20:40Z) Stage A: added fail-first logging regression tests
+  in `tests/test_logging.py` and confirmed they failed against the old
+  dependency because `getLogger`, logger convenience methods, and
+  `isEnabledFor` were absent.
+- [x] (2026-04-08 20:42Z) Stage B: updated the femtologging pin in
+  `pyproject.toml`, refreshed `uv.lock`, and confirmed the lockfile diff was
+  limited to the targeted SHA movement.
+- [x] (2026-04-08 20:50Z) Stage C: aligned `episodic` call sites and
+  compatibility helpers with the stdlib-like API.
+- [x] (2026-04-08 20:56Z) Stage D: updated maintainer documentation and the
+  local femtologging guide for the v0.1.0 surface.
+- [x] (2026-04-08 21:10Z) Stage E: ran the full repository gate set and
+  captured evidence under `/tmp/femtologging-migration-*.log`.
 
 ## Surprises & discoveries
 
@@ -174,6 +181,15 @@ Success is observable in six ways:
   need a breaking redesign just to survive the dependency bump. Impact: the
   migration can stay incremental.
 
+- Observation: femtologging v0.1.0 adds stdlib-style method names, but it
+  still does not implement stdlib lazy `*args` formatting. Impact: the direct
+  call-site migration must build final strings before calling
+  `logger.info(...)` or `logger.error(...)`.
+
+- Observation: runtime handler assertions need an explicit
+  `logger.flush_handlers()` before checking collected Python-handler output.
+  Impact: integration tests should flush before asserting on emitted records.
+
 ## Decision log
 
 - Decision: use a compatibility-first migration. Bump the dependency and
@@ -205,16 +221,27 @@ Success is observable in six ways:
 
 Outcome:
 
-- No code has been changed yet. This document defines the implementation path
-  and the evidence that must be captured when the migration is executed.
+- `pyproject.toml` and `uv.lock` now pin femtologging to
+  `691a73962df8f99308a82348d99c4f707c245e63`.
+- `tests/test_logging.py` covers wrapper normalization, compatibility helpers,
+  `getLogger`, direct convenience methods, and `isEnabledFor`.
+- `episodic.logging` remains the configuration seam, now re-exporting
+  `getLogger` and delegating compatibility helpers through direct logger
+  methods.
+- The internal logging call sites in ingestion, canonical services, unit of
+  work, and schema-drift detection now use direct logger methods.
+- Maintainer docs were updated to stop teaching wrapper-only usage and stale
+  builder names.
 
-Retrospective so far:
+Retrospective:
 
-- The actual code migration is likely small.
-- The larger risk is stale local guidance and missing regression tests.
-- The target femtologging revision is intentionally closer to stdlib logging,
-  so the migration should use that to simplify touched call sites rather than
-  preserving wrapper-heavy patterns everywhere.
+- The code migration was small, but the missing tests and stale docs were the
+  real risk surface.
+- Compatibility-first worked: the wrapper remains available without blocking
+  direct stdlib-style usage in touched code.
+- The main behavioural nuance worth preserving in docs and tests is that
+  femtologging v0.1.0 keeps pre-formatted-message semantics even though the
+  method names now look more like stdlib logging.
 
 ## Context and orientation
 

--- a/docs/execplans/femtologging-april-2026-migration.md
+++ b/docs/execplans/femtologging-april-2026-migration.md
@@ -454,13 +454,16 @@ Run all commands from the repository root.
 
 5. Stage D and E final repository gates:
 
+   Ensure the `markdownlint-cli2` executable required by `make markdownlint` is
+   already available on `PATH` before running this sequence.
+
    ```shell
    set -o pipefail; make fmt 2>&1 | tee /tmp/femtologging-migration-make-fmt.log
    set -o pipefail; make check-fmt 2>&1 | tee /tmp/femtologging-migration-make-check-fmt.log
    set -o pipefail; make lint 2>&1 | tee /tmp/femtologging-migration-make-lint.log
    set -o pipefail; make typecheck 2>&1 | tee /tmp/femtologging-migration-make-typecheck.log
    set -o pipefail; make test 2>&1 | tee /tmp/femtologging-migration-make-test.log
-   set -o pipefail; PATH=/root/.bun/bin:$PATH make markdownlint 2>&1 | \
+   set -o pipefail; make markdownlint 2>&1 | \
      tee /tmp/femtologging-migration-make-markdownlint.log
    set -o pipefail; make nixie 2>&1 | tee /tmp/femtologging-migration-make-nixie.log
    ```

--- a/docs/execplans/femtologging-april-2026-migration.md
+++ b/docs/execplans/femtologging-april-2026-migration.md
@@ -14,7 +14,7 @@ revision `7c139fb7aca18f9277e00b88604b8bf5eb471be0` in `pyproject.toml` and
 `uv.lock`. The target revision `691a73962df8f99308a82348d99c4f707c245e63`
 includes the v0.1.0 migration changes documented in the upstream migration
 guide:
-<https://raw.githubusercontent.com/leynos/femtologging/refs/heads/main/docs/v0-1-0-migration-guide.md>.
+<https://raw.githubusercontent.com/leynos/femtologging/691a73962df8f99308a82348d99c4f707c245e63/docs/v0-1-0-migration-guide.md>.
 
 The practical goal is not only to bump the pinned dependency, but to align the
 `episodic` codebase with the newer stdlib-like logging surface where it helps:
@@ -510,7 +510,7 @@ The migration is complete only when all of the following are true:
 
 ## Artifacts and notes
 
-Expected evidence artefacts:
+Expected evidence artifacts:
 
 - `/tmp/femtologging-migration-git-status.log`
 - `/tmp/femtologging-migration-scan.log`

--- a/docs/execplans/femtologging-april-2026-migration.md
+++ b/docs/execplans/femtologging-april-2026-migration.md
@@ -83,7 +83,7 @@ Success is observable in six ways:
   cannot be handled with a local compatibility shim.
 - Documentation tolerance: stop and escalate if updating
   `docs/femtologging-users-guide.md` would require a full upstream-document
-  resynchronisation larger than this migration itself. In that case, switch to
+  resynchronization larger than this migration itself. In that case, switch to
   a smaller accuracy-focused update and record the divergence explicitly.
 - Behaviour tolerance: stop and escalate after three failed attempts to make
   the same new logging test pass against the target dependency.
@@ -328,7 +328,7 @@ dependency pin.
 
 Add a new test module, expected to be `tests/test_logging.py`, covering:
 
-- `configure_logging(...)` normalisation and defaulting behaviour
+- `configure_logging(...)` normalization and defaulting behaviour
 - wrapper-level `log_info(...)` / `log_warning(...)` / `log_error(...)`
   compatibility against a lightweight spy object
 - integration coverage against the real femtologging runtime for the intended
@@ -503,7 +503,7 @@ The migration is complete only when all of the following are true:
   files on the wrapper for this revision and record that decision in
   `Decision log`; the dependency bump and documentation refresh can still ship
   separately.
-- If documentation synchronisation becomes too large, reduce Stage D to the
+- If documentation synchronization becomes too large, reduce Stage D to the
   sections known to be wrong and record the remaining drift explicitly in
   `Surprises & Discoveries`.
 - Preserve all `/tmp/femtologging-migration-*.log` files as the evidence trail.

--- a/docs/execplans/femtologging-april-2026-migration.md
+++ b/docs/execplans/femtologging-april-2026-migration.md
@@ -1,0 +1,540 @@
+# Migrate episodic to femtologging v0.1.0 API at SHA 691a73962df8f99308a82348d99c4f707c245e63
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision log`, and `Outcomes & retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+## Purpose and big picture
+
+`episodic` already depends on `femtologging`, but it is pinned to the older Git
+revision `7c139fb7aca18f9277e00b88604b8bf5eb471be0` in `pyproject.toml` and
+`uv.lock`. The target revision `691a73962df8f99308a82348d99c4f707c245e63`
+includes the v0.1.0 migration changes documented in the upstream migration
+guide:
+<https://raw.githubusercontent.com/leynos/femtologging/refs/heads/main/docs/v0-1-0-migration-guide.md>.
+
+The practical goal is not only to bump the pinned dependency, but to align the
+`episodic` codebase with the newer stdlib-like logging surface where it helps:
+direct `logger.info(...)` / `logger.error(...)` style calls,
+`logger.exception(...)`, `logger.isEnabledFor(...)`, and the `getLogger`
+compatibility alias. At the same time, the migration must preserve local
+behaviour that `episodic` currently relies on, especially
+`episodic.logging.configure_logging(...)` and the small amount of existing
+call-site logging inside the canonical-storage and ingestion code.
+
+Success is observable in six ways:
+
+1. `pyproject.toml` and `uv.lock` both pin `femtologging` to
+   `691a73962df8f99308a82348d99c4f707c245e63`.
+2. New fail-first tests cover the current `episodic.logging` wrapper and the
+   intended stdlib-style usage inside `episodic`.
+3. `episodic` code that currently uses `log_info(...)` / `log_error(...)`
+   either continues to work through thin compatibility shims or is migrated to
+   direct logger convenience methods without changing observable behaviour.
+4. No code or tests in `episodic` rely on the upstream renamed flush-builder
+   methods, old `as_dict()` keys, or old validation strings after the migration.
+5. Maintainer documentation is updated so it no longer teaches the stale
+   pre-v0.1.0 femtologging surface.
+6. All required repository gates pass after the migration:
+   `make fmt`, `make check-fmt`, `make lint`, `make typecheck`, `make test`,
+   `make markdownlint`, and `make nixie`.
+
+## Constraints
+
+- Keep the migration dependency-scoped. This is a logging-runtime upgrade, not
+  a broad observability redesign.
+- Preserve the current public `episodic` package surface unless there is a
+  strong, documented reason to change it. In particular,
+  `episodic.logging.configure_logging(...)` must either remain available or be
+  replaced by a compatibility shim in the same module.
+- Prefer the upstream stdlib-like `FemtoLogger` convenience methods for new or
+  touched `episodic` call sites, but do not remove compatibility helpers until
+  equivalent test coverage exists.
+- Treat completed historical ExecPlans in `docs/execplans/` as archival
+  records. Do not churn them solely to replace legacy logging examples unless a
+  specific plan is still active or normative.
+- Update maintainer-facing documentation that is meant to describe current
+  practice:
+  - `docs/developers-guide.md`
+  - `docs/femtologging-users-guide.md`
+- Do not invent builder-based usage in order to exercise the upstream rename.
+  Discovery already shows that the repository does not use the renamed builder
+  methods in production code.
+- Use test-first workflow for each touched behaviour:
+  1. add or modify tests,
+  2. confirm the new or updated tests fail,
+  3. implement the code change,
+  4. rerun targeted tests,
+  5. rerun all repository gates.
+- Prefer Makefile targets where they exist. The repository does not expose a
+  lockfile-refresh target, so `uv lock` may be invoked directly for that one
+  step.
+
+## Tolerances
+
+- Scope tolerance: stop and escalate if the migration requires more than
+  roughly 10 source files and 8 documentation files, or more than about 700 net
+  lines, before a working vertical slice exists.
+- API tolerance: stop and escalate if the new femtologging revision breaks
+  `basicConfig(...)`, `get_logger(...)`, or `logger.log(...)` in a way that
+  cannot be handled with a local compatibility shim.
+- Documentation tolerance: stop and escalate if updating
+  `docs/femtologging-users-guide.md` would require a full upstream-document
+  resynchronisation larger than this migration itself. In that case, switch to
+  a smaller accuracy-focused update and record the divergence explicitly.
+- Behaviour tolerance: stop and escalate after three failed attempts to make
+  the same new logging test pass against the target dependency.
+- Dependency tolerance: stop and escalate if the target femtologging SHA
+  requires additional new runtime dependencies in `episodic`.
+
+## Risks
+
+- Risk: `episodic/logging.py` has no direct tests today, so an apparently small
+  dependency bump could silently change wrapper behaviour. Severity: high.
+  Likelihood: high. Mitigation: add wrapper-focused unit and integration tests
+  before changing the pinned SHA.
+
+- Risk: the local `docs/femtologging-users-guide.md` is materially behind the
+  target upstream revision. It still documents old builder names and claims
+  that convenience methods do not exist. Severity: medium. Likelihood: high.
+  Mitigation: update the local guide from the target SHA, or at minimum replace
+  all sections known to be stale.
+
+- Risk: the repo-wide guidance in `docs/developers-guide.md` currently tells
+  maintainers to use `episodic.logging` wrappers, which could work against the
+  upstream stdlib-alignment goal. Severity: medium. Likelihood: high.
+  Mitigation: update the guide to distinguish between the minimal compatibility
+  wrapper and the preferred direct `FemtoLogger` convenience methods for new
+  code.
+
+- Risk: moving existing call sites from `log_info(...)` to `logger.info(...)`
+  can accidentally introduce eager string interpolation where the old wrapper
+  used percent-style templates. Severity: low. Likelihood: medium. Mitigation:
+  only migrate the four existing internal call sites, and use
+  `logger.isEnabledFor(...)` if any new string construction becomes materially
+  expensive.
+
+- Risk: lockfile refresh can cause unrelated dependency churn. Severity: medium.
+  Likelihood: medium. Mitigation: pin the exact femtologging SHA, inspect the
+  resulting `uv.lock` diff closely, and do not accept unrelated upgrades.
+
+## Progress
+
+- [x] (2026-04-08 00:00Z) Queried project memory and reviewed repository
+  instructions, quality gates, and documentation rules.
+- [x] (2026-04-08 00:00Z) Audited the current repository usage of
+  `femtologging`, `episodic.logging`, and related documentation.
+- [x] (2026-04-08 00:00Z) Verified the upstream migration guide and inspected
+  the target femtologging revision `691a73962df8f99308a82348d99c4f707c245e63`
+  directly.
+- [x] (2026-04-08 00:00Z) Drafted this ExecPlan.
+- [ ] Stage A: add fail-first logging regression tests.
+- [ ] Stage B: update the femtologging pin and refresh `uv.lock`.
+- [ ] Stage C: align `episodic` call sites and compatibility helpers with the
+  stdlib-like API.
+- [ ] Stage D: update maintainer documentation and local femtologging guide.
+- [ ] Stage E: run full validation and capture evidence.
+
+## Surprises & discoveries
+
+- Observation: the repository does not use the upstream-renamed builder methods
+  (`with_flush_timeout_ms`, `with_flush_record_interval`) anywhere in
+  production code or tests. Impact: the upstream breaking changes are mostly a
+  documentation and compatibility-audit exercise for `episodic`, not a large
+  code rewrite.
+
+- Observation: `episodic/logging.py` is a small local wrapper that imports only
+  `basicConfig` and `get_logger`, then adds three convenience helpers
+  (`log_info`, `log_warning`, `log_error`). Impact: the migration can either
+  keep this as a compatibility facade or thin it further while moving the few
+  internal call sites to direct `FemtoLogger` methods.
+
+- Observation: only four code locations currently import the wrapper helpers:
+  `episodic/canonical/ingestion_service.py`, `episodic/canonical/services.py`,
+  `episodic/canonical/storage/migration_check.py`, and
+  `episodic/canonical/storage/uow.py`. Impact: direct call-site migration is
+  cheap if the implementation chooses it.
+
+- Observation: `docs/femtologging-users-guide.md` is stale relative to the
+  target upstream revision. It still mentions `.with_flush_timeout_ms(...)`,
+  says convenience methods are not implemented, and omits `getLogger`,
+  `isEnabledFor`, and `StdlibHandlerAdapter`. Impact: documentation is part of
+  the real migration surface and cannot be skipped.
+
+- Observation: `docs/developers-guide.md` currently tells maintainers to import
+  `get_logger` from `episodic.logging` and emit via `log_info`, `log_warning`,
+  or `log_error`. Impact: a decision is needed about whether those wrappers
+  remain the preferred style or become legacy compatibility shims.
+
+- Observation: the target femtologging revision still accepts
+  `basicConfig(level=..., force=...)`, so `configure_logging(...)` does not
+  need a breaking redesign just to survive the dependency bump. Impact: the
+  migration can stay incremental.
+
+## Decision log
+
+- Decision: use a compatibility-first migration. Bump the dependency and
+  protect existing `episodic.logging` behaviour with tests before deciding how
+  much wrapper cleanup to do. Rationale: the wrapper is currently untested, and
+  dependency-only changes are safest when anchored by new regression tests.
+  Date/Author: 2026-04-08 / Codex.
+
+- Decision: prefer direct `FemtoLogger` convenience methods in touched
+  `episodic` production code, but keep `episodic.logging` available for
+  configuration and compatibility during this migration. Rationale: the target
+  revision adds stdlib-like methods specifically to reduce the need for local
+  wrappers, but removing the wrapper entirely would create avoidable churn.
+  Date/Author: 2026-04-08 / Codex.
+
+- Decision: do not mass-edit completed historical ExecPlans that mention the
+  wrapper. Rationale: those files document how earlier work was delivered, not
+  the preferred style for future changes. Current maintainer guidance should be
+  corrected in `docs/developers-guide.md` instead. Date/Author: 2026-04-08 /
+  Codex.
+
+- Decision: treat the local `docs/femtologging-users-guide.md` as a tracked
+  local copy of upstream guidance and update it to match the target dependency
+  revision. Rationale: the file is already in the repository and is clearly
+  meant to describe current femtologging behaviour for maintainers.
+  Date/Author: 2026-04-08 / Codex.
+
+## Outcomes & retrospective
+
+Outcome:
+
+- No code has been changed yet. This document defines the implementation path
+  and the evidence that must be captured when the migration is executed.
+
+Retrospective so far:
+
+- The actual code migration is likely small.
+- The larger risk is stale local guidance and missing regression tests.
+- The target femtologging revision is intentionally closer to stdlib logging,
+  so the migration should use that to simplify touched call sites rather than
+  preserving wrapper-heavy patterns everywhere.
+
+## Context and orientation
+
+### Current dependency state
+
+The repository currently pins femtologging in two places:
+
+- `pyproject.toml`
+- `uv.lock`
+
+Both point at the older Git revision
+`7c139fb7aca18f9277e00b88604b8bf5eb471be0`. The target revision for this
+migration is `691a73962df8f99308a82348d99c4f707c245e63`.
+
+### Current local logging wrapper
+
+`episodic/logging.py` currently:
+
+- re-exports `get_logger` from femtologging,
+- wraps `basicConfig(...)` in `configure_logging(...)`,
+- defines `log_info(...)`, `log_warning(...)`, and `log_error(...)`,
+- uses a local `_SupportsLog` protocol that targets `logger.log(...)`.
+
+The wrapper is not referenced by any direct test file today.
+
+### Current internal call sites
+
+Only four production files use the wrapper today:
+
+- `episodic/canonical/ingestion_service.py`
+- `episodic/canonical/services.py`
+- `episodic/canonical/storage/migration_check.py`
+- `episodic/canonical/storage/uow.py`
+
+These call sites are simple enough to move to `logger.info(...)`,
+`logger.error(...)`, or `logger.exception(...)` if desired.
+
+### Upstream change surface relevant to episodic
+
+From the upstream migration guide and direct inspection of the target revision:
+
+- Builder method renames:
+  - `with_flush_timeout_ms(...)` ->
+    `with_flush_after_ms(...)`
+  - `with_flush_record_interval(...)` ->
+    `with_flush_after_records(...)`
+- Matching `as_dict()` key renames:
+  - `flush_timeout_ms` -> `flush_after_ms`
+  - `flush_record_interval` -> `flush_after_records`
+- Matching validation message renames:
+  - `flush_timeout_ms must be greater than zero` ->
+    `flush_after_ms must be greater than zero`
+  - `flush_record_interval must be greater than zero` ->
+    `flush_after_records must be greater than zero`
+- New stdlib-like additions:
+  - `logger.debug(...)`, `logger.info(...)`, `logger.warning(...)`,
+    `logger.error(...)`, `logger.critical(...)`, `logger.exception(...)`
+  - `logger.isEnabledFor(...)`
+  - `getLogger(...)` alias for `get_logger(...)`
+  - `StdlibHandlerAdapter` for wrapping stdlib `logging.Handler` instances
+
+Only the additions, not the builder renames, appear relevant to current
+`episodic` production code.
+
+### Known documentation gap
+
+The local `docs/femtologging-users-guide.md` is out of date relative to the
+target dependency. At minimum, the following sections are known to need
+revision:
+
+- `FemtoStreamHandler` builder method naming
+- the statements about convenience methods being unavailable
+- the `basicConfig` / compatibility sections where stdlib alignment is now
+  wider than before
+- the deviations section that still says there is no `LoggerAdapter` bridge,
+  even though `StdlibHandlerAdapter` now exists
+
+## Plan of work
+
+### Stage A: add fail-first logging regression tests
+
+Create direct tests for the local logging surface before touching the
+dependency pin.
+
+Add a new test module, expected to be `tests/test_logging.py`, covering:
+
+- `configure_logging(...)` normalisation and defaulting behaviour
+- wrapper-level `log_info(...)` / `log_warning(...)` / `log_error(...)`
+  compatibility against a lightweight spy object
+- integration coverage against the real femtologging runtime for the intended
+  post-migration usage:
+  - `logger.info(...)`
+  - `logger.error(..., exc_info=True)`
+  - `logger.exception(...)`
+  - `logger.isEnabledFor(...)`
+
+The red phase should demonstrate at least one expectation that the current
+repository does not yet encode, such as the preferred direct convenience-method
+usage or any newly documented wrapper compatibility behaviour.
+
+Go/no-go: the new tests fail before implementation, and the failure is clearly
+explained in the test names or assertions.
+
+### Stage B: update the femtologging pin and refresh uv.lock
+
+Update both dependency declarations:
+
+- `pyproject.toml`
+- `uv.lock`
+
+Use the exact Git revision `691a73962df8f99308a82348d99c4f707c245e63`. Keep the
+lockfile diff narrow. If `uv lock` pulls unrelated upgrades, revert and retry
+with a more targeted dependency refresh approach.
+
+Go/no-go: `pyproject.toml` and `uv.lock` both point at the target SHA, and the
+lockfile diff contains only the expected femtologging movement.
+
+### Stage C: align episodic code with the stdlib-like API
+
+Refactor the tiny set of internal call sites to use the newer upstream logger
+convenience methods where it improves clarity:
+
+- `logger.info(...)` for simple informational logs
+- `logger.error(...)` or `logger.exception(...)` where exception capture is the
+  actual intent
+
+Keep `episodic/logging.py` as a small compatibility module, but simplify it so
+it no longer hides the upstream API unnecessarily. The expected end state is:
+
+- `configure_logging(...)` remains available
+- `get_logger(...)` remains available, and optionally `getLogger(...)` is
+  re-exported if that improves internal consistency
+- legacy wrapper helpers remain only if there is still local value in keeping
+  them, and if retained they should delegate to the new convenience methods
+  rather than duplicating logging semantics
+
+Do not remove the compatibility helpers until the new logging tests are green.
+
+Go/no-go: all touched production call sites compile, the logging tests pass,
+and the wrapper module has a clear, smaller purpose.
+
+### Stage D: update maintainer documentation
+
+Update the maintainer-facing docs to reflect the new dependency revision and
+the intended local usage style.
+
+Required files:
+
+- `docs/developers-guide.md`
+- `docs/femtologging-users-guide.md`
+- this ExecPlan, updating status/progress/discoveries as implementation
+  proceeds
+
+Documentation changes should:
+
+- stop teaching the old builder method names
+- stop claiming that convenience methods are unavailable
+- explain whether new `episodic` code should prefer direct `logger.info(...)`
+  style calls or the local compatibility wrapper
+- mention `getLogger(...)`, `isEnabledFor(...)`, and `StdlibHandlerAdapter`
+  where relevant
+
+Go/no-go: maintainer guidance no longer contradicts the target femtologging
+revision.
+
+### Stage E: run full validation and capture evidence
+
+After the targeted tests and docs are green, run the full repository gates in
+the required order and capture all output via `tee`.
+
+Go/no-go: all gates exit `0`, and the resulting logs are saved under `/tmp/`.
+
+## Concrete steps
+
+Run all commands from the repository root.
+
+1. Baseline discovery and current-state evidence:
+
+   ```shell
+   set -o pipefail; git status --short 2>&1 | tee /tmp/femtologging-migration-git-status.log
+   set -o pipefail; rg -n "femtologging|episodic\\.logging|log_info\\(|log_warning\\(|log_error\\(" \
+     pyproject.toml uv.lock episodic docs tests 2>&1 | \
+     tee /tmp/femtologging-migration-scan.log
+   ```
+
+2. Stage A red phase:
+
+   ```shell
+   set -o pipefail; PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 \
+     uv run pytest -v tests/test_logging.py 2>&1 | \
+     tee /tmp/femtologging-migration-red-logging.log
+   ```
+
+3. Stage B dependency refresh:
+
+   ```shell
+   set -o pipefail; PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 \
+     uv lock 2>&1 | tee /tmp/femtologging-migration-uv-lock.log
+   set -o pipefail; make build 2>&1 | tee /tmp/femtologging-migration-make-build.log
+   ```
+
+4. Stage C targeted green checks after code changes:
+
+   ```shell
+   set -o pipefail; PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 \
+     uv run pytest -v tests/test_logging.py tests/test_migration_check.py \
+     tests/canonical_storage/test_unit_of_work.py tests/test_ingestion_integration.py \
+     2>&1 | tee /tmp/femtologging-migration-green-targeted.log
+   ```
+
+5. Stage D and E final repository gates:
+
+   ```shell
+   set -o pipefail; make fmt 2>&1 | tee /tmp/femtologging-migration-make-fmt.log
+   set -o pipefail; make check-fmt 2>&1 | tee /tmp/femtologging-migration-make-check-fmt.log
+   set -o pipefail; make lint 2>&1 | tee /tmp/femtologging-migration-make-lint.log
+   set -o pipefail; make typecheck 2>&1 | tee /tmp/femtologging-migration-make-typecheck.log
+   set -o pipefail; make test 2>&1 | tee /tmp/femtologging-migration-make-test.log
+   set -o pipefail; PATH=/root/.bun/bin:$PATH make markdownlint 2>&1 | \
+     tee /tmp/femtologging-migration-make-markdownlint.log
+   set -o pipefail; make nixie 2>&1 | tee /tmp/femtologging-migration-make-nixie.log
+   ```
+
+Expected success indicators:
+
+- `tests/test_logging.py` fails before the implementation and passes after it.
+- The lockfile diff is narrow and points at the target femtologging SHA.
+- The touched production modules still pass their targeted tests.
+- Maintainer docs describe the new API correctly.
+- All make targets complete successfully.
+
+## Validation and acceptance
+
+The migration is complete only when all of the following are true:
+
+- `pyproject.toml` pins femtologging to
+  `691a73962df8f99308a82348d99c4f707c245e63`.
+- `uv.lock` matches the same femtologging revision.
+- Logging regression tests exist and pass.
+- Touched `episodic` code uses the intended post-migration logging style.
+- `episodic/logging.py` remains accurate and test-covered.
+- `docs/developers-guide.md` no longer recommends stale wrapper-only usage.
+- `docs/femtologging-users-guide.md` no longer documents the pre-v0.1.0 API.
+- All required quality gates pass:
+  - `make fmt`
+  - `make check-fmt`
+  - `make lint`
+  - `make typecheck`
+  - `make test`
+  - `make markdownlint`
+  - `make nixie`
+
+## Idempotence and recovery
+
+- All steps are re-runnable.
+- If `uv lock` introduces unrelated dependency churn, revert the lockfile and
+  retry the refresh with the dependency pin narrowed first.
+- If direct call-site migration proves unexpectedly noisy, keep the production
+  files on the wrapper for this revision and record that decision in
+  `Decision log`; the dependency bump and documentation refresh can still ship
+  separately.
+- If documentation synchronisation becomes too large, reduce Stage D to the
+  sections known to be wrong and record the remaining drift explicitly in
+  `Surprises & Discoveries`.
+- Preserve all `/tmp/femtologging-migration-*.log` files as the evidence trail.
+
+## Artifacts and notes
+
+Expected evidence artefacts:
+
+- `/tmp/femtologging-migration-git-status.log`
+- `/tmp/femtologging-migration-scan.log`
+- `/tmp/femtologging-migration-red-logging.log`
+- `/tmp/femtologging-migration-uv-lock.log`
+- `/tmp/femtologging-migration-make-build.log`
+- `/tmp/femtologging-migration-green-targeted.log`
+- `/tmp/femtologging-migration-make-fmt.log`
+- `/tmp/femtologging-migration-make-check-fmt.log`
+- `/tmp/femtologging-migration-make-lint.log`
+- `/tmp/femtologging-migration-make-typecheck.log`
+- `/tmp/femtologging-migration-make-test.log`
+- `/tmp/femtologging-migration-make-markdownlint.log`
+- `/tmp/femtologging-migration-make-nixie.log`
+
+Implementation files expected to change:
+
+- `pyproject.toml`
+- `uv.lock`
+- `episodic/logging.py`
+- `episodic/canonical/ingestion_service.py`
+- `episodic/canonical/services.py`
+- `episodic/canonical/storage/migration_check.py`
+- `episodic/canonical/storage/uow.py`
+- `tests/test_logging.py`
+- `docs/developers-guide.md`
+- `docs/femtologging-users-guide.md`
+
+## Interfaces and dependencies
+
+Upstream interfaces expected to matter during implementation:
+
+- `femtologging.basicConfig(...)`
+- `femtologging.get_logger(...)`
+- `femtologging.getLogger(...)`
+- `FemtoLogger.log(...)`
+- `FemtoLogger.info(...)`
+- `FemtoLogger.warning(...)`
+- `FemtoLogger.error(...)`
+- `FemtoLogger.exception(...)`
+- `FemtoLogger.isEnabledFor(...)`
+- `StdlibHandlerAdapter`
+
+Local interfaces expected to matter during implementation:
+
+- `episodic.logging.configure_logging(...)`
+- `episodic.logging.get_logger(...)`
+- `episodic.logging.log_info(...)`
+- `episodic.logging.log_warning(...)`
+- `episodic.logging.log_error(...)`
+
+The implementation should actively decide which of the local wrapper helpers
+remain part of the preferred internal style after the dependency bump, then
+document that decision in `Decision log` and `docs/developers-guide.md`.

--- a/docs/femtologging-users-guide.md
+++ b/docs/femtologging-users-guide.md
@@ -16,12 +16,11 @@ pip install .
 ```
 
 ```python
-from femtologging import FemtoStreamHandler, get_logger
+from femtologging import FemtoStreamHandler, getLogger
 
-logger = get_logger("demo.app")
+logger = getLogger("demo.app")
 logger.add_handler(FemtoStreamHandler.stderr())
-
-logger.log("INFO", "hello from femtologging")
+logger.info("hello from femtologging")
 ```
 
 Handlers run in background threads, so remember to flush or close them before
@@ -48,7 +47,8 @@ your process exits.
 
 ### Creating and naming loggers
 
-- Use `get_logger(name)` to obtain a singleton `FemtoLogger`. Names must not be
+- Use `get_logger(name)` to obtain a singleton `FemtoLogger`. `getLogger(name)`
+  is an equivalent alias when you want stdlib-style naming. Names must not be
   empty, start or end with `.`, or contain consecutive dots.
 - Logger parents are derived from dotted names. `get_logger("api.v1")` creates
   a parent `api` logger that ultimately propagates to `root`.
@@ -65,11 +65,18 @@ your process exits.
   (default format is `"{logger} [LEVEL] message"`), or `None` when the record
   is filtered out. This differs from `logging.Logger.log()`, which always
   returns `None`.
-- Convenience methods (`logger.info`, `logger.warning`, and so on) are not
-  implemented yet; call `log()` directly or wrap it in a helper.
+- Convenience methods (`logger.debug`, `logger.info`, `logger.warning`,
+  `logger.error`, `logger.critical`, and `logger.exception`) are available and
+  accept a pre-formatted message plus optional `exc_info` and `stack_info`
+  keyword arguments.
+- `logger.exception(message)` behaves like `logger.error(message)` but defaults
+  `exc_info=True`, so it automatically captures the active exception.
+- `logger.isEnabledFor(level)` is available for guarding expensive message
+  construction.
 - Currently, `FemtoLogger` sends only the text form of each record to handlers.
-  There is no equivalent to `extra`, `exc_info`, `stack_info`, or lazy
-  formatting. Build the final message string yourself before calling `log()`.
+  There is no equivalent to `extra` or stdlib lazy `*args` / `**kwargs`
+  formatting. Build the final message string yourself before calling a logger
+  method.
 
 ### Managing handlers and custom sinks
 
@@ -97,8 +104,8 @@ your process exits.
 - `handler.flush()` waits (up to one second by default) for the worker to flush
   buffered writes and returns `True` on success. `handler.close()` shuts down
   the worker thread and should be called before process exit.
-- To tune capacity, flush timeout, or formatters use `StreamHandlerBuilder`. It
-  provides `.with_capacity(n)`, `.with_flush_timeout_ms(ms)`, and
+- To tune capacity, flush timing, or formatters use `StreamHandlerBuilder`. It
+  provides `.with_capacity(n)`, `.with_flush_after_ms(ms)`, and
   `.with_formatter(callable_or_id)` fluent methods before calling `.build()`.
 
 ### FemtoFileHandler
@@ -395,21 +402,19 @@ stream = StreamHandlerBuilder.stdout().with_formatter(json_formatter).build()
 
 ## Deviations from stdlib logging
 
-- No shorthand methods (`info`, `debug`, `warning`, …) or `LoggerAdapter`.
-- `log()` returns the formatted string instead of `None`, and there is no
-  `Logger.isEnabledFor()` helper.
-- Records lack `extra`, `exc_info`, `stack_info`, and stack introspection.
+- `log()` returns the formatted string instead of `None`.
+- Records still lack `extra` and stdlib lazy `*args` / `**kwargs` formatting.
 - Handlers expect `handle(logger, level, message)` rather than `emit(LogRecord)`
-  and run on dedicated worker threads, so Python `logging.Handler` subclasses
-  cannot be reused.
+  unless you wrap a stdlib handler with `StdlibHandlerAdapter`.
 - The `dictConfig` schema lacks incremental updates, filters, handler levels,
   and formatter attachment. `fileConfig` is likewise cut down.
 - Queue capacity is capped (1 024 per logger/handler). The stdlib blocks the
   emitting thread; femtologging drops records and emits warnings instead.
 - Formatting styles (`%`, `{}`, `$`) are not implemented. Provide the final
   string yourself, or supply a callable formatter per handler.
-- The logging manager is separate from `logging`’s global state. Mixing both
-  systems in the same process is unsupported.
+- The logging manager is separate from `logging`’s global state. Use
+  `StdlibHandlerAdapter` when you need a stdlib `logging.Handler` subclass to
+  receive femtologging records, but do not treat this as shared global state.
 
 ## Operational tips and caveats
 

--- a/docs/femtologging-users-guide.md
+++ b/docs/femtologging-users-guide.md
@@ -48,8 +48,8 @@ your process exits.
 ### Creating and naming loggers
 
 - Use `get_logger(name)` to obtain a singleton `FemtoLogger`. `getLogger(name)`
-  is an equivalent alias when you want stdlib-style naming. Names must not be
-  empty, start or end with `.`, or contain consecutive dots.
+  is an equivalent alias for stdlib-style naming. Names must not be empty,
+  start or end with `.`, or contain consecutive dots.
 - Logger parents are derived from dotted names. `get_logger("api.v1")` creates
   a parent `api` logger that ultimately propagates to `root`.
 - Call `logger.set_propagate(False)` to stop parent propagation. The default is
@@ -75,8 +75,7 @@ your process exits.
   construction.
 - Currently, `FemtoLogger` sends only the text form of each record to handlers.
   There is no equivalent to `extra` or stdlib lazy `*args` / `**kwargs`
-  formatting. Build the final message string yourself before calling a logger
-  method.
+  formatting. Build the final message string before calling a logger method.
 
 ### Managing handlers and custom sinks
 
@@ -411,9 +410,9 @@ stream = StreamHandlerBuilder.stdout().with_formatter(json_formatter).build()
 - Queue capacity is capped (1 024 per logger/handler). The stdlib blocks the
   emitting thread; femtologging drops records and emits warnings instead.
 - Formatting styles (`%`, `{}`, `$`) are not implemented. Provide the final
-  string yourself, or supply a callable formatter per handler.
-- The logging manager is separate from `logging`’s global state. Use
-  `StdlibHandlerAdapter` when you need a stdlib `logging.Handler` subclass to
+  string, or supply a callable formatter per handler.
+- The logging manager is separate from `logging`’s global state.
+  Use `StdlibHandlerAdapter` when a stdlib `logging.Handler` subclass must
   receive femtologging records, but do not treat this as shared global state.
 
 ## Operational tips and caveats

--- a/episodic/canonical/ingestion_service.py
+++ b/episodic/canonical/ingestion_service.py
@@ -21,7 +21,7 @@ import dataclasses as dc
 import typing as typ
 
 from episodic.asyncio_tasks import TaskMetadata, create_task
-from episodic.logging import get_logger, log_info
+from episodic.logging import get_logger
 
 from .domain import IngestionRequest
 from .services import ingest_sources
@@ -190,14 +190,10 @@ def _log_multi_source_outcome(
     episode: CanonicalEpisode,
 ) -> None:
     """Log the completed multi-source ingestion outcome."""
-    log_info(
-        logger,
-        "Multi-source ingestion complete: %s sources, "
-        "%s preferred, %s rejected. Episode %s.",
-        len(source_inputs),
-        len(outcome.preferred_sources),
-        len(outcome.rejected_sources),
-        episode.id,
+    logger.info(
+        f"Multi-source ingestion complete: {len(source_inputs)} sources, "
+        f"{len(outcome.preferred_sources)} preferred, "
+        f"{len(outcome.rejected_sources)} rejected. Episode {episode.id}."
     )
 
 

--- a/episodic/canonical/services.py
+++ b/episodic/canonical/services.py
@@ -20,7 +20,7 @@ import datetime as dt
 import typing as typ
 import uuid
 
-from episodic.logging import get_logger, log_info
+from episodic.logging import get_logger
 
 from . import reference_documents
 from .domain import (
@@ -268,11 +268,8 @@ async def ingest_sources(
     await uow.approval_events.add(event)
 
     await uow.commit()
-    log_info(
-        logger,
-        "Ingested %s sources into canonical episode %s.",
-        len(request.sources),
-        episode_id,
+    logger.info(
+        f"Ingested {len(request.sources)} sources into canonical episode {episode_id}."
     )
 
     return episode

--- a/episodic/canonical/storage/migration_check.py
+++ b/episodic/canonical/storage/migration_check.py
@@ -24,7 +24,7 @@ from sqlalchemy.exc import SQLAlchemyError
 
 from episodic.canonical.storage.alembic_helpers import apply_migrations
 from episodic.canonical.storage.models import Base
-from episodic.logging import get_logger, log_error, log_info
+from episodic.logging import get_logger
 
 if typ.TYPE_CHECKING:
     import sqlalchemy as sa
@@ -75,10 +75,7 @@ async def check_migrations_cli() -> int:
         detected, 2 on infrastructure errors.
     """
     if importlib.util.find_spec("py_pglite") is None:
-        log_error(
-            _logger,
-            "py-pglite is not installed; cannot run migration drift check.",
-        )
+        _logger.error("py-pglite is not installed; cannot run migration drift check.")
         return 2
 
     import tempfile
@@ -98,31 +95,24 @@ async def check_migrations_cli() -> int:
                 dsn = config.get_connection_string()
                 engine = create_async_engine(dsn, pool_pre_ping=True)
                 try:
-                    log_info(
-                        _logger,
-                        "Applying migrations to ephemeral database.",
-                    )
+                    _logger.info("Applying migrations to ephemeral database.")
                     await apply_migrations(engine)
 
-                    log_info(_logger, "Checking for schema drift.")
+                    _logger.info("Checking for schema drift.")
                     diffs = await detect_schema_drift(engine)
                 finally:
                     await engine.dispose()
     except _INFRASTRUCTURE_ERRORS:
-        log_error(_logger, "Infrastructure error.", exc_info=True)
+        _logger.exception("Infrastructure error.")
         return 2
 
     if diffs:
-        log_error(
-            _logger,
-            "Schema drift detected (%s difference(s)):",
-            len(diffs),
-        )
+        _logger.error(f"Schema drift detected ({len(diffs)} difference(s)):")
         for diff in diffs:
-            log_error(_logger, "  %s", diff)
+            _logger.error(f"  {diff}")
         return 1
 
-    log_info(_logger, "No schema drift detected.")
+    _logger.info("No schema drift detected.")
     return 0
 
 

--- a/episodic/canonical/storage/uow.py
+++ b/episodic/canonical/storage/uow.py
@@ -15,7 +15,7 @@ Commit work in a single unit-of-work:
 import typing as typ
 
 from episodic.canonical.ports import CanonicalUnitOfWork
-from episodic.logging import get_logger, log_info
+from episodic.logging import get_logger
 
 from .repositories import (
     SqlAlchemyApprovalEventRepository,
@@ -164,7 +164,7 @@ class SqlAlchemyUnitOfWork(CanonicalUnitOfWork):
             If no session has been initialized for the unit of work.
         """
         await self._apply_session_action("commit")
-        log_info(logger, "Committed canonical unit of work.")
+        logger.info("Committed canonical unit of work.")
 
     async def flush(self) -> None:
         """Flush pending unit-of-work changes."""

--- a/episodic/logging.py
+++ b/episodic/logging.py
@@ -116,26 +116,30 @@ class _SupportsConvenienceLog(typ.Protocol):
     ) -> None: ...
 
 
+class _SupportsLogMethod(typ.Protocol):
+    """Protocol for loggers exposing the stdlib-style `log` entry point."""
+
+    def log(
+        self,
+        level: LogLevel,
+        message: str,
+        /,
+        *,
+        exc_info: object | None = None,
+        stack_info: bool = False,
+    ) -> None: ...
+
+
+type _CompatibleLogger = _SupportsConvenienceLog | _SupportsLogMethod
+
+
 def _format_message(template: str, args: tuple[object, ...]) -> str:
     """Format a log message template."""
     return template % args if args else template
 
 
-def _emit(
-    emit: typ.Callable[..., None],
-    message: str,
-    exc_info: object | None = None,
-) -> None:
-    """Emit a log message."""
-    emit(
-        message,
-        exc_info=exc_info,
-        stack_info=False,
-    )
-
-
 def log_info(
-    logger: _SupportsConvenienceLog,
+    logger: _CompatibleLogger,
     template: str,
     *args: object,
     exc_info: object | None = None,
@@ -162,11 +166,24 @@ def log_info(
     TypeError
         If the template and arguments do not align for percent formatting.
     """
-    _emit(logger.info, _format_message(template, args), exc_info=exc_info)
+    message = _format_message(template, args)
+    try:
+        typ.cast("_SupportsConvenienceLog", logger).info(
+            message,
+            exc_info=exc_info,
+            stack_info=False,
+        )
+    except AttributeError, TypeError:
+        typ.cast("_SupportsLogMethod", logger).log(
+            LogLevel.INFO,
+            message,
+            exc_info=exc_info,
+            stack_info=False,
+        )
 
 
 def log_warning(
-    logger: _SupportsConvenienceLog,
+    logger: _CompatibleLogger,
     template: str,
     *args: object,
     exc_info: object | None = None,
@@ -193,11 +210,24 @@ def log_warning(
     TypeError
         If the template and arguments do not align for percent formatting.
     """
-    _emit(logger.warning, _format_message(template, args), exc_info=exc_info)
+    message = _format_message(template, args)
+    try:
+        typ.cast("_SupportsConvenienceLog", logger).warning(
+            message,
+            exc_info=exc_info,
+            stack_info=False,
+        )
+    except AttributeError, TypeError:
+        typ.cast("_SupportsLogMethod", logger).log(
+            LogLevel.WARNING,
+            message,
+            exc_info=exc_info,
+            stack_info=False,
+        )
 
 
 def log_error(
-    logger: _SupportsConvenienceLog,
+    logger: _CompatibleLogger,
     template: str,
     *args: object,
     exc_info: object | None = None,
@@ -224,7 +254,20 @@ def log_error(
     TypeError
         If the template and arguments do not align for percent formatting.
     """
-    _emit(logger.error, _format_message(template, args), exc_info=exc_info)
+    message = _format_message(template, args)
+    try:
+        typ.cast("_SupportsConvenienceLog", logger).error(
+            message,
+            exc_info=exc_info,
+            stack_info=False,
+        )
+    except AttributeError, TypeError:
+        typ.cast("_SupportsLogMethod", logger).log(
+            LogLevel.ERROR,
+            message,
+            exc_info=exc_info,
+            stack_info=False,
+        )
 
 
 __all__ = (

--- a/episodic/logging.py
+++ b/episodic/logging.py
@@ -13,6 +13,7 @@ Configure logging and emit a message:
 """
 
 import enum
+import logging
 import typing as typ
 import warnings
 
@@ -121,7 +122,7 @@ class _SupportsLogMethod(typ.Protocol):
 
     def log(
         self,
-        level: LogLevel,
+        level: int | LogLevel,
         message: str,
         /,
         *,
@@ -148,8 +149,9 @@ def log_info(
 
     Parameters
     ----------
-    logger : _SupportsConvenienceLog
-        Logger instance that supports femtologging convenience methods.
+    logger : _CompatibleLogger
+        Logger instance that supports femtologging convenience methods or a
+        stdlib-style `log(...)` fallback.
     template : str
         Percent-style format string for the log message.
     *args : object
@@ -173,9 +175,9 @@ def log_info(
             exc_info=exc_info,
             stack_info=False,
         )
-    except AttributeError, TypeError:
+    except (AttributeError, TypeError):  # fmt: skip
         typ.cast("_SupportsLogMethod", logger).log(
-            LogLevel.INFO,
+            logging.INFO,
             message,
             exc_info=exc_info,
             stack_info=False,
@@ -192,8 +194,9 @@ def log_warning(
 
     Parameters
     ----------
-    logger : _SupportsConvenienceLog
-        Logger instance that supports femtologging convenience methods.
+    logger : _CompatibleLogger
+        Logger instance that supports femtologging convenience methods or a
+        stdlib-style `log(...)` fallback.
     template : str
         Percent-style format string for the log message.
     *args : object
@@ -217,9 +220,9 @@ def log_warning(
             exc_info=exc_info,
             stack_info=False,
         )
-    except AttributeError, TypeError:
+    except (AttributeError, TypeError):  # fmt: skip
         typ.cast("_SupportsLogMethod", logger).log(
-            LogLevel.WARNING,
+            logging.WARNING,
             message,
             exc_info=exc_info,
             stack_info=False,
@@ -236,8 +239,9 @@ def log_error(
 
     Parameters
     ----------
-    logger : _SupportsConvenienceLog
-        Logger instance that supports femtologging convenience methods.
+    logger : _CompatibleLogger
+        Logger instance that supports femtologging convenience methods or a
+        stdlib-style `log(...)` fallback.
     template : str
         Percent-style format string for the log message.
     *args : object
@@ -261,9 +265,9 @@ def log_error(
             exc_info=exc_info,
             stack_info=False,
         )
-    except AttributeError, TypeError:
+    except (AttributeError, TypeError):  # fmt: skip
         typ.cast("_SupportsLogMethod", logger).log(
-            LogLevel.ERROR,
+            logging.ERROR,
             message,
             exc_info=exc_info,
             stack_info=False,

--- a/episodic/logging.py
+++ b/episodic/logging.py
@@ -1,27 +1,22 @@
 """Logging helpers for femtologging integration.
 
-This module wraps femtologging with convenience helpers that keep logging
-configuration and structured formatting consistent across the codebase.
-
-Note: The log_info, log_warning, and log_error functions intentionally follow a
-consistent structure to provide a discoverable, ergonomic public API. Shared
-formatting and emission logic is factored into private helpers (_format_message,
-_emit). This design mirrors Python's standard logging module and prioritizes
-usability over eliminating structural similarity.
+This module keeps the local logging configuration seam stable while exposing
+the newer stdlib-aligned femtologging logger surface for current code.
 
 Examples
 --------
 Configure logging and emit a message:
 
 >>> level, used_default = configure_logging("INFO")
->>> log_info(get_logger(__name__), "Started %s", "ingestion")
+>>> logger = get_logger(__name__)
+>>> logger.info("Started ingestion")
 """
 
 import enum
 import typing as typ
 import warnings
 
-from femtologging import basicConfig, get_logger
+from femtologging import basicConfig, get_logger, getLogger
 
 
 class LogLevel(enum.StrEnum):
@@ -90,12 +85,29 @@ def configure_logging(level: str | None, *, force: bool = False) -> tuple[str, b
 
 
 # _SupportsLog is private because callers can rely on structural typing instead.
-class _SupportsLog(typ.Protocol):
-    """Protocol for loggers supporting the femtologging API."""
+class _SupportsConvenienceLog(typ.Protocol):
+    """Protocol for loggers supporting stdlib-like femtologging methods."""
 
-    def log(
+    def info(
         self,
-        level: str,
+        message: str,
+        /,
+        *,
+        exc_info: object | None = None,
+        stack_info: bool = False,
+    ) -> None: ...
+
+    def warning(
+        self,
+        message: str,
+        /,
+        *,
+        exc_info: object | None = None,
+        stack_info: bool = False,
+    ) -> None: ...
+
+    def error(
+        self,
         message: str,
         /,
         *,
@@ -110,14 +122,12 @@ def _format_message(template: str, args: tuple[object, ...]) -> str:
 
 
 def _emit(
-    logger: _SupportsLog,
-    level: LogLevel,
+    emit: typ.Callable[..., None],
     message: str,
     exc_info: object | None = None,
 ) -> None:
     """Emit a log message."""
-    logger.log(
-        level,
+    emit(
         message,
         exc_info=exc_info,
         stack_info=False,
@@ -125,7 +135,7 @@ def _emit(
 
 
 def log_info(
-    logger: _SupportsLog,
+    logger: _SupportsConvenienceLog,
     template: str,
     *args: object,
     exc_info: object | None = None,
@@ -134,8 +144,8 @@ def log_info(
 
     Parameters
     ----------
-    logger : _SupportsLog
-        Logger instance that supports the femtologging log API.
+    logger : _SupportsConvenienceLog
+        Logger instance that supports femtologging convenience methods.
     template : str
         Percent-style format string for the log message.
     *args : object
@@ -152,11 +162,11 @@ def log_info(
     TypeError
         If the template and arguments do not align for percent formatting.
     """
-    _emit(logger, LogLevel.INFO, _format_message(template, args), exc_info=exc_info)
+    _emit(logger.info, _format_message(template, args), exc_info=exc_info)
 
 
 def log_warning(
-    logger: _SupportsLog,
+    logger: _SupportsConvenienceLog,
     template: str,
     *args: object,
     exc_info: object | None = None,
@@ -165,8 +175,8 @@ def log_warning(
 
     Parameters
     ----------
-    logger : _SupportsLog
-        Logger instance that supports the femtologging log API.
+    logger : _SupportsConvenienceLog
+        Logger instance that supports femtologging convenience methods.
     template : str
         Percent-style format string for the log message.
     *args : object
@@ -183,11 +193,11 @@ def log_warning(
     TypeError
         If the template and arguments do not align for percent formatting.
     """
-    _emit(logger, LogLevel.WARNING, _format_message(template, args), exc_info=exc_info)
+    _emit(logger.warning, _format_message(template, args), exc_info=exc_info)
 
 
 def log_error(
-    logger: _SupportsLog,
+    logger: _SupportsConvenienceLog,
     template: str,
     *args: object,
     exc_info: object | None = None,
@@ -196,8 +206,8 @@ def log_error(
 
     Parameters
     ----------
-    logger : _SupportsLog
-        Logger instance that supports the femtologging log API.
+    logger : _SupportsConvenienceLog
+        Logger instance that supports femtologging convenience methods.
     template : str
         Percent-style format string for the log message.
     *args : object
@@ -214,12 +224,13 @@ def log_error(
     TypeError
         If the template and arguments do not align for percent formatting.
     """
-    _emit(logger, LogLevel.ERROR, _format_message(template, args), exc_info=exc_info)
+    _emit(logger.error, _format_message(template, args), exc_info=exc_info)
 
 
 __all__ = (
     "LogLevel",
     "configure_logging",
+    "getLogger",
     "get_logger",
     "log_error",
     "log_info",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "alembic>=1.13,<2.0",
     "asyncpg>=0.20.0,<1.0",
     "falcon>=4.2,<5.0",
-    "femtologging @ git+https://github.com/leynos/femtologging@7c139fb7aca18f9277e00b88604b8bf5eb471be0",
+    "femtologging @ git+https://github.com/leynos/femtologging@691a73962df8f99308a82348d99c4f707c245e63",
     "granian>=2.2,<3.0",
     "httpx>=0.28,<1.0",
     "langgraph>=1.1,<2.0",

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import time
+import typing as typ
+
 import pytest
 
 from episodic import logging as episodic_logging
@@ -78,6 +81,29 @@ class _CollectorHandler:
 
     def handle(self, logger_name: str, level: str, message: str) -> None:
         self.records.append((logger_name, level, message))
+
+
+class _SupportsFlushHandlers(typ.Protocol):
+    """Minimal logger protocol needed by the asynchronous test helper."""
+
+    def flush_handlers(self) -> object: ...
+
+
+def _wait_for_record_count(
+    logger: _SupportsFlushHandlers,
+    collector: _CollectorHandler,
+    *,
+    expected_count: int,
+    timeout_seconds: float = 2.0,
+) -> None:
+    """Wait until the asynchronous logger worker drains into the collector."""
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        logger.flush_handlers()
+        if len(collector.records) >= expected_count:
+            return
+        time.sleep(0.01)
+    logger.flush_handlers()
 
 
 @pytest.mark.parametrize(
@@ -191,7 +217,7 @@ def test_stdlib_style_logger_methods_emit_to_python_handlers() -> None:
     except RuntimeError:
         logger.exception("captured failure")
 
-    logger.flush_handlers()
+    _wait_for_record_count(logger, collector, expected_count=3)
 
     assert collector.records == [
         ("tests.logging.runtime", "INFO", "hello from episodic"),

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,7 +1,5 @@
 """Tests for episodic logging integration and femtologging compatibility."""
 
-from __future__ import annotations
-
 import time
 import typing as typ
 
@@ -14,11 +12,13 @@ class _SpyLogger:
     """Collect low-level log calls emitted by the compatibility wrappers."""
 
     def __init__(self) -> None:
-        self.calls: list[tuple[str, str, object | None, bool]] = []
+        self.calls: list[
+            tuple[episodic_logging.LogLevel, str, object | None, bool]
+        ] = []
 
     def _record(
         self,
-        level: str,
+        level: episodic_logging.LogLevel,
         message: str,
         /,
         *,
@@ -71,6 +71,26 @@ class _SpyLogger:
             exc_info=exc_info,
             stack_info=stack_info,
         )
+
+
+class _LogOnlySpyLogger:
+    """Collect low-level log calls through a stdlib-style `log` method only."""
+
+    def __init__(self) -> None:
+        self.calls: list[
+            tuple[episodic_logging.LogLevel, str, object | None, bool]
+        ] = []
+
+    def log(
+        self,
+        level: episodic_logging.LogLevel,
+        message: str,
+        /,
+        *,
+        exc_info: object | None = None,
+        stack_info: bool = False,
+    ) -> None:
+        self.calls.append((level, message, exc_info, stack_info))
 
 
 class _CollectorHandler:
@@ -142,9 +162,68 @@ def test_configure_logging_normalizes_levels(
     assert recorded_calls == [(expected_level, True)]
 
 
-def test_log_wrappers_delegate_through_logger_log() -> None:
+def test_configure_logging_uses_false_as_default_force_value() -> None:
+    """configure_logging should forward `force=False` when omitted."""
+    recorded_calls: list[tuple[str, bool]] = []
+
+    def _fake_basic_config(*, level: str, force: bool) -> None:
+        recorded_calls.append((level, force))
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(episodic_logging, "basicConfig", _fake_basic_config)
+    try:
+        effective_level, used_default = episodic_logging.configure_logging("debug")
+    finally:
+        monkeypatch.undo()
+
+    assert (effective_level, used_default) == (episodic_logging.LogLevel.DEBUG, False)
+    assert recorded_calls == [(episodic_logging.LogLevel.DEBUG, False)]
+
+
+def test_log_wrappers_delegate_through_convenience_methods() -> None:
     """Compatibility helpers should preserve percent-style formatting semantics."""
     logger = _SpyLogger()
+    err = RuntimeError("boom")
+
+    episodic_logging.log_info(logger, "Loaded %s documents", 3)
+    episodic_logging.log_warning(logger, "Potential issue in %s", "ingestion")
+    episodic_logging.log_error(
+        logger,
+        "Failed job %s",
+        "job-1",
+        exc_info=err,
+    )
+
+    assert logger.calls == [
+        (episodic_logging.LogLevel.INFO, "Loaded 3 documents", None, False),
+        (
+            episodic_logging.LogLevel.WARNING,
+            "Potential issue in ingestion",
+            None,
+            False,
+        ),
+        (
+            episodic_logging.LogLevel.ERROR,
+            "Failed job job-1",
+            err,
+            False,
+        ),
+    ]
+
+
+def test_log_wrappers_raise_type_error_on_mismatched_format() -> None:
+    """Compatibility helpers should propagate `TypeError` from formatting."""
+    logger = _SpyLogger()
+
+    with pytest.raises(TypeError):
+        episodic_logging.log_info(logger, "Loaded %s documents for %s", 3)
+
+    assert logger.calls == []
+
+
+def test_log_wrappers_fall_back_to_logger_log_when_needed() -> None:
+    """Compatibility helpers should support loggers that only expose `log()`."""
+    logger = _LogOnlySpyLogger()
     err = RuntimeError("boom")
 
     episodic_logging.log_info(logger, "Loaded %s documents", 3)
@@ -190,6 +269,22 @@ def test_femtologging_exposes_stdlib_style_logger_surface() -> None:
         "isEnabledFor",
     ):
         assert hasattr(logger, method_name), method_name
+
+
+def test_episodic_logging_get_logger_reexport_matches_femtologging_surface() -> None:
+    """Episodic logging should re-export the stdlib-style logger constructor."""
+    logger = episodic_logging.getLogger("tests.logging.surface")
+    for method_name in (
+        "debug",
+        "info",
+        "warning",
+        "error",
+        "critical",
+        "exception",
+        "isEnabledFor",
+    ):
+        assert hasattr(logger, method_name), method_name
+    assert logger.isEnabledFor("INFO") is True
 
 
 def _raise_logged_exception() -> None:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -149,7 +149,7 @@ def _wait_for_record_count(
 def test_configure_logging_normalizes_levels(
     monkeypatch: pytest.MonkeyPatch,
     requested_level: str | None,
-    expected_level: str,
+    expected_level: episodic_logging.LogLevel,
     expected_used_default: object,
 ) -> None:
     """configure_logging should normalize levels before delegating to femtologging."""
@@ -223,7 +223,10 @@ def test_log_wrappers_raise_type_error_on_mismatched_format() -> None:
     """Compatibility helpers should propagate `TypeError` from formatting."""
     logger = _SpyLogger()
 
-    with pytest.raises(TypeError):
+    with pytest.raises(
+        TypeError,
+        match=r"not enough arguments for format string",
+    ):
         episodic_logging.log_info(logger, "Loaded %s documents for %s", 3)
 
     assert logger.calls == []

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,5 +1,6 @@
 """Tests for episodic logging integration and femtologging compatibility."""
 
+import logging
 import time
 import typing as typ
 
@@ -77,19 +78,18 @@ class _LogOnlySpyLogger:
     """Collect low-level log calls through a stdlib-style `log` method only."""
 
     def __init__(self) -> None:
-        self.calls: list[
-            tuple[episodic_logging.LogLevel, str, object | None, bool]
-        ] = []
+        self.calls: list[tuple[int, str, object | None, bool]] = []
 
     def log(
         self,
-        level: episodic_logging.LogLevel,
+        level: int | episodic_logging.LogLevel,
         message: str,
         /,
         *,
         exc_info: object | None = None,
         stack_info: bool = False,
     ) -> None:
+        assert isinstance(level, int)
         self.calls.append((level, message, exc_info, stack_info))
 
 
@@ -162,19 +162,17 @@ def test_configure_logging_normalizes_levels(
     assert recorded_calls == [(expected_level, True)]
 
 
-def test_configure_logging_uses_false_as_default_force_value() -> None:
+def test_configure_logging_uses_false_as_default_force_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """configure_logging should forward `force=False` when omitted."""
     recorded_calls: list[tuple[str, bool]] = []
 
     def _fake_basic_config(*, level: str, force: bool) -> None:
         recorded_calls.append((level, force))
 
-    monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(episodic_logging, "basicConfig", _fake_basic_config)
-    try:
-        effective_level, used_default = episodic_logging.configure_logging("debug")
-    finally:
-        monkeypatch.undo()
+    effective_level, used_default = episodic_logging.configure_logging("debug")
 
     assert (effective_level, used_default) == (episodic_logging.LogLevel.DEBUG, False)
     assert recorded_calls == [(episodic_logging.LogLevel.DEBUG, False)]
@@ -236,15 +234,15 @@ def test_log_wrappers_fall_back_to_logger_log_when_needed() -> None:
     )
 
     assert logger.calls == [
-        (episodic_logging.LogLevel.INFO, "Loaded 3 documents", None, False),
+        (logging.INFO, "Loaded 3 documents", None, False),
         (
-            episodic_logging.LogLevel.WARNING,
+            logging.WARNING,
             "Potential issue in ingestion",
             None,
             False,
         ),
         (
-            episodic_logging.LogLevel.ERROR,
+            logging.ERROR,
             "Failed job job-1",
             err,
             False,

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,200 @@
+"""Tests for episodic logging integration and femtologging compatibility."""
+
+from __future__ import annotations
+
+import pytest
+
+from episodic import logging as episodic_logging
+
+
+class _SpyLogger:
+    """Collect low-level log calls emitted by the compatibility wrappers."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, object | None, bool]] = []
+
+    def _record(
+        self,
+        level: str,
+        message: str,
+        /,
+        *,
+        exc_info: object | None = None,
+        stack_info: bool = False,
+    ) -> None:
+        self.calls.append((level, message, exc_info, stack_info))
+
+    def info(
+        self,
+        message: str,
+        /,
+        *,
+        exc_info: object | None = None,
+        stack_info: bool = False,
+    ) -> None:
+        self._record(
+            episodic_logging.LogLevel.INFO,
+            message,
+            exc_info=exc_info,
+            stack_info=stack_info,
+        )
+
+    def warning(
+        self,
+        message: str,
+        /,
+        *,
+        exc_info: object | None = None,
+        stack_info: bool = False,
+    ) -> None:
+        self._record(
+            episodic_logging.LogLevel.WARNING,
+            message,
+            exc_info=exc_info,
+            stack_info=stack_info,
+        )
+
+    def error(
+        self,
+        message: str,
+        /,
+        *,
+        exc_info: object | None = None,
+        stack_info: bool = False,
+    ) -> None:
+        self._record(
+            episodic_logging.LogLevel.ERROR,
+            message,
+            exc_info=exc_info,
+            stack_info=stack_info,
+        )
+
+
+class _CollectorHandler:
+    """Capture femtologging records through the Python handler protocol."""
+
+    def __init__(self) -> None:
+        self.records: list[tuple[str, str, str]] = []
+
+    def handle(self, logger_name: str, level: str, message: str) -> None:
+        self.records.append((logger_name, level, message))
+
+
+@pytest.mark.parametrize(
+    ("requested_level", "expected_level", "expected_used_default"),
+    [
+        (None, episodic_logging.LogLevel.INFO, True),
+        ("", episodic_logging.LogLevel.INFO, True),
+        ("debug", episodic_logging.LogLevel.DEBUG, False),
+        ("warning", episodic_logging.LogLevel.WARNING, False),
+        ("invalid", episodic_logging.LogLevel.INFO, True),
+    ],
+)
+def test_configure_logging_normalizes_levels(
+    monkeypatch: pytest.MonkeyPatch,
+    requested_level: str | None,
+    expected_level: str,
+    expected_used_default: object,
+) -> None:
+    """configure_logging should normalize levels before delegating to femtologging."""
+    recorded_calls: list[tuple[str, bool]] = []
+
+    def _fake_basic_config(*, level: str, force: bool) -> None:
+        recorded_calls.append((level, force))
+
+    monkeypatch.setattr(episodic_logging, "basicConfig", _fake_basic_config)
+
+    effective_level, used_default = episodic_logging.configure_logging(
+        requested_level,
+        force=True,
+    )
+
+    assert (effective_level, used_default) == (
+        expected_level,
+        expected_used_default,
+    )
+    assert recorded_calls == [(expected_level, True)]
+
+
+def test_log_wrappers_delegate_through_logger_log() -> None:
+    """Compatibility helpers should preserve percent-style formatting semantics."""
+    logger = _SpyLogger()
+    err = RuntimeError("boom")
+
+    episodic_logging.log_info(logger, "Loaded %s documents", 3)
+    episodic_logging.log_warning(logger, "Potential issue in %s", "ingestion")
+    episodic_logging.log_error(
+        logger,
+        "Failed job %s",
+        "job-1",
+        exc_info=err,
+    )
+
+    assert logger.calls == [
+        (episodic_logging.LogLevel.INFO, "Loaded 3 documents", None, False),
+        (
+            episodic_logging.LogLevel.WARNING,
+            "Potential issue in ingestion",
+            None,
+            False,
+        ),
+        (
+            episodic_logging.LogLevel.ERROR,
+            "Failed job job-1",
+            err,
+            False,
+        ),
+    ]
+
+
+def test_femtologging_exposes_stdlib_style_logger_surface() -> None:
+    """The upgraded dependency should expose stdlib-like logger helpers."""
+    import femtologging
+
+    assert hasattr(femtologging, "getLogger")
+
+    logger = femtologging.get_logger("tests.logging.surface")
+    for method_name in (
+        "debug",
+        "info",
+        "warning",
+        "error",
+        "critical",
+        "exception",
+        "isEnabledFor",
+    ):
+        assert hasattr(logger, method_name), method_name
+
+
+def _raise_logged_exception() -> None:
+    msg = "boom"
+    raise RuntimeError(msg)
+
+
+def test_stdlib_style_logger_methods_emit_to_python_handlers() -> None:
+    """Direct logger convenience methods should work with Python handlers."""
+    import femtologging
+
+    femtologging.reset_manager()
+    logger = femtologging.getLogger("tests.logging.runtime")
+    collector = _CollectorHandler()
+    logger.clear_handlers()
+    logger.set_propagate(False)
+    logger.add_handler(collector)
+
+    assert logger.isEnabledFor("INFO") is True
+
+    logger.info("hello from episodic")
+    logger.error("failed job")
+    try:
+        _raise_logged_exception()
+    except RuntimeError:
+        logger.exception("captured failure")
+
+    logger.flush_handlers()
+
+    assert collector.records == [
+        ("tests.logging.runtime", "INFO", "hello from episodic"),
+        ("tests.logging.runtime", "ERROR", "failed job"),
+        ("tests.logging.runtime", "ERROR", "captured failure"),
+    ]

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -109,6 +109,16 @@ class _SupportsFlushHandlers(typ.Protocol):
     def flush_handlers(self) -> object: ...
 
 
+@pytest.fixture
+def isolated_femtologging() -> typ.Generator[None]:
+    """Reset the femtologging global manager before and after each test."""
+    import femtologging
+
+    femtologging.reset_manager()
+    yield
+    femtologging.reset_manager()
+
+
 def _wait_for_record_count(
     logger: _SupportsFlushHandlers,
     collector: _CollectorHandler,
@@ -290,11 +300,12 @@ def _raise_logged_exception() -> None:
     raise RuntimeError(msg)
 
 
-def test_stdlib_style_logger_methods_emit_to_python_handlers() -> None:
+def test_stdlib_style_logger_methods_emit_to_python_handlers(
+    isolated_femtologging: None,
+) -> None:
     """Direct logger convenience methods should work with Python handlers."""
     import femtologging
 
-    femtologging.reset_manager()
     logger = femtologging.getLogger("tests.logging.runtime")
     collector = _CollectorHandler()
     logger.clear_handlers()

--- a/uv.lock
+++ b/uv.lock
@@ -168,7 +168,7 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.13,<2.0" },
     { name = "asyncpg", specifier = ">=0.20.0,<1.0" },
     { name = "falcon", specifier = ">=4.2,<5.0" },
-    { name = "femtologging", git = "https://github.com/leynos/femtologging?rev=7c139fb7aca18f9277e00b88604b8bf5eb471be0" },
+    { name = "femtologging", git = "https://github.com/leynos/femtologging?rev=691a73962df8f99308a82348d99c4f707c245e63" },
     { name = "granian", specifier = ">=2.2,<3.0" },
     { name = "httpx", specifier = ">=0.28,<1.0" },
     { name = "langgraph", specifier = ">=1.1,<2.0" },
@@ -223,7 +223,7 @@ wheels = [
 [[package]]
 name = "femtologging"
 version = "0.1.0"
-source = { git = "https://github.com/leynos/femtologging?rev=7c139fb7aca18f9277e00b88604b8bf5eb471be0#7c139fb7aca18f9277e00b88604b8bf5eb471be0" }
+source = { git = "https://github.com/leynos/femtologging?rev=691a73962df8f99308a82348d99c4f707c245e63#691a73962df8f99308a82348d99c4f707c245e63" }
 
 [[package]]
 name = "gherkin-official"


### PR DESCRIPTION
## Summary
- Adds a formal ExecPlan documenting the plan to migrate episodic to femtologging v0.1.0 API and implements code changes to align with stdlib-like logging while preserving compatibility.

## Changes
- New ExecPlan document at `docs/execplans/femtologging-april-2026-migration.md` (target SHA: 691a73962df8f99308a82348d99c4f707c245e63).
- Code changes to align episodic with the stdlib-like logging surface:
  - Updated internal call sites to use direct `logger.info(...)`, `logger.error(...)`, and `logger.exception(...)` where applicable (e.g., `episodic/canonical/ingestion_service.py`, `episodic/canonical/services.py`, `episodic/canonical/storage/migration_check.py`, `episodic/canonical/storage/uow.py`).
  - Reduced reliance on legacy `log_info`/`log_warning`/`log_error` wrappers in favor of direct methods with compatibility shims where needed.
- New test coverage for logging surface:
  - Added `tests/test_logging.py` to verify wrapper behavior, stdlib-style surface exposure, and runtime logging using Python handlers.
- Documentation updates:
  - Updated `docs/developers-guide.md` and `docs/femtologging-users-guide.md` to reflect the v0.1.0 surface and recommended usage.
- Dependency updates:
  - Pin femtologging to SHA `691a73962df8f99308a82348d99c4f707c245e63` in `pyproject.toml` and refresh `uv.lock` accordingly.
- Repository metadata:
  - Updated `uv.lock` to reference the same pinned SHA.

## Rationale
- Provides a traceable, test-driven migration path with clear success criteria, risk assessment, and gate definitions to minimize risk and ensure reproducible approvals.
- Balances a minimal compatibility surface with a forward-leaning stdlib-like API where it improves clarity and reduces wrapper churn.

## Plan of work (high level)
- Stage A: add fail-first logging regression tests (covered in `tests/test_logging.py`).
- Stage B: update the femtologging pin and refresh uv.lock.
- Stage C: align episodic code with the stdlib-like API (migrate select call sites to direct `logger.*` usage).
- Stage D: update maintainer documentation (docs/workflows reflecting the new surface).
- Stage E: run full validation and capture evidence (gates cover fmt, lint, typecheck, test, etc.).
- The ExecPlan contains detailed steps, tolerances, risks, decisions, and progression criteria.

## Validation and acceptance
- Success criteria include:
  - Pinning femtologging to SHA `691a73962df8f99308a82348d99c4f707c245e63` in both `pyproject.toml` and `uv.lock`.
  - Added logging regression tests (Stage A) and their green status after implementation.
  - Code paths migrated to stdlib-like logger calls where applicable while preserving behavior via compatibility shims.
  - Documentation updated to reflect the new API and remove stale guidance.
  - All repository gates pass: `make fmt`, `make check-fmt`, `make lint`, `make typecheck`, `make test`, `make markdownlint`, `make nixie`.

## Risks and mitigations
- Risk: wrapper surface remains under-tested and could diverge from upstream behavior. Mitigation: add targeted regression tests before or alongside the pin.
- Risk: local guidance (docs) may lag upstream changes. Mitigation: align docs in Stage D/During ongoing updates.
- Risk: potential lockfile churn during `uv lock`. Mitigation: narrow pin and keep diffs focused.

## Artifacts and notes
- Evidence files generated during the migration process are described in the ExecPlan and will be used to validate gates.
- Expected touched areas in a future PR (not part of this doc-only change):
  - `pyproject.toml`, `uv.lock`, `episodic/logging.py`, and a small set of call sites.
  - Tests under `tests/` and maintainer docs under `docs/`.
- The following files were updated or added as part of this PR:
  - `docs/developers-guide.md`
  - `docs/femtologging-users-guide.md`
  - `docs/execplans/femtologging-april-2026-migration.md` (new)
  - `episodic/logging.py` (updated)
  - `episodic/canonical/ingestion_service.py` (updated)
  - `episodic/canonical/services.py` (updated)
  - `episodic/canonical/storage/migration_check.py` (updated)
  - `episodic/canonical/storage/uow.py` (updated)
  - `pyproject.toml` (pin updated)
  - `uv.lock` (lockfile updated)
  - `tests/test_logging.py` (new)

  uv.lock ...

📎 **Task**: https://www.devboxer.com/task/bdeb9537-ba41-4e4f-bc16-f56a93791943

## Summary by Sourcery

Migrate episodic’s logging integration to femtologging v0.1.0 with a stdlib-like logger surface, updated documentation, tests, and dependency pinning.

New Features:
- Expose femtologging’s stdlib-style logger surface (including getLogger and convenience methods) through episodic.logging while keeping configure_logging as the configuration seam.

Enhancements:
- Adjust internal logging helpers to delegate to logger.info/warning/error while preserving legacy wrapper compatibility.
- Update canonical ingestion, storage, and migration code paths to use direct logger convenience methods for clearer, exception-aware logging.

Build:
- Pin femtologging to Git revision 691a73962df8f99308a82348d99c4f707c245e63 and refresh uv.lock accordingly.

Documentation:
- Add an ExecPlan documenting the femtologging v0.1.0 migration strategy, risks, and validation steps.
- Refresh the femtologging user guide and developer guide to describe the new stdlib-aligned API, handler options, and recommended usage patterns.

Tests:
- Introduce tests for episodic.logging wrappers and for runtime behavior of the femtologging stdlib-style logger surface, including Python handler integration.