### PR TITLE
Plan hexagonal-architecture enforcement checks (1.5.4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,10 @@ jobs:
         run: make check-fmt
 
       - name: Run ruff
-        run: make lint
+        run: ruff check
+
+      - name: Run architecture checks
+        run: make check-architecture
 
       - name: Run typechecker
         run: make typecheck

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ MDLINT ?= npx -y markdownlint-cli2
 NIXIE ?= nixie
 MDFORMAT_ALL ?= mdformat-all
 export PATH := $(HOME)/.local/bin:$(HOME)/.bun/bin:$(PATH)
-TOOLS = $(MDFORMAT_ALL) uv
+UV ?= $(shell command -v uv 2>/dev/null || printf '/home/leynos/.local/bin/uv')
+TOOLS = $(MDFORMAT_ALL)
 VENV_TOOLS = pytest
 UV_ENV = PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools
 PYTEST_XDIST_WORKERS ?= 1
@@ -15,10 +16,10 @@ PYTEST_XDIST_WORKERS ?= 1
 all: build check-fmt test typecheck
 
 .venv: pyproject.toml
-	$(UV_ENV) uv venv --clear
+	$(UV_ENV) $(UV) venv --clear
 
-build: uv .venv ## Build virtual-env and install deps
-	$(UV_ENV) uv sync --group dev
+build: .venv ## Build virtual-env and install deps
+	$(UV_ENV) $(UV) sync --group dev
 
 build-release: ## Build artefacts (sdist & wheel)
 	python -m build --sdist --wheel
@@ -37,7 +38,7 @@ define ensure_tool
 endef
 
 define ensure_tool_venv
-	@$(UV_ENV) uv run which $(1) >/dev/null 2>&1 || { \
+	@$(UV_ENV) $(UV) run which $(1) >/dev/null 2>&1 || { \
 	  printf "Error: '%s' is required in the virtualenv, but is not installed\n" "$(1)" >&2; \
 	  exit 1; \
 	}
@@ -56,23 +57,23 @@ $(VENV_TOOLS): ## Verify required CLI tools in venv
 endif
 
 fmt: build $(MDFORMAT_ALL) ## Format sources
-	$(UV_ENV) uv run ruff format
-	$(UV_ENV) uv run ruff check --select I --fix
+	$(UV_ENV) $(UV) run ruff format
+	$(UV_ENV) $(UV) run ruff check --select I --fix
 	$(MDFORMAT_ALL)
 
 check-fmt: build ## Verify formatting
-	$(UV_ENV) uv run ruff format --check
+	$(UV_ENV) $(UV) run ruff format --check
 	# mdformat-all doesn't currently do checking
 
 lint: build check-architecture ## Run linters
-	$(UV_ENV) uv run ruff check
+	$(UV_ENV) $(UV) run ruff check
 
-check-architecture: build uv ## Check hexagonal architecture import boundaries
-	$(UV_ENV) uv run python -m episodic.architecture
+check-architecture: build ## Check hexagonal architecture import boundaries
+	$(UV_ENV) $(UV) run python -m episodic.architecture
 
 typecheck: build ## Run typechecking
-	$(UV_ENV) uv tool run ty==0.0.32 --version
-	$(UV_ENV) uv tool run ty==0.0.32 check
+	$(UV_ENV) $(UV) tool run ty==0.0.32 --version
+	$(UV_ENV) $(UV) tool run ty==0.0.32 check
 
 markdownlint: ## Lint Markdown files
 	env -u NO_COLOR $(MDLINT) '**/*.md'
@@ -81,11 +82,11 @@ nixie: ## Validate Mermaid diagrams
 	$(call ensure_tool,nixie)
 	$(NIXIE) --no-sandbox
 
-test: build uv $(VENV_TOOLS) ## Run tests
-	$(UV_ENV) uv run pytest -v -n $(PYTEST_XDIST_WORKERS)
+test: build $(VENV_TOOLS) ## Run tests
+	$(UV_ENV) $(UV) run pytest -v -n $(PYTEST_XDIST_WORKERS)
 
-check-migrations: build uv $(VENV_TOOLS) ## Check for schema drift between models and migrations
-	$(UV_ENV) uv run python -m episodic.canonical.storage.migration_check
+check-migrations: build $(VENV_TOOLS) ## Check for schema drift between models and migrations
+	$(UV_ENV) $(UV) run python -m episodic.canonical.storage.migration_check
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?##' $(MAKEFILE_LIST) | \

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ MDLINT ?= npx -y markdownlint-cli2
 NIXIE ?= nixie
 MDFORMAT_ALL ?= mdformat-all
 export PATH := $(HOME)/.local/bin:$(HOME)/.bun/bin:$(PATH)
-UV ?= $(shell command -v uv 2>/dev/null || printf '/home/leynos/.local/bin/uv')
+UV ?= $(shell command -v uv 2>/dev/null || printf '%s/.local/bin/uv' "$$HOME")
 TOOLS = $(MDFORMAT_ALL)
 VENV_TOOLS = pytest
 UV_ENV = PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools
@@ -65,8 +65,9 @@ check-fmt: build ## Verify formatting
 	$(UV_ENV) $(UV) run ruff format --check
 	# mdformat-all doesn't currently do checking
 
-lint: build check-architecture ## Run linters
+lint: build ## Run linters
 	$(UV_ENV) $(UV) run ruff check
+	$(MAKE) check-architecture
 
 check-architecture: build ## Check hexagonal architecture import boundaries
 	$(UV_ENV) $(UV) run python -m episodic.architecture

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,11 @@ check-fmt: ruff ## Verify formatting
 	ruff format --check
 	# mdformat-all doesn't currently do checking
 
-lint: ruff ## Run linters
+lint: ruff check-architecture ## Run linters
 	ruff check
+
+check-architecture: build uv ## Check hexagonal architecture import boundaries
+	$(UV_ENV) uv run python -m episodic.architecture
 
 typecheck: build ty ## Run typechecking
 	ty --version

--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,8 @@ check-fmt: build ## Verify formatting
 	$(UV_ENV) $(UV) run ruff format --check
 	# mdformat-all doesn't currently do checking
 
-lint: build ## Run linters
+lint: check-architecture ## Run linters
 	$(UV_ENV) $(UV) run ruff check
-	$(MAKE) check-architecture
 
 check-architecture: build ## Check hexagonal architecture import boundaries
 	$(UV_ENV) $(UV) run python -m episodic.architecture

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-MDLINT ?= markdownlint-cli2
+MDLINT ?= npx -y markdownlint-cli2
 NIXIE ?= nixie
 MDFORMAT_ALL ?= mdformat-all
 export PATH := $(HOME)/.local/bin:$(HOME)/.bun/bin:$(PATH)
-TOOLS = $(MDFORMAT_ALL) ruff ty $(MDLINT) uv
+TOOLS = $(MDFORMAT_ALL) uv
 VENV_TOOLS = pytest
 UV_ENV = PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 UV_CACHE_DIR=.uv-cache UV_TOOL_DIR=.uv-tools
 PYTEST_XDIST_WORKERS ?= 1
@@ -55,26 +55,26 @@ $(VENV_TOOLS): ## Verify required CLI tools in venv
 	$(call ensure_tool_venv,$@)
 endif
 
-fmt: ruff $(MDFORMAT_ALL) ## Format sources
-	ruff format
-	ruff check --select I --fix
+fmt: build $(MDFORMAT_ALL) ## Format sources
+	$(UV_ENV) uv run ruff format
+	$(UV_ENV) uv run ruff check --select I --fix
 	$(MDFORMAT_ALL)
 
-check-fmt: ruff ## Verify formatting
-	ruff format --check
+check-fmt: build ## Verify formatting
+	$(UV_ENV) uv run ruff format --check
 	# mdformat-all doesn't currently do checking
 
-lint: ruff check-architecture ## Run linters
-	ruff check
+lint: build check-architecture ## Run linters
+	$(UV_ENV) uv run ruff check
 
 check-architecture: build uv ## Check hexagonal architecture import boundaries
 	$(UV_ENV) uv run python -m episodic.architecture
 
-typecheck: build ty ## Run typechecking
-	ty --version
-	ty check
+typecheck: build ## Run typechecking
+	$(UV_ENV) uv tool run ty==0.0.32 --version
+	$(UV_ENV) uv tool run ty==0.0.32 check
 
-markdownlint: $(MDLINT) ## Lint Markdown files
+markdownlint: ## Lint Markdown files
 	env -u NO_COLOR $(MDLINT) '**/*.md'
 
 nixie: ## Validate Mermaid diagrams

--- a/docs/adr/adr-005-hexagonal-architecture-enforcement.md
+++ b/docs/adr/adr-005-hexagonal-architecture-enforcement.md
@@ -1,0 +1,92 @@
+# ADR-005: Hexagonal architecture enforcement
+
+## Status
+
+Accepted
+
+## Context
+
+Episodic already documents a hexagonal architecture: canonical domain logic and
+ports sit inside the boundary, while Falcon, Celery, SQLAlchemy, and provider
+SDK integrations live in adapters. Ruff enforces general import hygiene, but it
+does not know the repository's dependency graph. A module can therefore import
+in the wrong direction while still satisfying ordinary lint rules.
+
+The immediate need is roadmap item `1.5.4`: enforce the current service
+scaffold boundaries. The deeper orchestration-specific checks for LangGraph
+nodes, Celery task payloads, and checkpoint state remain roadmap item `2.4.5`.
+
+## Decision
+
+Add a repo-local architecture checker under `episodic.architecture`.
+
+The checker parses Python files with `ast`, classifies imports into explicit
+module groups, and emits stable diagnostics with a rule identifier, importer,
+imported module, and dependency direction. `make check-architecture` runs the
+checker, `make lint` includes it after Ruff, and CI exposes it as a named
+architecture gate.
+
+The first enforced groups are:
+
+- `domain_ports`: canonical domain models, canonical ports, ingestion ports,
+  canonical constraint names, and LLM ports.
+- `application`: canonical application services, profile/template services,
+  reference-document services, and generation services.
+- `inbound_adapter`: Falcon API modules and worker task/topology seams.
+- `outbound_adapter`: SQLAlchemy storage, canonical ingestion adapters, and
+  OpenAI-compatible LLM adapters.
+- `composition_root`: runtime modules whose job is to wire concrete adapters,
+  currently `episodic.api.runtime` and `episodic.worker.runtime`.
+
+Composition roots are deliberate exceptions. They may import concrete inbound
+and outbound adapters because their responsibility is dependency wiring. The
+exception is modelled as its own group instead of weakening adapter rules.
+
+Port contract tests mark the public protocols used by the enforcement slice as
+`@runtime_checkable` and assert that the current concrete adapters satisfy the
+published structural surface.
+
+## Consequences
+
+### Positive
+
+- `make lint` now fails on forbidden import directions in the scoped package
+  graph.
+- `make test` verifies concrete adapter conformance to the public port
+  protocols.
+- Architecture behaviour is covered by `pytest-bdd` fixture packages, so the
+  checker can evolve without rewriting production source during tests.
+- CI distinguishes the architecture gate from Ruff, type checking, and tests.
+
+### Negative
+
+- The checker is repository-specific and must be updated when new packages or
+  architecture groups are introduced.
+- Runtime-checkable protocols prove method and attribute presence, not full
+  semantic behaviour. Behavioural adapter tests remain necessary.
+
+### Neutral
+
+- Constraint-name constants used by service-layer conflict handling now live in
+  `episodic.canonical.constraints`. SQLAlchemy models import those constants
+  rather than owning the only copy.
+- `2.4.5` remains responsible for LangGraph-node-specific policies, Celery
+  checkpoint payload audits, and deeper orchestration checks.
+
+## References
+
+Roadmap items `1.5.4` and `2.4.5` in `docs/roadmap.md`.[^1] ExecPlan:
+`docs/execplans/1-5-4-architectural-enforcement-for-hexagonal-boundaries.md`.[
+^2] Implementation: `episodic/architecture/checker.py`.[^3] Tests:
+`tests/test_architecture_enforcement.py`, `tests/test_port_contracts.py`,
+`tests/features/architecture_enforcement.feature`, and
+`tests/steps/test_architecture_enforcement_steps.py`.[^4]
+
+[^1]: Roadmap items `1.5.4` and `2.4.5` in `docs/roadmap.md`
+[^2]: ExecPlan:
+  `docs/execplans/1-5-4-architectural-enforcement-for-hexagonal-boundaries.md`
+[^3]: Implementation: `episodic/architecture/checker.py`
+[^4]: Tests: `tests/test_architecture_enforcement.py`,
+  `tests/test_port_contracts.py`,
+  `tests/features/architecture_enforcement.feature`, and
+  `tests/steps/test_architecture_enforcement_steps.py`

--- a/docs/adr/adr-006-hexagonal-architecture-enforcement.md
+++ b/docs/adr/adr-006-hexagonal-architecture-enforcement.md
@@ -1,4 +1,4 @@
-# ADR-005: Hexagonal architecture enforcement
+# ADR-006: Hexagonal architecture enforcement
 
 ## Status
 
@@ -76,8 +76,8 @@ published structural surface.
 ## References
 
 Roadmap items `1.5.4` and `2.4.5` in `docs/roadmap.md`.[^1] ExecPlan:
-`docs/execplans/1-5-4-architectural-enforcement-for-hexagonal-boundaries.md`.[
-^2] Implementation: `episodic/architecture/checker.py`.[^3] Tests:
+`docs/execplans/1-5-4-architectural-enforcement-for-hexagonal-boundaries.md`.[^2]
+Implementation: `episodic/architecture/checker.py`.[^3] Tests:
 `tests/test_architecture_enforcement.py`, `tests/test_port_contracts.py`,
 `tests/features/architecture_enforcement.feature`, and
 `tests/steps/test_architecture_enforcement_steps.py`.[^4]

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -306,6 +306,44 @@ Database-level constraints (unique slugs, foreign keys, and CHECK constraints
 such as the weight bound on source documents) are enforced by Postgres and
 raise `sqlalchemy.exc.IntegrityError` on violation.
 
+
+### Architecture enforcement
+
+Run the architecture checker directly when changing package boundaries:
+
+```shell
+make check-architecture
+```
+
+`make lint` runs Ruff and then this architecture gate. The checker lives in
+`episodic.architecture` and reports diagnostics as `ARCH001` with the importer,
+imported module, and dependency direction.
+
+The enforced groups are:
+
+- `domain_ports`: canonical domain types, canonical ports, ingestion ports,
+  canonical constraint names, and LLM ports.
+- `application`: canonical services, profile/template workflows,
+  reference-document workflows, and generation services.
+- `inbound_adapter`: Falcon API modules and worker task/topology seams.
+- `outbound_adapter`: SQLAlchemy storage, canonical ingestion adapters, and
+  OpenAI-compatible LLM adapters.
+- `composition_root`: modules that wire concrete adapters, currently
+  `episodic.api.runtime` and `episodic.worker.runtime`.
+
+When adding a new port or adapter, update the manifest in
+`episodic/architecture/checker.py` in the same change as the package. Add or
+adjust fixture coverage in `tests/fixtures/architecture/` and run:
+
+```shell
+uv run pytest -q tests/test_architecture_enforcement.py \
+  tests/steps/test_architecture_enforcement_steps.py
+```
+
+Port contract coverage lives in `tests/test_port_contracts.py`. Future
+behavioural tests that exercise real `LLMPort` inference paths should use Vidai
+Mock; structural conformance tests do not need an inference server.
+
 ### TEI payload compression
 
 Canonical TEI payload storage now supports transparent Zstandard compression

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -306,7 +306,6 @@ Database-level constraints (unique slugs, foreign keys, and CHECK constraints
 such as the weight bound on source documents) are enforced by Postgres and
 raise `sqlalchemy.exc.IntegrityError` on violation.
 
-
 ### Architecture enforcement
 
 Run the architecture checker directly when changing package boundaries:

--- a/docs/episodic-podcast-generation-system-design.md
+++ b/docs/episodic-podcast-generation-system-design.md
@@ -12,6 +12,7 @@ Accepted decision records:
 - [ADR 003: Celery worker scaffold](adr/adr-003-celery-worker-scaffold.md)
 - [ADR 004: Show-notes TEI representation](adr/adr-004-show-notes-tei-representation.md)
 - [ADR 005: Structured planning and tool execution for generation orchestration](adr/adr-005-structured-planning-and-tool-execution.md)
+- [ADR 005: Hexagonal architecture enforcement](adr/adr-005-hexagonal-architecture-enforcement.md)
 
 ## Overview
 
@@ -106,23 +107,28 @@ Boundary rules:
   domain and ports, but never on outbound adapter implementations.
 - **Outbound adapters** (database, object storage, message broker, LLM/TTS
   vendors) depend on the domain and ports, but never on inbound adapters.
-- **Orchestration code** (LangGraph nodes and Celery tasks) depends on domain
-  services and ports only; direct adapter access is forbidden.
+- **Orchestration code** (LangGraph nodes and Celery tasks) will depend on
+  domain services and ports only; direct adapter access is reserved for the
+  later orchestration-specific enforcement slice.
 - **Cross-adapter imports** are forbidden; interactions happen through ports or
   well-defined message schemas.
-- **Checkpoint payloads** hold orchestration metadata; canonical domain state
-  is persisted through repositories rather than state blobs.
+- **Checkpoint payloads** should hold orchestration metadata; canonical domain
+  state is persisted through repositories rather than state blobs. Dedicated
+  checkpoint audits are part of the later orchestration enforcement slice.
 
 Enforcement mechanisms:
 
-- Lint rules and import conventions flag forbidden dependency direction
-  (e.g. inbound or outbound modules importing each other).
+- `make check-architecture` runs the repo-local architecture checker in
+  `episodic.architecture`, and `make lint` includes that gate after Ruff.
 - Architecture tests validate the allowed dependency graph and port contract
   adherence as part of `make test`.
-- Architecture tests cover LangGraph node and Celery task imports, enforcing
-  port-only dependencies for orchestration code.
+- The current checker covers canonical domain and port modules, application
+  services, Falcon and worker adapter seams, SQLAlchemy and LLM outbound
+  adapters, and explicit composition roots.
 - Contract tests exercise port behaviour against adapter implementations, so
   adapters are verified without coupling to infrastructure in the domain.
+- Roadmap item `2.4.5` extends the same mechanism to LangGraph-node-specific
+  imports, Celery task policies, and checkpoint payload boundaries.
 - Code review checklists enforce idempotency keys, single-responsibility task
   scope, and checkpoint payload audits for orchestration changes.
 

--- a/docs/episodic-podcast-generation-system-design.md
+++ b/docs/episodic-podcast-generation-system-design.md
@@ -12,7 +12,7 @@ Accepted decision records:
 - [ADR 003: Celery worker scaffold](adr/adr-003-celery-worker-scaffold.md)
 - [ADR 004: Show-notes TEI representation](adr/adr-004-show-notes-tei-representation.md)
 - [ADR 005: Structured planning and tool execution for generation orchestration](adr/adr-005-structured-planning-and-tool-execution.md)
-- [ADR 005: Hexagonal architecture enforcement](adr/adr-005-hexagonal-architecture-enforcement.md)
+- [ADR 006: Hexagonal architecture enforcement](adr/adr-006-hexagonal-architecture-enforcement.md)
 
 ## Overview
 

--- a/docs/episodic-podcast-generation-system-design.md
+++ b/docs/episodic-podcast-generation-system-design.md
@@ -487,7 +487,7 @@ sequenceDiagram
     end
 ```
 
-_Figure: default weighting strategy executor-selection and dispatch sequence._
+_Figure 2: Default weighting strategy executor-selection and dispatch sequence._
 
 #### Execution patterns for long-running tasks
 
@@ -1167,7 +1167,7 @@ erDiagram
     EPISODES ||--o{ APPROVAL_EVENTS : records
 ```
 
-_Figure 7: Canonical content schema relationships._
+_Figure 3: Canonical content schema relationships._
 
 The diagram below details the series profile, episode template, and immutable
 revision-history tables used by the current profile-template management flows.
@@ -1222,7 +1222,7 @@ erDiagram
     EPISODE_TEMPLATES ||--o{ EPISODE_TEMPLATE_HISTORY : has_template_history
 ```
 
-_Figure 8: Series profile, episode template, and history-table relationships._
+_Figure 4: Series profile, episode template, and history-table relationships._
 
 ### Reusable reference-document model
 
@@ -1312,7 +1312,7 @@ erDiagram
     REFERENCE_DOCUMENT_REVISIONS ||--o{ SOURCE_DOCUMENTS : snapshot
 ```
 
-_Figure 9: Approved reusable reference material and profile schema._
+_Figure 5: Approved reusable reference material and profile schema._
 
 ### Reference-document glossary
 

--- a/docs/episodic-podcast-generation-system-design.md
+++ b/docs/episodic-podcast-generation-system-design.md
@@ -116,6 +116,80 @@ Boundary rules:
   state is persisted through repositories rather than state blobs. Dedicated
   checkpoint audits are part of the later orchestration enforcement slice.
 
+For screen readers: The following class diagram shows the module categories
+used by the architecture checker, the allowed dependency directions between
+them, and the conceptual forbidden adapter and composition-root dependencies
+that the checker reports as diagnostics.
+
+```mermaid
+classDiagram
+  class DomainModule {
+    +str name
+    +list imports
+  }
+
+  class PortModule {
+    +str name
+    +list imports
+  }
+
+  class ApplicationServiceModule {
+    +str name
+    +list imports
+  }
+
+  class InboundAdapterModule {
+    +str name
+    +list imports
+  }
+
+  class OutboundAdapterModule {
+    +str name
+    +list imports
+  }
+
+  class CompositionRootModule {
+    +str name
+    +list imports
+  }
+
+  class ArchitectureChecker {
+    +run_check(paths)
+    +classify_module(module_path)
+    +validate_dependency(importer_kind, imported_kind)
+    +emit_diagnostic(rule_id, importer, imported, reason)
+  }
+
+  %% Allowed dependency directions
+  DomainModule --> PortModule : may depend on
+  ApplicationServiceModule --> DomainModule : may depend on
+  ApplicationServiceModule --> PortModule : may depend on
+  InboundAdapterModule --> DomainModule : may depend on
+  InboundAdapterModule --> ApplicationServiceModule : may depend on
+  InboundAdapterModule --> PortModule : may depend on
+  CompositionRootModule --> InboundAdapterModule : wires
+  CompositionRootModule --> OutboundAdapterModule : wires
+  CompositionRootModule --> DomainModule : may depend on
+  CompositionRootModule --> ApplicationServiceModule : may depend on
+  CompositionRootModule --> PortModule : may depend on
+
+  %% Forbidden directions (conceptual, enforced by checker)
+  ArchitectureChecker --> DomainModule : forbid imports from
+  ArchitectureChecker --> InboundAdapterModule : forbid imports from
+  ArchitectureChecker --> OutboundAdapterModule : forbid imports from
+  ArchitectureChecker --> CompositionRootModule : forbid imports from
+
+  ArchitectureChecker ..> DomainModule : classifies
+  ArchitectureChecker ..> PortModule : classifies
+  ArchitectureChecker ..> ApplicationServiceModule : classifies
+  ArchitectureChecker ..> InboundAdapterModule : classifies
+  ArchitectureChecker ..> OutboundAdapterModule : classifies
+  ArchitectureChecker ..> CompositionRootModule : classifies
+```
+
+_Figure 1: Hexagonal architecture module categories, allowed dependency
+directions, and checker-enforced forbidden dependency concepts._
+
 Enforcement mechanisms:
 
 - `make check-architecture` runs the repo-local architecture checker in

--- a/docs/execplans/1-5-4-architectural-enforcement-for-hexagonal-boundaries.md
+++ b/docs/execplans/1-5-4-architectural-enforcement-for-hexagonal-boundaries.md
@@ -244,6 +244,11 @@ Implementation approval rule:
   the `ty` tool runner to the already validated `0.0.32` version, and invokes
   Markdown lint through `npx -y markdownlint-cli2`.
 
+- Observation: The hook environment can also omit `uv` from `PATH` even though
+  it is installed at `/home/leynos/.local/bin/uv`. Impact: the Makefile now
+  resolves `UV` once, falling back to that absolute path, and all `uv`
+  invocations use `$(UV)`.
+
 ## Decision Log
 
 - Decision: implement architecture import enforcement as a repo-local checker

--- a/docs/execplans/1-5-4-architectural-enforcement-for-hexagonal-boundaries.md
+++ b/docs/execplans/1-5-4-architectural-enforcement-for-hexagonal-boundaries.md
@@ -237,6 +237,13 @@ Implementation approval rule:
   `make test`, `make typecheck`, `make markdownlint`, and `make nixie` are
   green.
 
+- Observation: Post-turn hooks run in a narrower `PATH` than the interactive
+  shell, so Makefile targets that required global `ruff`, `ty`, or
+  `markdownlint-cli2` binaries failed before reaching the actual checks.
+  Impact: the Makefile now invokes Python developer tools through `uv`, pins
+  the `ty` tool runner to the already validated `0.0.32` version, and invokes
+  Markdown lint through `npx -y markdownlint-cli2`.
+
 ## Decision Log
 
 - Decision: implement architecture import enforcement as a repo-local checker

--- a/docs/execplans/1-5-4-architectural-enforcement-for-hexagonal-boundaries.md
+++ b/docs/execplans/1-5-4-architectural-enforcement-for-hexagonal-boundaries.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: APPROVED - implementation in progress
 
 ## Purpose and big picture
 
@@ -167,18 +167,26 @@ Implementation approval rule:
   implementation, especially `episodic/canonical/profile_templates/helpers.py`
   and `episodic/canonical/reference_documents/bindings.py`, which currently
   reach into `episodic.canonical.storage.models`.
-- [ ] Stage A: define the first enforced module map and add fail-first
+- [x] (2026-04-30 22:14Z) User explicitly approved implementation of this
+  ExecPlan and requested that the living plan stay current throughout the
+  change.
+- [x] (2026-04-30 22:14Z) Stage A: define the first enforced module map and add
+      fail-first
   architecture tests plus behaviour fixtures.
-- [ ] Stage B: implement the repo-local architecture checker and Makefile
+- [x] (2026-04-30 22:18Z) Stage B: implement the repo-local architecture
+      checker and Makefile
   wiring.
-- [ ] Stage C: remove or explicitly justify current boundary leaks, then enable
+- [x] (2026-04-30 22:21Z) Stage C: remove or explicitly justify current
+      boundary leaks, then enable
   the checker on the scoped production packages.
-- [ ] Stage D: add runtime-checkable port contract tests for current concrete
+- [x] (2026-04-30 22:23Z) Stage D: add runtime-checkable port contract tests
+      for current concrete
   adapters.
-- [ ] Stage E: wire CI, ADR, and guide updates, then mark the roadmap item
+- [x] (2026-04-30 22:27Z) Stage E: wire CI, ADR, and guide updates, then mark
+      the roadmap item
   complete.
-- [ ] Stage F: run the full validation gates and update this ExecPlan with the
-  delivery outcome.
+- [x] (2026-04-30 22:42Z) Stage F: run the full validation gates and update
+  this ExecPlan with the delivery outcome.
 
 ## Surprises & Discoveries
 
@@ -209,6 +217,26 @@ Implementation approval rule:
   task checks already exist. Impact: the documentation update in this plan must
   reconcile that staged rollout clearly.
 
+- Observation: The first focused red run could not reach pytest collection
+  until the Makefile's `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` environment was
+  applied. Impact: all subsequent focused and full validation commands should
+  use the Makefile targets or carry the same environment variable when invoking
+  `uv run` directly.
+
+- Observation: The checker initially saw `from package import storage` as an
+  import of `package` only. Impact: `ImportFrom` handling now emits both the
+  base module and imported member path so fixture and production diagnostics
+  catch package-level adapter imports.
+
+- Observation: `make fmt` runs `mdformat-all`, which shells out to a
+  repository-wide `markdownlint --fix` invocation and reports older MD013
+  line-length findings in many pre-existing documents. The dedicated
+  `make markdownlint` gate uses the configured `markdownlint-cli2` path and
+  passes with zero errors. Impact: this slice treats `make fmt` as blocked by
+  pre-existing formatter-tool scope, while `make check-fmt`, `make lint`,
+  `make test`, `make typecheck`, `make markdownlint`, and `make nixie` are
+  green.
+
 ## Decision Log
 
 - Decision: implement architecture import enforcement as a repo-local checker
@@ -235,13 +263,24 @@ Implementation approval rule:
   should prove the checker's observable behaviour without rewriting real source
   files during the test run. Date/Author: 2026-04-24 / Codex.
 
+- Decision: move database constraint-name constants used by service-layer
+  conflict handling into `episodic.canonical.constraints` and re-export them to
+  storage models by import. Rationale: the names are part of the canonical
+  conflict contract, while SQLAlchemy model classes remain outbound adapter
+  infrastructure. Date/Author: 2026-04-30 / Codex.
+
+- Decision: keep Stage D port tests structural and avoid live inference calls.
+  Rationale: `LLMPort` conformance only needs the adapter method surface for
+  `1.5.4`, so Vidai Mock remains unnecessary until future behaviour tests
+  exercise inference-backed orchestration. Date/Author: 2026-04-30 / Codex.
+
 ## Outcomes & Retrospective
 
-No implementation has started yet. The current outcome is a draft,
-self-contained plan that identifies the staged path to make the documented
-hexagonal boundaries enforceable.
+Implementation began after explicit approval on 2026-04-30. The delivery adds
+the repo-local architecture checker, production boundary fixes, port contract
+tests, CI visibility, ADR-005, guide updates, and roadmap completion.
 
-Expected outcome after implementation:
+Delivered outcome:
 
 - `make lint` includes an architecture-enforcement step that rejects forbidden
   import directions in the scoped package groups.
@@ -252,6 +291,19 @@ Expected outcome after implementation:
   `1.5.4` covers the core service scaffold, while `2.4.5` extends the same
   mechanism to orchestration-specific rules.
 - `docs/roadmap.md` marks `1.5.4` done only after all validation gates pass.
+
+Validation outcome:
+
+- `make check-fmt` passed.
+- `make typecheck` passed with existing `ty` redundant-cast warnings.
+- `make lint` passed, including `make check-architecture`.
+- `make test` passed: 393 passed, 3 skipped.
+- `make markdownlint` passed with zero errors.
+- `make nixie` passed.
+- `make fmt` failed in `mdformat-all` because its raw `markdownlint --fix`
+  invocation reports pre-existing MD013 line-length findings across older
+  documentation files that are outside this change. The committed files pass
+  the configured Markdown and formatting gates above.
 
 ## Context and orientation
 

--- a/docs/execplans/1-5-4-architectural-enforcement-for-hexagonal-boundaries.md
+++ b/docs/execplans/1-5-4-architectural-enforcement-for-hexagonal-boundaries.md
@@ -1,0 +1,544 @@
+# Implement architectural enforcement for hexagonal boundaries
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+## Purpose and big picture
+
+Roadmap item `1.5.4` is the missing automation layer for the boundary rules
+that were documented in `1.5.3`. The design document already says Episodic uses
+a hexagonal architecture with domain logic, typed ports, inbound adapters,
+outbound adapters, and composition roots. Today, however, that rule set is
+still enforced mostly by convention. Ruff is configured and CI already gates on
+`make lint` plus `make test`, but the repository does not yet have a dedicated
+dependency-direction checker or an architecture-test suite that proves concrete
+adapters still satisfy the published port contracts.
+
+After this work, a maintainer should be able to change code in
+`episodic/canonical`, `episodic/api`, `episodic/llm`, and related packages and
+immediately learn whether the change crosses a forbidden boundary. The local
+developer path and the Continuous Integration (CI) path should agree:
+`make lint` must fail on forbidden imports, `make test` must fail when adapters
+stop honouring port contracts, and CI must surface the architecture gate
+clearly enough that a reviewer can tell whether a failure is a formatting
+problem, a typing problem, or a boundary-regression problem.
+
+This plan intentionally lands the foundation for boundary enforcement in the
+current service scaffold without consuming roadmap item `2.4.5`. Item `1.5.4`
+should make the core canonical, HTTP, worker-runtime, and Large Language Model
+(LLM) seams enforceable now. Item `2.4.5` should then extend the same checker
+framework to deeper orchestration-specific rules for LangGraph nodes, Celery
+tasks, and checkpoint payload audits.
+
+Success is observable in eight ways:
+
+1. A repo-local architecture checker exists, emits stable diagnostics, and can
+   classify modules into allowed dependency groups without requiring an
+   external service.
+2. `make lint` fails when a scoped module imports from a forbidden layer, with
+   messages that name the offending importer, imported module, and violated
+   rule.
+3. Dedicated `pytest` architecture tests validate that concrete adapters still
+   satisfy the public port protocols they are meant to implement.
+4. `pytest-bdd` scenarios prove the architecture checker's behaviour against
+   small fixture packages that represent allowed and forbidden import graphs.
+5. Current boundary leaks inside the scoped packages are either removed or
+   reduced to a documented, explicit allowlist with a roadmap-backed reason.
+6. CI exposes architecture enforcement as a named gate and fails the pipeline
+   when the checker or architecture tests fail.
+7. A new Architecture Decision Record (ADR), the design document, the
+   developers' guide, and a short users' guide note all describe the
+   enforcement model and its scope.
+8. `docs/roadmap.md` marks `1.5.4` done only after
+   `make check-fmt`, `make typecheck`, `make lint`, `make test`,
+   `make markdownlint`, and `make nixie` all pass.
+
+Implementation approval rule:
+
+- This document is a draft only. No implementation work should begin until the
+  user explicitly approves this plan.
+
+## Constraints
+
+- Preserve the core invariants from the `hexagonal-architecture` skill:
+  - domain and application logic must not import Falcon, SQLAlchemy adapter
+    modules, Celery runtime code, provider SDK adapters, or other
+    infrastructure-heavy modules directly;
+  - ports remain the typed integration boundary;
+  - inbound adapters depend on domain or application code plus ports, not on
+    concrete outbound adapters; and
+  - cross-adapter imports are forbidden unless the file is an explicitly named
+    composition root.
+- Treat composition roots as a small, explicit exception set. Files such as
+  `episodic/api/runtime.py` and `episodic/worker/runtime.py` are allowed to
+  wire concrete adapters together because that is their purpose. The checker
+  must model that exception deliberately rather than weakening the whole rule
+  set.
+- Keep `1.5.4` scoped to enforceable architecture rules for the current service
+  scaffold. Do not use this roadmap item to implement the orchestration
+  extensions already reserved for `2.4.5`, such as deep checkpoint-payload
+  audits or LangGraph-node-specific policies beyond what is necessary to avoid
+  contradiction with the design.
+- Avoid a broad package reorganisation unless the checker cannot be made
+  truthful without moving code. Prefer small refactors that remove specific
+  boundary leaks over renaming half the repository.
+- Use fail-first tests for each milestone: add or update tests, run them to
+  confirm failure, implement the production changes, then rerun the same test
+  cluster.
+- Use `pytest` for unit and architecture tests, and `pytest-bdd` for
+  behavioural tests.
+- Use Vidai Mock for behavioural testing of inference services. This roadmap
+  item does not need to invoke an inference path merely to mention Vidai Mock.
+  If an implementation change causes a behavioural test to exercise
+  `LLMPort`-backed inference directly, that behaviour test must use Vidai Mock.
+- Keep existing public API and runtime behaviour stable. This work adds
+  enforcement, not new user-facing endpoints or protocol changes.
+- Record the enforcement design in a new ADR under `docs/adr/`.
+- Update `docs/episodic-podcast-generation-system-design.md`,
+  `docs/developers-guide.md`, and `docs/users-guide.md` so the documented
+  enforcement scope matches the implementation exactly.
+- Mark roadmap item `1.5.4` done only after the implementation, tests,
+  documentation updates, and validation gates are complete.
+
+## Tolerances
+
+- Scope tolerance: stop and escalate if the first working slice requires more
+  than roughly 18 files or 1200 net new lines before the checker can run on at
+  least one meaningful production package group.
+- Dependency tolerance: stop and escalate if the plan appears to require more
+  than one lightweight new development dependency. The preferred path is zero
+  new dependencies, using a repo-local checker plus existing test tooling.
+- Refactor tolerance: stop and escalate if current boundary leaks are numerous
+  enough that enforcement would first require a large package split rather than
+  a few targeted fixes.
+- Roadmap tolerance: stop and escalate if making `1.5.4` pass would force full
+  implementation of `2.4.5` in the same change.
+- Composition-root tolerance: stop and escalate if the checker cannot model
+  composition-root exceptions cleanly and would therefore report legitimate
+  runtime-wiring modules as violations.
+- Diagnostic tolerance: stop and escalate after three failed attempts to make
+  the same checker message stable enough for reliable `pytest-bdd` assertions.
+
+## Risks
+
+- Risk: some current canonical service helpers already import
+  `episodic.canonical.storage.models`, which means a strict gate will fail
+  immediately. Severity: high. Likelihood: high. Mitigation: identify the
+  existing leaks early, then either refactor them behind neutral constants or
+  classify them in a temporary, explicit allowlist with a removal note tied to
+  the roadmap.
+
+- Risk: composition roots legitimately import concrete adapters, and an
+  over-simplified checker could classify them as violations. Severity: high.
+  Likelihood: medium. Mitigation: encode composition roots as a first-class
+  module group with narrow, documented exceptions rather than ad hoc ignores.
+
+- Risk: public ports are expressed as `typing.Protocol`, but the repository
+  does not currently mark them `@runtime_checkable`, which makes direct runtime
+  contract assertions awkward. Severity: medium. Likelihood: high. Mitigation:
+  add `@runtime_checkable` only to the public ports that architecture tests
+  actually need to assert at runtime.
+
+- Risk: the design document currently speaks as though orchestration-specific
+  architecture tests already exist, while the roadmap defers a dedicated
+  extension of those rules to `2.4.5`. Severity: medium. Likelihood: high.
+  Mitigation: use the ADR and design update to clarify the staged rollout:
+  `1.5.4` establishes the checker framework and current core rules, and `2.4.5`
+  extends that framework to orchestration-specific policies.
+
+- Risk: behavioural tests for an internal linting tool can become brittle if
+  they assert on full multi-line output. Severity: medium. Likelihood: medium.
+  Mitigation: assert on stable substrings such as rule identifiers, importer
+  paths, and imported-module names rather than exact whole-file transcripts.
+
+## Progress
+
+- [x] (2026-04-24 00:00Z) Reviewed `docs/roadmap.md`, the system design, the
+  async Falcon and py-pglite testing references, the existing scaffold
+  ExecPlans, and the current Makefile and CI workflow.
+- [x] (2026-04-24 00:00Z) Re-inspected the current package layout under
+  `episodic/` and confirmed that Ruff import conventions are present but no
+  dedicated architecture checker or architecture-test suite exists yet.
+- [x] (2026-04-24 00:00Z) Identified current hot spots that will matter during
+  implementation, especially `episodic/canonical/profile_templates/helpers.py`
+  and `episodic/canonical/reference_documents/bindings.py`, which currently
+  reach into `episodic.canonical.storage.models`.
+- [ ] Stage A: define the first enforced module map and add fail-first
+  architecture tests plus behaviour fixtures.
+- [ ] Stage B: implement the repo-local architecture checker and Makefile
+  wiring.
+- [ ] Stage C: remove or explicitly justify current boundary leaks, then enable
+  the checker on the scoped production packages.
+- [ ] Stage D: add runtime-checkable port contract tests for current concrete
+  adapters.
+- [ ] Stage E: wire CI, ADR, and guide updates, then mark the roadmap item
+  complete.
+- [ ] Stage F: run the full validation gates and update this ExecPlan with the
+  delivery outcome.
+
+## Surprises & Discoveries
+
+- Observation: `pyproject.toml` already enables Ruff's general import hygiene
+  rules (`ICN`, `TID`, `TC`), but nothing in the current config encodes the
+  repository's package-to-package dependency graph. Impact: `1.5.4` needs a
+  dedicated checker rather than a small Ruff setting tweak.
+
+- Observation: CI already runs `make lint` and `make test`, so the plumbing for
+  a gate exists, but no named architecture-enforcement step is present in
+  `.github/workflows/ci.yml`. Impact: the implementation can reuse the current
+  pipeline while still adding a visible architecture gate for reviewers.
+
+- Observation: `episodic/api/runtime.py` legitimately imports the concrete
+  `SqlAlchemyUnitOfWork` adapter. Impact: composition roots must be modelled as
+  explicit exceptions, not accidental false positives.
+
+- Observation: `episodic/canonical/profile_templates/helpers.py` imports
+  `REVISION_CONSTRAINT_NAMES` from `episodic.canonical.storage.models`, and
+  `episodic/canonical/reference_documents/bindings.py` imports several storage
+  uniqueness-constraint constants from the same module. Impact: at least two
+  current boundary leaks must be addressed before a repo-wide gate can be made
+  truthful.
+
+- Observation: `docs/roadmap.md` reserves
+  `2.4.5 Extend architecture enforcement to orchestration code`, while the
+  design document's current prose reads as though LangGraph-node and Celery
+  task checks already exist. Impact: the documentation update in this plan must
+  reconcile that staged rollout clearly.
+
+## Decision Log
+
+- Decision: implement architecture import enforcement as a repo-local checker
+  with a dedicated Makefile target, then wire that target into `make lint` and
+  CI. Rationale: the boundary rules are specific to Episodic's package map, and
+  a repo-local checker keeps diagnostics deterministic, testable, and easy to
+  extend for `2.4.5`. Date/Author: 2026-04-24 / Codex.
+
+- Decision: scope the first enforcement slice to the current core service
+  layers and their composition roots, not the full future orchestration rule
+  set. Rationale: this honours the roadmap sequencing and avoids collapsing
+  `1.5.4` and `2.4.5` into one over-large change. Date/Author: 2026-04-24 /
+  Codex.
+
+- Decision: validate port adherence through `@runtime_checkable` public
+  protocols plus focused adapter tests that use existing fixtures, especially
+  the py-pglite `session_factory` and LLM adapter fixtures. Rationale: this
+  proves the published contracts using the repository's existing test harness
+  instead of inventing a second abstract contract layer. Date/Author:
+  2026-04-24 / Codex.
+
+- Decision: use `pytest-bdd` against small architecture-fixture packages rather
+  than against self-mutating production files. Rationale: behavioural tests
+  should prove the checker's observable behaviour without rewriting real source
+  files during the test run. Date/Author: 2026-04-24 / Codex.
+
+## Outcomes & Retrospective
+
+No implementation has started yet. The current outcome is a draft,
+self-contained plan that identifies the staged path to make the documented
+hexagonal boundaries enforceable.
+
+Expected outcome after implementation:
+
+- `make lint` includes an architecture-enforcement step that rejects forbidden
+  import directions in the scoped package groups.
+- `make test` includes architecture tests that prove the current concrete
+  adapters still satisfy the public port contracts.
+- CI exposes architecture enforcement as a named gate.
+- The design document and ADR set explain the staged scope clearly:
+  `1.5.4` covers the core service scaffold, while `2.4.5` extends the same
+  mechanism to orchestration-specific rules.
+- `docs/roadmap.md` marks `1.5.4` done only after all validation gates pass.
+
+## Context and orientation
+
+This section describes the current repository state so a novice can navigate
+the change confidently.
+
+### Relevant documentation
+
+The implementation should stay anchored to the following documents:
+
+- `docs/roadmap.md`
+  - `1.5.4 Implement architectural enforcement checks for hexagonal
+    boundaries`
+  - `2.4.5 Extend architecture enforcement to orchestration code`
+- `docs/episodic-podcast-generation-system-design.md`
+  - `Architectural Summary`
+  - `Hexagonal architecture enforcement`
+  - `Orchestration ports and adapters`
+- `docs/async-sqlalchemy-with-pg-and-falcon.md`
+- `docs/testing-async-falcon-endpoints.md`
+- `docs/testing-sqlalchemy-with-pytest-and-py-pglite.md`
+- `docs/agentic-systems-with-langgraph-and-celery.md`
+- `docs/execplans/1-5-1-scaffold-falcon-http-services-on-granian.md`
+- `docs/execplans/1-5-2-scaffold-celery-workers-with-rabbit-mq-integration.md`
+- `docs/adr/adr-002-http-service-composition-root.md`
+- `docs/adr/adr-003-celery-worker-scaffold.md`
+
+### Relevant skills
+
+The implementer should keep the following skills close at hand:
+
+- `execplans` for keeping this document current as implementation proceeds.
+- `hexagonal-architecture` for the dependency-rule, port-ownership, and
+  adapter-isolation invariants.
+- `vidai-mock` only if a behavioural test in this slice ends up exercising a
+  real `LLMPort`-backed inference path.
+
+### Current package map
+
+The production package already has enough structure for a useful first
+enforcement slice:
+
+- `episodic/canonical/domain.py`, `episodic/canonical/ingestion.py`,
+  `episodic/canonical/ports.py`, and `episodic/canonical/ingestion_ports.py`
+  hold the core domain and public port contracts for canonical content.
+- `episodic/canonical/services.py`,
+  `episodic/canonical/ingestion_service.py`,
+  `episodic/canonical/profile_templates/`, and
+  `episodic/canonical/reference_documents/` hold application-service style
+  workflows that should depend on domain types and ports rather than concrete
+  storage adapters.
+- `episodic/canonical/storage/` and `episodic/canonical/adapters/` hold the
+  concrete outbound adapters for persistence and ingestion pipeline behaviour.
+- `episodic/api/` holds the Falcon inbound adapter, with
+  `episodic/api/runtime.py` acting as the composition root.
+- `episodic/llm/ports.py` defines the public LLM port, while
+  `episodic/llm/openai_adapter.py` and `episodic/llm/openai_client.py` hold a
+  concrete outbound adapter.
+- `episodic/worker/runtime.py` is another composition root. It should remain
+  explicitly modelled, but orchestration-specific worker-task rules are still a
+  later roadmap concern.
+
+### Current gaps
+
+The current codebase documents the architecture but does not yet automate it:
+
+- `Makefile` exposes `lint`, `typecheck`, and `test`, but `lint` currently
+  runs `ruff check` only.
+- `.github/workflows/ci.yml` runs `make lint` and `make test`, but there is no
+  named architecture-enforcement step.
+- No `tests/test_architecture_*.py` module exists yet.
+- No `tests/features/architecture_*.feature` scenario exists yet.
+- Public ports such as `CanonicalUnitOfWork`, the ingestion ports, and
+  `LLMPort` are `typing.Protocol` contracts but are not currently marked
+  `@runtime_checkable`.
+
+### Terms used in this plan
+
+- Architecture checker: the repo-local static checker that walks imports,
+  classifies modules, and reports forbidden dependency directions.
+- Composition root: a module whose job is to construct concrete adapters and
+  wire them into an inbound surface, for example `episodic/api/runtime.py`.
+- Port contract test: a `pytest` test that proves a concrete adapter still
+  satisfies the public protocol it claims to implement.
+- Architecture fixture package: a small package tree under `tests/fixtures/`
+  used by behavioural tests to prove allowed and forbidden import graphs.
+
+## Stage A: define the first enforced module map and add fail-first tests
+
+Start by turning the intended rules into executable expectations before adding
+the checker itself.
+
+1. Add a new unit-test module, suggested name
+   `tests/test_architecture_enforcement.py`, that defines the first supported
+   module groups and expected dependency directions.
+2. The first rule set should be intentionally small and explicit:
+   - domain and public-port modules may not import inbound adapters, outbound
+     adapters, or composition roots;
+   - application-service modules may depend on domain and ports, but not on
+     concrete storage or LLM adapter modules;
+   - inbound adapters may depend on domain or application code plus ports, but
+     not directly on concrete outbound adapters except through explicit
+     composition roots; and
+   - composition roots may import the concrete adapters they wire.
+3. Add architecture-fixture packages under `tests/fixtures/architecture/`, for
+   example:
+   - `allowed_case/`
+   - `domain_imports_storage/`
+   - `api_imports_outbound_adapter/`
+   - `composition_root_allows_wiring/`
+4. Add a behavioural feature file,
+   `tests/features/architecture_enforcement.feature`, with scenarios such as:
+   - a violating domain module is rejected with a clear diagnostic;
+   - a violating inbound adapter is rejected with a clear diagnostic; and
+   - a composition root that wires adapters is accepted.
+5. Add matching BDD steps in
+   `tests/steps/test_architecture_enforcement_steps.py`. The steps should call
+   the checker through its public function or command-line entrypoint, not by
+   importing private helpers.
+6. Add a red-phase assertion for the current production hot spots so the work
+   is honest about today's leaks. The initial failure may reference
+   `episodic/canonical/profile_templates/helpers.py` and
+   `episodic/canonical/reference_documents/bindings.py`.
+7. Run the targeted architecture unit tests and BDD scenarios first and record
+   the red phase.
+
+Suitable red-phase examples:
+
+```plaintext
+E architecture: episodic.canonical.profile_templates.helpers imports forbidden
+  module episodic.canonical.storage.models
+E architecture: episodic.canonical.reference_documents.bindings imports
+  forbidden module episodic.canonical.storage.models
+E ModuleNotFoundError: No module named 'episodic.architecture'
+```
+
+## Stage B: implement the repo-local architecture checker and Makefile wiring
+
+Implement the smallest production checker that can satisfy the new tests.
+
+1. Add a new module for the checker, for example:
+   - `episodic/architecture/__init__.py`
+   - `episodic/architecture/checker.py`
+   - `episodic/architecture/rules.py`
+2. Keep the checker repo-local and deterministic:
+   - parse imports from Python source using the standard library `ast` module;
+   - resolve only repository-local `episodic.*` imports for rule checking;
+   - ignore imports inside `tests/` except for the fixture packages used to
+     prove checker behaviour; and
+   - emit stable diagnostics that include a rule identifier, importer module,
+     imported module, and a short reason.
+3. Store the first-scope dependency policy in one explicit manifest structure
+   rather than scattering ad hoc conditionals. A frozen dataclass or named
+   tuple structure is suitable here.
+4. Add a Makefile target such as `check-architecture` that runs the checker
+   through `uv run python -m episodic.architecture`.
+5. Update `make lint` so it runs both Ruff and `check-architecture`.
+6. Keep the checker extensible for `2.4.5`, but do not yet implement deep
+   checkpoint-payload or LangGraph-node-specific rules in this stage.
+
+Expected Stage B result:
+
+- `make lint` has an explicit architecture-enforcement sub-step.
+- The checker can run against both production code and fixture packages.
+
+## Stage C: remove current boundary leaks and enable the scoped production gate
+
+With the checker available, make the production package conform to the scoped
+rules.
+
+1. Fix the known canonical-to-storage leaks identified during discovery:
+   - `episodic/canonical/profile_templates/helpers.py`
+   - `episodic/canonical/reference_documents/bindings.py`
+2. The preferred fix is to move storage-specific constraint-name knowledge
+   behind a neutral seam, for example:
+   - a small port-facing constant module that is safe for service-layer use; or
+   - a storage helper that translates database exceptions into domain-level
+     conflict signals before the service layer inspects them.
+3. Keep any allowlist temporary, narrow, and documented. If one exception must
+   survive this roadmap item, record it in the checker manifest together with a
+   comment that names the owning roadmap item or ADR.
+4. Confirm that the scoped production packages now pass the checker locally.
+5. Keep composition roots explicitly allowed and covered by fixture tests so
+   the checker remains truthful about wiring modules such as
+   `episodic/api/runtime.py`.
+
+Go/no-go for Stage C:
+
+- the checker passes on the scoped production modules without undocumented
+  ignores; and
+- the BDD scenarios still distinguish genuine violations from legitimate
+  composition-root wiring.
+
+## Stage D: add runtime-checkable port contract tests
+
+Once import-direction enforcement exists, prove that the current concrete
+adapters still satisfy the published ports.
+
+1. Add `@runtime_checkable` to the public protocols that architecture tests
+   need to assert at runtime. The likely initial set is:
+   - `episodic.canonical.ports.CanonicalUnitOfWork`
+   - `episodic.canonical.ingestion_ports.SourceNormalizer`
+   - `episodic.canonical.ingestion_ports.WeightingStrategy`
+   - `episodic.canonical.ingestion_ports.ConflictResolver`
+   - `episodic.llm.ports.LLMPort`
+2. Extend `tests/test_architecture_enforcement.py` or add a sibling module such
+   as `tests/test_port_contracts.py`.
+3. Prove the current concrete adapters satisfy those protocols using existing
+   fixtures:
+   - `SqlAlchemyUnitOfWork` against the py-pglite-backed `session_factory`
+   - `InMemorySourceNormalizer`
+   - `DefaultWeightingStrategy`
+   - `HighestWeightConflictResolver`
+   - `OpenAICompatibleLLMAdapter` through the existing LLM adapter fixture
+     pattern in `tests/fixtures/llm.py`
+4. Keep these tests structural and contract-focused. They should not duplicate
+   the existing adapter behaviour tests in full; they should prove that the
+   adapter still exposes the expected protocol surface and can be treated as
+   the port type.
+5. If a runtime-checkable protocol would be misleading because a structural
+   `isinstance(...)` check is too weak on its own, pair it with one or two
+   targeted assertions on method names or call signatures rather than widening
+   the public API.
+
+Vidai Mock note:
+
+- Stage D should not require Vidai Mock unless the contract test for
+  `LLMPort` intentionally exercises a live inference-facing behaviour path. A
+  structural adapter contract test using the existing fixture and mock
+  transport is sufficient for `1.5.4`.
+
+## Stage E: wire CI and update the documentation set
+
+After the checker and tests are green locally, update the documented operating
+model.
+
+1. Update `.github/workflows/ci.yml` so architecture enforcement is visible as
+   a named gate. One acceptable pattern is:
+   - add a `Run architecture checks` step that calls `make check-architecture`;
+   - keep `Run ruff` as the general lint step; and
+   - leave `make test` to collect the architecture tests along with the rest of
+     the suite.
+2. Add a new ADR, expected path
+   `docs/adr/adr-005-hexagonal-architecture-enforcement.md`, describing:
+   - why Ruff alone is insufficient for Episodic's dependency graph;
+   - the chosen checker shape and scope;
+   - the explicit composition-root exception model; and
+   - the staged relationship between `1.5.4` and `2.4.5`.
+3. Update `docs/episodic-podcast-generation-system-design.md`:
+   - add the new ADR to the accepted decision-record list; and
+   - revise the enforcement prose so it matches the staged rollout honestly.
+4. Update `docs/developers-guide.md` with:
+   - the architecture checker command;
+   - the meaning of each enforced module group;
+   - how to extend the manifest when a new port or adapter is added;
+   - how to run the architecture BDD tests; and
+   - when Vidai Mock becomes required for future inference-facing behavioural
+     coverage.
+5. Update `docs/users-guide.md` with a brief, truthful note only. This feature
+   does not add a new public API surface, so the user-facing update should be
+   small, for example noting that releases now gate on architecture checks that
+   protect API and workflow stability.
+6. Update `docs/roadmap.md` and mark `1.5.4` done only after Stage F passes.
+
+## Stage F: run the full validation gates
+
+Run every gate sequentially from repository root. Use `tee` so truncated
+outputs remain inspectable.
+
+```shell
+set -o pipefail; make fmt 2>&1 | tee /tmp/execplan-1-5-4-make-fmt.log
+set -o pipefail; make check-fmt 2>&1 | tee /tmp/execplan-1-5-4-make-check-fmt.log
+set -o pipefail; make typecheck 2>&1 | tee /tmp/execplan-1-5-4-make-typecheck.log
+set -o pipefail; make lint 2>&1 | tee /tmp/execplan-1-5-4-make-lint.log
+set -o pipefail; make test 2>&1 | tee /tmp/execplan-1-5-4-make-test.log
+set -o pipefail; PATH=/root/.bun/bin:$PATH make markdownlint 2>&1 | tee /tmp/execplan-1-5-4-make-markdownlint.log
+set -o pipefail; make nixie 2>&1 | tee /tmp/execplan-1-5-4-make-nixie.log
+```
+
+Acceptance criteria for completion:
+
+1. `make check-fmt`, `make typecheck`, `make lint`, and `make test` all pass.
+2. Markdown validation also passes because this feature adds an ExecPlan, an
+   ADR, and guide updates.
+3. The checker fails on known bad fixture packages and passes on the scoped
+   production package set.
+4. Port contract tests pass for the concrete adapters covered in Stage D.
+5. CI exposes the architecture gate clearly.
+6. `docs/roadmap.md` marks `1.5.4` done only after the previous five items are
+   true.

--- a/docs/execplans/1-5-4-architectural-enforcement-for-hexagonal-boundaries.md
+++ b/docs/execplans/1-5-4-architectural-enforcement-for-hexagonal-boundaries.md
@@ -5,20 +5,19 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: APPROVED - implementation in progress
+Status: SHIPPED - implementation complete
 
 ## Purpose and big picture
 
 Roadmap item `1.5.4` is the missing automation layer for the boundary rules
 that were documented in `1.5.3`. The design document already says Episodic uses
 a hexagonal architecture with domain logic, typed ports, inbound adapters,
-outbound adapters, and composition roots. Today, however, that rule set is
-still enforced mostly by convention. Ruff is configured and CI already gates on
-`make lint` plus `make test`, but the repository does not yet have a dedicated
-dependency-direction checker or an architecture-test suite that proves concrete
-adapters still satisfy the published port contracts.
+outbound adapters, and composition roots. This shipped slice turns those rules
+from convention into a repo-local dependency-direction checker and
+architecture-test suite that proves concrete adapters still satisfy the
+published port contracts.
 
-After this work, a maintainer should be able to change code in
+After this work, a maintainer can change code in
 `episodic/canonical`, `episodic/api`, `episodic/llm`, and related packages and
 immediately learn whether the change crosses a forbidden boundary. The local
 developer path and the Continuous Integration (CI) path should agree:
@@ -59,8 +58,8 @@ Success is observable in eight ways:
 
 Implementation approval rule:
 
-- This document is a draft only. No implementation work should begin until the
-  user explicitly approves this plan.
+- Implementation was explicitly approved on 2026-04-30 and has shipped. Future
+  edits should keep this document aligned with the delivered behaviour.
 
 ## Constraints
 
@@ -249,10 +248,10 @@ Implementation approval rule:
   the `ty` tool runner to the already validated `0.0.32` version, and invokes
   Markdown lint through `npx -y markdownlint-cli2`.
 
-- Observation: The hook environment can also omit `uv` from `PATH` even though
-  it is installed at `/home/leynos/.local/bin/uv`. Impact: the Makefile now
-  resolves `UV` once, falling back to that absolute path, and all `uv`
-  invocations use `$(UV)`.
+- Observation: The hook environment can also omit `uv` from `PATH`, and the
+  fallback install location is user-specific. Impact: the Makefile now resolves
+  `UV` once, falling back to `$(HOME)/.local/bin/uv`, and all `uv` invocations
+  use `$(UV)`.
 
 - Observation: Application and inbound modules can import concrete adapters
   through package barrels such as
@@ -360,6 +359,15 @@ Review follow-up validation:
 - `make test` passed: 451 passed, 3 skipped.
 - `make markdownlint` passed with zero errors.
 
+Shipped-state and star-import follow-up validation:
+
+- `make check-fmt` passed.
+- `make lint` passed.
+- `make typecheck` passed.
+- Focused architecture tests passed: 10 passed.
+- `make test` passed: 452 passed, 3 skipped.
+- `make markdownlint` passed with zero errors.
+
 ## Context and orientation
 
 This section describes the current repository state so a novice can navigate
@@ -421,19 +429,17 @@ enforcement slice:
   explicitly modelled, but orchestration-specific worker-task rules are still a
   later roadmap concern.
 
-### Current gaps
+### Resolved gaps
 
-The current codebase documents the architecture but does not yet automate it:
+The shipped codebase now automates the documented architecture:
 
-- `Makefile` exposes `lint`, `typecheck`, and `test`, but `lint` currently
-  runs `ruff check` only.
-- `.github/workflows/ci.yml` runs `make lint` and `make test`, but there is no
-  named architecture-enforcement step.
-- No `tests/test_architecture_*.py` module exists yet.
-- No `tests/features/architecture_*.feature` scenario exists yet.
+- `Makefile` exposes `check-architecture`, and `make lint` includes that gate.
+- `.github/workflows/ci.yml` includes a named architecture-enforcement step.
+- `tests/test_architecture_enforcement.py` covers the static checker.
+- `tests/features/architecture_enforcement.feature` covers behaviour fixtures.
 - Public ports such as `CanonicalUnitOfWork`, the ingestion ports, and
-  `LLMPort` are `typing.Protocol` contracts but are not currently marked
-  `@runtime_checkable`.
+  `LLMPort` are runtime-checkable where the contract tests need structural
+  assertions.
 
 ### Terms used in this plan
 
@@ -634,7 +640,7 @@ set -o pipefail; make check-fmt 2>&1 | tee /tmp/execplan-1-5-4-make-check-fmt.lo
 set -o pipefail; make typecheck 2>&1 | tee /tmp/execplan-1-5-4-make-typecheck.log
 set -o pipefail; make lint 2>&1 | tee /tmp/execplan-1-5-4-make-lint.log
 set -o pipefail; make test 2>&1 | tee /tmp/execplan-1-5-4-make-test.log
-set -o pipefail; PATH=/root/.bun/bin:$PATH make markdownlint 2>&1 | tee /tmp/execplan-1-5-4-make-markdownlint.log
+set -o pipefail; make markdownlint 2>&1 | tee /tmp/execplan-1-5-4-make-markdownlint.log
 set -o pipefail; make nixie 2>&1 | tee /tmp/execplan-1-5-4-make-nixie.log
 ```
 

--- a/docs/execplans/1-5-4-architectural-enforcement-for-hexagonal-boundaries.md
+++ b/docs/execplans/1-5-4-architectural-enforcement-for-hexagonal-boundaries.md
@@ -306,7 +306,7 @@ Implementation approval rule:
 
 Implementation began after explicit approval on 2026-04-30. The delivery adds
 the repo-local architecture checker, production boundary fixes, port contract
-tests, CI visibility, ADR-005, guide updates, and roadmap completion.
+tests, CI visibility, ADR-006, guide updates, and roadmap completion.
 
 Delivered outcome:
 
@@ -584,7 +584,7 @@ model.
    - leave `make test` to collect the architecture tests along with the rest of
      the suite.
 2. Add a new ADR, expected path
-   `docs/adr/adr-005-hexagonal-architecture-enforcement.md`, describing:
+   `docs/adr/adr-006-hexagonal-architecture-enforcement.md`, describing:
    - why Ruff alone is insufficient for Episodic's dependency graph;
    - the chosen checker shape and scope;
    - the explicit composition-root exception model; and

--- a/docs/execplans/1-5-4-architectural-enforcement-for-hexagonal-boundaries.md
+++ b/docs/execplans/1-5-4-architectural-enforcement-for-hexagonal-boundaries.md
@@ -83,7 +83,7 @@ Implementation approval rule:
   extensions already reserved for `2.4.5`, such as deep checkpoint-payload
   audits or LangGraph-node-specific policies beyond what is necessary to avoid
   contradiction with the design.
-- Avoid a broad package reorganisation unless the checker cannot be made
+- Avoid a broad package reorganization unless the checker cannot be made
   truthful without moving code. Prefer small refactors that remove specific
   boundary leaks over renaming half the repository.
 - Use fail-first tests for each milestone: add or update tests, run them to
@@ -190,6 +190,8 @@ Implementation approval rule:
 - [x] (2026-05-08 00:00Z) Fixed a post-delivery false negative where imports
   through package `__init__` re-exports could hide concrete outbound adapters
   from the architecture checker.
+- [x] (2026-05-08 00:00Z) Applied review follow-ups for Makefile lint wiring,
+  fixture-policy reuse, assertion diagnostics, and checker helper extraction.
 
 ## Surprises & Discoveries
 
@@ -253,11 +255,12 @@ Implementation approval rule:
   invocations use `$(UV)`.
 
 - Observation: Application and inbound modules can import concrete adapters
-  through package barrels such as `from episodic.llm import
-  OpenAICompatibleLLMAdapter`. The original checker only emitted
-  `episodic.llm` and `episodic.llm.OpenAICompatibleLLMAdapter`, neither of
-  which matched the outbound adapter prefixes. Impact: package `__init__`
-  re-exports must be resolved before dependency groups are classified.
+  through package barrels such as
+  `from episodic.llm import OpenAICompatibleLLMAdapter`. The original checker
+  only emitted `episodic.llm` and `episodic.llm.OpenAICompatibleLLMAdapter`,
+  neither of which matched the outbound adapter prefixes. Impact: package
+  `__init__` re-exports must be resolved before dependency groups are
+  classified.
 
 ## Decision Log
 
@@ -302,6 +305,12 @@ Implementation approval rule:
   application at lint time or requiring runtime introspection. Date/Author:
   2026-05-08 / Codex.
 
+- Decision: keep tests aligned with the CLI fixture mode by importing
+  `fixture_policy` from `episodic.architecture.checker` instead of duplicating
+  the policy in tests. Rationale: fixture tests should exercise the same helper
+  as `python -m episodic.architecture --fixture-policy`. Date/Author:
+  2026-05-08 / Codex.
+
 ## Outcomes & Retrospective
 
 Implementation began after explicit approval on 2026-04-30. The delivery adds
@@ -339,6 +348,15 @@ Post-delivery barrel-import fix validation:
 - `make lint` passed, including `make check-architecture`.
 - `make typecheck` passed.
 - Focused architecture and port-contract tests passed: 12 passed.
+- `make test` passed: 451 passed, 3 skipped.
+- `make markdownlint` passed with zero errors.
+
+Review follow-up validation:
+
+- `make check-fmt` passed.
+- `make lint` passed.
+- `make typecheck` passed.
+- Focused architecture and port-contract tests passed: 9 passed.
 - `make test` passed: 451 passed, 3 skipped.
 - `make markdownlint` passed with zero errors.
 

--- a/docs/execplans/1-5-4-architectural-enforcement-for-hexagonal-boundaries.md
+++ b/docs/execplans/1-5-4-architectural-enforcement-for-hexagonal-boundaries.md
@@ -187,6 +187,9 @@ Implementation approval rule:
   complete.
 - [x] (2026-04-30 22:42Z) Stage F: run the full validation gates and update
   this ExecPlan with the delivery outcome.
+- [x] (2026-05-08 00:00Z) Fixed a post-delivery false negative where imports
+  through package `__init__` re-exports could hide concrete outbound adapters
+  from the architecture checker.
 
 ## Surprises & Discoveries
 
@@ -249,6 +252,13 @@ Implementation approval rule:
   resolves `UV` once, falling back to that absolute path, and all `uv`
   invocations use `$(UV)`.
 
+- Observation: Application and inbound modules can import concrete adapters
+  through package barrels such as `from episodic.llm import
+  OpenAICompatibleLLMAdapter`. The original checker only emitted
+  `episodic.llm` and `episodic.llm.OpenAICompatibleLLMAdapter`, neither of
+  which matched the outbound adapter prefixes. Impact: package `__init__`
+  re-exports must be resolved before dependency groups are classified.
+
 ## Decision Log
 
 - Decision: implement architecture import enforcement as a repo-local checker
@@ -286,6 +296,12 @@ Implementation approval rule:
   `1.5.4`, so Vidai Mock remains unnecessary until future behaviour tests
   exercise inference-backed orchestration. Date/Author: 2026-04-30 / Codex.
 
+- Decision: build a static re-export index from package `__init__.py` files
+  and emit the concrete re-export target during `from ... import ...` scanning.
+  Rationale: this catches common public barrel imports without importing the
+  application at lint time or requiring runtime introspection. Date/Author:
+  2026-05-08 / Codex.
+
 ## Outcomes & Retrospective
 
 Implementation began after explicit approval on 2026-04-30. The delivery adds
@@ -316,6 +332,15 @@ Validation outcome:
   invocation reports pre-existing MD013 line-length findings across older
   documentation files that are outside this change. The committed files pass
   the configured Markdown and formatting gates above.
+
+Post-delivery barrel-import fix validation:
+
+- `make check-fmt` passed.
+- `make lint` passed, including `make check-architecture`.
+- `make typecheck` passed.
+- Focused architecture and port-contract tests passed: 12 passed.
+- `make test` passed: 451 passed, 3 skipped.
+- `make markdownlint` passed with zero errors.
 
 ## Context and orientation
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -145,12 +145,12 @@ Completion enables feature development within enforced boundaries.
   - Define allowed dependency directions between layers.
   - See
     [Hexagonal architecture enforcement](episodic-podcast-generation-system-design.md#hexagonal-architecture-enforcement).
-- [ ] 1.5.4. Implement architectural enforcement checks for hexagonal
+- [x] 1.5.4. Implement architectural enforcement checks for hexagonal
   boundaries.
-  - Add lint rules to flag forbidden import directions.
-  - Add architecture tests to validate port contract adherence.
-  - Gate CI pipelines on enforcement check pass.
-  - Note: Ruff linting configured; dedicated architecture tests pending.
+  - Added `make check-architecture` and wired it into `make lint`.
+  - Added architecture tests and BDD fixtures for dependency-direction checks.
+  - Added port contract tests for the current concrete adapters.
+  - CI exposes architecture enforcement as a named gate.
 
 ## 2. Intelligent content generation and quality assurance (QA)
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -293,6 +293,10 @@ While we're building out the platform, you can:
 4. **Contribute**: If you're interested in contributing, check out
    [`../AGENTS.md`](../AGENTS.md) for guidelines and code quality standards.
 
+Architecture checks now run as part of the development and CI gates. They do
+not add a public API, but they protect release stability by preventing service
+code from bypassing the documented ports and adapter boundaries.
+
 ## Questions or Feedback?
 
 This project is developed by **df12 Productions**. Visit

--- a/episodic/architecture/__init__.py
+++ b/episodic/architecture/__init__.py
@@ -1,0 +1,17 @@
+"""Architecture enforcement for Episodic's hexagonal boundaries."""
+
+from .checker import (
+    ArchitectureCheckResult,
+    ArchitecturePolicy,
+    ArchitectureViolation,
+    ModuleGroup,
+    check_architecture,
+)
+
+__all__ = [
+    "ArchitectureCheckResult",
+    "ArchitecturePolicy",
+    "ArchitectureViolation",
+    "ModuleGroup",
+    "check_architecture",
+]

--- a/episodic/architecture/__main__.py
+++ b/episodic/architecture/__main__.py
@@ -1,0 +1,5 @@
+"""Command-line entrypoint for architecture enforcement."""
+
+from .checker import main
+
+raise SystemExit(main())

--- a/episodic/architecture/__main__.py
+++ b/episodic/architecture/__main__.py
@@ -1,6 +1,6 @@
 """Command-line entrypoint for architecture enforcement."""
 
-from .checker import main
+from .cli import main
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/episodic/architecture/__main__.py
+++ b/episodic/architecture/__main__.py
@@ -2,4 +2,5 @@
 
 from .checker import main
 
-raise SystemExit(main())
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/episodic/architecture/checker.py
+++ b/episodic/architecture/checker.py
@@ -1,0 +1,326 @@
+"""Static import checker for hexagonal architecture boundaries."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import dataclasses as dc
+import sys
+import typing as typ
+from pathlib import Path
+
+
+@dc.dataclass(frozen=True, slots=True)
+class ModuleGroup:
+    """One named architecture layer and the groups it may import."""
+
+    name: str
+    module_prefixes: tuple[str, ...]
+    allowed_groups: frozenset[str]
+
+    def contains(self, module_name: str) -> bool:
+        """Return True when a module belongs to this group."""
+        return any(
+            module_name == prefix or module_name.startswith(f"{prefix}.")
+            for prefix in self.module_prefixes
+        )
+
+
+@dc.dataclass(frozen=True, slots=True)
+class ArchitecturePolicy:
+    """Dependency-direction policy for a package tree."""
+
+    groups: tuple[ModuleGroup, ...]
+    rule_id: str = "ARCH001"
+
+    def group_for(self, module_name: str) -> ModuleGroup | None:
+        """Return the first matching module group, if the module is scoped."""
+        for group in self.groups:
+            if group.contains(module_name):
+                return group
+        return None
+
+
+@dc.dataclass(frozen=True, slots=True)
+class ArchitectureViolation:
+    """A forbidden import between two classified architecture groups."""
+
+    rule_id: str
+    importer: str
+    imported: str
+    importer_group: str
+    imported_group: str
+
+    def render(self) -> str:
+        """Render a stable single-line diagnostic."""
+        return (
+            f"{self.rule_id}: {self.importer} imports forbidden module "
+            f"{self.imported} ({self.importer_group} -> {self.imported_group})"
+        )
+
+
+@dc.dataclass(frozen=True, slots=True)
+class ArchitectureCheckResult:
+    """Result from checking one package tree."""
+
+    violations: tuple[ArchitectureViolation, ...]
+
+    @property
+    def ok(self) -> bool:
+        """Return True when no architecture violations were found."""
+        return not self.violations
+
+
+def default_policy() -> ArchitecturePolicy:
+    """Return the first-scope Episodic architecture policy."""
+    all_groups = frozenset({
+        "domain_ports",
+        "application",
+        "inbound_adapter",
+        "outbound_adapter",
+        "composition_root",
+    })
+    return ArchitecturePolicy(
+        groups=(
+            ModuleGroup(
+                name="composition_root",
+                module_prefixes=(
+                    "episodic.api.runtime",
+                    "episodic.worker.runtime",
+                ),
+                allowed_groups=all_groups,
+            ),
+            ModuleGroup(
+                name="domain_ports",
+                module_prefixes=(
+                    "episodic.canonical.domain",
+                    "episodic.canonical.constraints",
+                    "episodic.canonical.ingestion",
+                    "episodic.canonical.ingestion_ports",
+                    "episodic.canonical.ports",
+                    "episodic.llm.ports",
+                ),
+                allowed_groups=frozenset({"domain_ports"}),
+            ),
+            ModuleGroup(
+                name="application",
+                module_prefixes=(
+                    "episodic.canonical.services",
+                    "episodic.canonical.ingestion_service",
+                    "episodic.canonical.profile_templates",
+                    "episodic.canonical.reference_documents",
+                    "episodic.generation",
+                ),
+                allowed_groups=frozenset({"domain_ports", "application"}),
+            ),
+            ModuleGroup(
+                name="inbound_adapter",
+                module_prefixes=(
+                    "episodic.api",
+                    "episodic.worker.tasks",
+                    "episodic.worker.topology",
+                ),
+                allowed_groups=frozenset({
+                    "domain_ports",
+                    "application",
+                    "inbound_adapter",
+                }),
+            ),
+            ModuleGroup(
+                name="outbound_adapter",
+                module_prefixes=(
+                    "episodic.canonical.adapters",
+                    "episodic.canonical.storage",
+                    "episodic.llm.openai_adapter",
+                    "episodic.llm.openai_client",
+                ),
+                allowed_groups=frozenset({
+                    "domain_ports",
+                    "application",
+                    "outbound_adapter",
+                }),
+            ),
+        )
+    )
+
+
+def fixture_policy(package: str) -> ArchitecturePolicy:
+    """Return the generic fixture policy used by behavioural tests."""
+    all_groups = frozenset({
+        "domain",
+        "application",
+        "inbound_adapter",
+        "outbound_adapter",
+        "composition_root",
+    })
+    return ArchitecturePolicy(
+        groups=(
+            ModuleGroup(
+                name="composition_root",
+                module_prefixes=(f"{package}.runtime",),
+                allowed_groups=all_groups,
+            ),
+            ModuleGroup(
+                name="domain",
+                module_prefixes=(f"{package}.domain",),
+                allowed_groups=frozenset({"domain"}),
+            ),
+            ModuleGroup(
+                name="application",
+                module_prefixes=(f"{package}.service",),
+                allowed_groups=frozenset({"domain", "application"}),
+            ),
+            ModuleGroup(
+                name="inbound_adapter",
+                module_prefixes=(f"{package}.api",),
+                allowed_groups=frozenset({
+                    "domain",
+                    "application",
+                    "inbound_adapter",
+                }),
+            ),
+            ModuleGroup(
+                name="outbound_adapter",
+                module_prefixes=(f"{package}.storage",),
+                allowed_groups=frozenset({
+                    "domain",
+                    "application",
+                    "outbound_adapter",
+                }),
+            ),
+        )
+    )
+
+
+def check_architecture(
+    *,
+    package_root: Path | str = Path("episodic"),
+    package: str = "episodic",
+    policy: ArchitecturePolicy | None = None,
+) -> ArchitectureCheckResult:
+    """Check import directions under one package root."""
+    root = Path(package_root)
+    active_policy = default_policy() if policy is None else policy
+    violations: list[ArchitectureViolation] = []
+    for source_path in sorted(root.rglob("*.py")):
+        module_name = _module_name(root, package, source_path)
+        importer_group = active_policy.group_for(module_name)
+        if importer_group is None:
+            continue
+        for imported_module in _iter_imported_modules(
+            source_path, package, module_name
+        ):
+            imported_group = active_policy.group_for(imported_module)
+            if imported_group is None:
+                continue
+            if imported_group.name in importer_group.allowed_groups:
+                continue
+            violations.append(
+                ArchitectureViolation(
+                    rule_id=active_policy.rule_id,
+                    importer=module_name,
+                    imported=imported_module,
+                    importer_group=importer_group.name,
+                    imported_group=imported_group.name,
+                )
+            )
+    return ArchitectureCheckResult(violations=tuple(violations))
+
+
+def _module_name(root: Path, package: str, source_path: Path) -> str:
+    relative = source_path.relative_to(root).with_suffix("")
+    parts = tuple(part for part in relative.parts if part != "__init__")
+    if not parts:
+        return package
+    return ".".join((package, *parts))
+
+
+def _iter_imported_modules(
+    source_path: Path,
+    package: str,
+    module_name: str,
+) -> typ.Iterator[str]:
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            yield from _iter_direct_imports(node, package)
+        elif isinstance(node, ast.ImportFrom):
+            yield from _iter_from_imports(node, source_path, package, module_name)
+
+
+def _iter_direct_imports(node: ast.Import, package: str) -> typ.Iterator[str]:
+    for alias in node.names:
+        if alias.name == package or alias.name.startswith(f"{package}."):
+            yield alias.name
+
+
+def _iter_from_imports(
+    node: ast.ImportFrom,
+    source_path: Path,
+    package: str,
+    module_name: str,
+) -> typ.Iterator[str]:
+    imported_module = _resolve_import_from(node, source_path, package, module_name)
+    if imported_module is None:
+        return
+    yield imported_module
+    for alias in node.names:
+        if alias.name != "*":
+            yield f"{imported_module}.{alias.name}"
+
+
+def _resolve_import_from(
+    node: ast.ImportFrom,
+    source_path: Path,
+    package: str,
+    module_name: str,
+) -> str | None:
+    if node.level:
+        module_name = _relative_import_base(node, source_path, module_name)
+        if node.module:
+            module_name = f"{module_name}.{node.module}" if module_name else node.module
+    else:
+        module_name = node.module or ""
+
+    if module_name == package or module_name.startswith(f"{package}."):
+        return module_name
+    return None
+
+
+def _relative_import_base(
+    node: ast.ImportFrom, source_path: Path, module_name: str
+) -> str:
+    parent_parts = module_name.split(".")
+    if source_path.name == "__init__.py":
+        module_parts = parent_parts
+    else:
+        module_parts = parent_parts[:-1]
+    drop_count = node.level - 1
+    if drop_count:
+        module_parts = module_parts[:-drop_count]
+    return ".".join(module_parts)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the architecture checker from the command line."""
+    parser = argparse.ArgumentParser(
+        description="Check Episodic hexagonal architecture import boundaries."
+    )
+    parser.add_argument("--root", default="episodic", help="Package root to scan.")
+    parser.add_argument("--package", default="episodic", help="Import package name.")
+    parser.add_argument(
+        "--fixture-policy",
+        action="store_true",
+        help="Use the generic fixture policy for architecture BDD fixtures.",
+    )
+    args = parser.parse_args(argv)
+
+    policy = fixture_policy(args.package) if args.fixture_policy else default_policy()
+    result = check_architecture(
+        package_root=Path(args.root),
+        package=args.package,
+        policy=policy,
+    )
+    for violation in result.violations:
+        print(violation.render(), file=sys.stderr)
+    return 0 if result.ok else 1

--- a/episodic/architecture/checker.py
+++ b/episodic/architecture/checker.py
@@ -230,6 +230,16 @@ class _ModuleContext:
     reexport_index: dict[str, str]
 
 
+@dc.dataclass(frozen=True, slots=True)
+class _ReexportContext:
+    """Bundled package context for re-export index scanning."""
+
+    root: Path
+    source_path: Path
+    package: str
+    module_name: str
+
+
 def _violations_for_module(
     ctx: _ModuleContext,
     importer_group: ModuleGroup,
@@ -346,32 +356,147 @@ def _build_reexport_index(root: Path, package: str) -> dict[str, str]:
         tree = ast.parse(
             source_path.read_text(encoding="utf-8"), filename=str(source_path)
         )
-        reexport_index.update(
-            _collect_reexports_from_tree(tree, source_path, package, module_name)
+        ctx = _ReexportContext(
+            root=root,
+            source_path=source_path,
+            package=package,
+            module_name=module_name,
         )
+        reexport_index.update(_collect_reexports_from_tree(tree, ctx))
     return reexport_index
 
 
 def _reexports_from_import_node(
     node: ast.ImportFrom,
     imported_module: str,
-    module_name: str,
+    ctx: _ReexportContext,
 ) -> dict[str, str]:
     """Return the re-export mapping contributed by a single ``from … import`` node."""
     reexports: dict[str, str] = {}
     for alias in node.names:
         if alias.name == "*":
+            for exported_name in _exported_names_from_module(
+                ctx.root, ctx.package, imported_module
+            ):
+                reexports[f"{ctx.module_name}.{exported_name}"] = (
+                    f"{imported_module}.{exported_name}"
+                )
             continue
         exported_name = alias.asname or alias.name
-        reexports[f"{module_name}.{exported_name}"] = f"{imported_module}.{alias.name}"
+        reexports[f"{ctx.module_name}.{exported_name}"] = (
+            f"{imported_module}.{alias.name}"
+        )
     return reexports
+
+
+def _exported_names_from_module(
+    root: Path, package: str, module_name: str
+) -> tuple[str, ...]:
+    """Return exported symbol names declared by one module."""
+    source_path = _source_path_for_module(root, package, module_name)
+    if source_path is None:
+        return ()
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    if explicit_exports := _explicit_all_exports(tree):
+        return explicit_exports
+    return tuple(
+        sorted(
+            name for name in _public_names_from_tree(tree) if not name.startswith("_")
+        )
+    )
+
+
+def _source_path_for_module(root: Path, package: str, module_name: str) -> Path | None:
+    """Return the source path for a package-local module."""
+    if module_name == package:
+        relative_parts: tuple[str, ...] = ()
+    elif module_name.startswith(f"{package}."):
+        relative_parts = tuple(module_name.removeprefix(f"{package}.").split("."))
+    else:
+        return None
+
+    module_path = root.joinpath(*relative_parts)
+    source_path = module_path.with_suffix(".py")
+    if source_path.is_file():
+        return source_path
+    package_path = module_path / "__init__.py"
+    if package_path.is_file():
+        return package_path
+    return None
+
+
+def _explicit_all_exports(tree: ast.AST) -> tuple[str, ...]:
+    """Return literal string exports assigned to ``__all__``."""
+    for node in tree.body if isinstance(tree, ast.Module) else ():
+        if _is_all_assign(node):
+            return _string_sequence_values(node.value)
+        if _is_all_ann_assign(node):
+            return _string_sequence_values(node.value)
+    return ()
+
+
+def _is_all_assign(node: ast.stmt) -> typ.TypeIs[ast.Assign]:
+    """Return whether a statement assigns to ``__all__``."""
+    return isinstance(node, ast.Assign) and any(
+        isinstance(target, ast.Name) and target.id == "__all__"
+        for target in node.targets
+    )
+
+
+def _is_all_ann_assign(node: ast.stmt) -> typ.TypeIs[ast.AnnAssign]:
+    """Return whether a statement annotates and assigns ``__all__``."""
+    return isinstance(node, ast.AnnAssign) and _is_all_name(node.target)
+
+
+def _is_all_name(node: ast.AST) -> typ.TypeIs[ast.Name]:
+    """Return whether a node names ``__all__``."""
+    return isinstance(node, ast.Name) and node.id == "__all__"
+
+
+def _string_sequence_values(node: ast.AST | None) -> tuple[str, ...]:
+    """Return literal string values from a list or tuple node."""
+    if not isinstance(node, ast.List | ast.Tuple):
+        return ()
+    values = tuple(
+        element.value
+        for element in node.elts
+        if isinstance(element, ast.Constant) and isinstance(element.value, str)
+    )
+    return values if len(values) == len(node.elts) else ()
+
+
+def _public_names_from_tree(tree: ast.AST) -> set[str]:
+    """Return public names bound at module top level."""
+    if not isinstance(tree, ast.Module):
+        return set()
+    public_names: set[str] = set()
+    for node in tree.body:
+        public_names.update(_public_names_from_node(node))
+    return public_names
+
+
+def _public_names_from_node(node: ast.stmt) -> set[str]:
+    """Return public names bound by one module-level statement."""
+    if isinstance(node, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
+        return {node.name}
+    if isinstance(node, ast.Assign):
+        return {
+            target.id
+            for target in node.targets
+            if isinstance(target, ast.Name) and target.id != "__all__"
+        }
+    if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+        return {node.target.id} if node.target.id != "__all__" else set()
+    if isinstance(node, ast.Import | ast.ImportFrom):
+        return {
+            alias.asname or alias.name.split(".", maxsplit=1)[0] for alias in node.names
+        }
+    return set()
 
 
 def _collect_reexports_from_tree(
     tree: ast.AST,
-    source_path: Path,
-    package: str,
-    module_name: str,
+    ctx: _ReexportContext,
 ) -> dict[str, str]:
     """Collect re-export mappings from one parsed ``__init__`` tree."""
     reexports: dict[str, str] = {}
@@ -380,13 +505,11 @@ def _collect_reexports_from_tree(
             continue
         if (
             imported_module := _resolve_import_from(
-                node, source_path, package, module_name
+                node, ctx.source_path, ctx.package, ctx.module_name
             )
         ) is None:
             continue
-        reexports.update(
-            _reexports_from_import_node(node, imported_module, module_name)
-        )
+        reexports.update(_reexports_from_import_node(node, imported_module, ctx))
     return reexports
 
 

--- a/episodic/architecture/checker.py
+++ b/episodic/architecture/checker.py
@@ -222,7 +222,7 @@ def fixture_policy(package: str) -> ArchitecturePolicy:
 
 @dc.dataclass(frozen=True, slots=True)
 class _ModuleContext:
-    """Import-scanning context for one module in a checked package tree."""
+    """Store source path, package, module name, and re-export index for a module."""
 
     source_path: Path
     package: str
@@ -235,7 +235,7 @@ def _violations_for_module(
     importer_group: ModuleGroup,
     active_policy: ArchitecturePolicy,
 ) -> list[ArchitectureViolation]:
-    """Return the policy violations caused by imports in one module."""
+    """Collect violations for one module against the policy."""
     violations: list[ArchitectureViolation] = []
     for imported_module in _iter_imported_modules(ctx):
         imported_group = active_policy.group_for(imported_module)
@@ -282,7 +282,7 @@ def check_architecture(
 
 
 def _module_name(root: Path, package: str, source_path: Path) -> str:
-    """Return the importable module name for one source file."""
+    """Derive the dotted module name from a source path."""
     relative = source_path.relative_to(root).with_suffix("")
     parts = tuple(part for part in relative.parts if part != "__init__")
     if not parts:
@@ -291,7 +291,7 @@ def _module_name(root: Path, package: str, source_path: Path) -> str:
 
 
 def _iter_imported_modules(ctx: _ModuleContext) -> cabc.Iterator[str]:
-    """Yield package-local modules imported by one source file."""
+    """Yield package-local imports discovered in one source file."""
     tree = ast.parse(
         ctx.source_path.read_text(encoding="utf-8"), filename=str(ctx.source_path)
     )
@@ -303,14 +303,14 @@ def _iter_imported_modules(ctx: _ModuleContext) -> cabc.Iterator[str]:
 
 
 def _iter_direct_imports(node: ast.Import, package: str) -> cabc.Iterator[str]:
-    """Yield scoped module names from an ``import ...`` statement."""
+    """Yield scoped module names from an ``import ...`` node."""
     for alias in node.names:
         if alias.name == package or alias.name.startswith(f"{package}."):
             yield alias.name
 
 
 def _iter_from_imports(node: ast.ImportFrom, ctx: _ModuleContext) -> cabc.Iterator[str]:
-    """Yield scoped modules and symbols from a ``from ... import ...`` statement."""
+    """Yield scoped modules and symbols from a ``from ... import ...`` node."""
     imported_module = _resolve_import_from(
         node, ctx.source_path, ctx.package, ctx.module_name
     )
@@ -330,7 +330,7 @@ def _iter_from_imports(node: ast.ImportFrom, ctx: _ModuleContext) -> cabc.Iterat
 def _iter_star_reexports(
     imported_module: str, reexport_index: dict[str, str]
 ) -> cabc.Iterator[str]:
-    """Yield barrel symbols exposed by a scoped star import."""
+    """Yield re-exported symbols exposed by a scoped star import."""
     prefix = f"{imported_module}."
     for exported_symbol, resolved_reexport in reexport_index.items():
         if exported_symbol.startswith(prefix):
@@ -339,7 +339,7 @@ def _iter_star_reexports(
 
 
 def _build_reexport_index(root: Path, package: str) -> dict[str, str]:
-    """Return package-barrel symbol mappings for ``__init__.py`` files."""
+    """Build package-barrel symbol mappings for ``__init__.py`` files."""
     reexport_index: dict[str, str] = {}
     for source_path in sorted(root.rglob("__init__.py")):
         module_name = _module_name(root, package, source_path)
@@ -373,7 +373,7 @@ def _collect_reexports_from_tree(
     package: str,
     module_name: str,
 ) -> dict[str, str]:
-    """Return re-export mappings declared by one parsed module tree."""
+    """Collect re-export mappings declared by one parsed module tree."""
     reexports: dict[str, str] = {}
     for node in ast.walk(tree):
         if not isinstance(node, ast.ImportFrom):
@@ -396,7 +396,7 @@ def _resolve_import_from(
     package: str,
     module_name: str,
 ) -> str | None:
-    """Return the scoped module targeted by an ``ImportFrom`` node, if any."""
+    """Resolve the scoped module targeted by an ``ImportFrom`` node."""
     if node.level:
         module_name = _relative_import_base(node, source_path, module_name)
         if node.module:
@@ -412,7 +412,7 @@ def _resolve_import_from(
 def _relative_import_base(
     node: ast.ImportFrom, source_path: Path, module_name: str
 ) -> str:
-    """Return the absolute module base for a relative ``from`` import."""
+    """Resolve the absolute module base for a relative ``from`` import."""
     parent_parts = module_name.split(".")
     if source_path.name == "__init__.py":
         module_parts = parent_parts

--- a/episodic/architecture/checker.py
+++ b/episodic/architecture/checker.py
@@ -220,6 +220,15 @@ class _ModuleContext:
     source_path: Path
     package: str
     module_name: str
+    reexport_index: dict[str, str]
+
+
+@dataclasses.dataclass(frozen=True)
+class _ImportContext:
+    source_path: Path
+    package: str
+    module_name: str
+    reexport_index: dict[str, str]
 
 
 def _violations_for_module(
@@ -229,9 +238,12 @@ def _violations_for_module(
 ) -> list[ArchitectureViolation]:
     violations: list[ArchitectureViolation] = []
     for imported_module in _iter_imported_modules(
-        ctx.source_path,
-        ctx.package,
-        ctx.module_name,
+        _ImportContext(
+            source_path=ctx.source_path,
+            package=ctx.package,
+            module_name=ctx.module_name,
+            reexport_index=ctx.reexport_index,
+        )
     ):
         imported_group = active_policy.group_for(imported_module)
         if imported_group is None:
@@ -259,6 +271,7 @@ def check_architecture(
     """Check import directions under one package root."""
     root = Path(package_root)
     active_policy = default_policy() if policy is None else policy
+    reexport_index = _build_reexport_index(root, package)
     violations: list[ArchitectureViolation] = []
     for source_path in sorted(root.rglob("*.py")):
         module_name = _module_name(root, package, source_path)
@@ -269,6 +282,7 @@ def check_architecture(
             source_path=source_path,
             package=package,
             module_name=module_name,
+            reexport_index=reexport_index,
         )
         violations.extend(_violations_for_module(ctx, importer_group, active_policy))
     return ArchitectureCheckResult(violations=tuple(violations))
@@ -282,17 +296,15 @@ def _module_name(root: Path, package: str, source_path: Path) -> str:
     return ".".join((package, *parts))
 
 
-def _iter_imported_modules(
-    source_path: Path,
-    package: str,
-    module_name: str,
-) -> typ.Iterator[str]:
-    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+def _iter_imported_modules(ctx: _ImportContext) -> typ.Iterator[str]:
+    tree = ast.parse(
+        ctx.source_path.read_text(encoding="utf-8"), filename=str(ctx.source_path)
+    )
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
-            yield from _iter_direct_imports(node, package)
+            yield from _iter_direct_imports(node, ctx.package)
         elif isinstance(node, ast.ImportFrom):
-            yield from _iter_from_imports(node, source_path, package, module_name)
+            yield from _iter_from_imports(node, ctx)
 
 
 def _iter_direct_imports(node: ast.Import, package: str) -> typ.Iterator[str]:
@@ -301,19 +313,44 @@ def _iter_direct_imports(node: ast.Import, package: str) -> typ.Iterator[str]:
             yield alias.name
 
 
-def _iter_from_imports(
-    node: ast.ImportFrom,
-    source_path: Path,
-    package: str,
-    module_name: str,
-) -> typ.Iterator[str]:
-    imported_module = _resolve_import_from(node, source_path, package, module_name)
+def _iter_from_imports(node: ast.ImportFrom, ctx: _ImportContext) -> typ.Iterator[str]:
+    imported_module = _resolve_import_from(
+        node, ctx.source_path, ctx.package, ctx.module_name
+    )
     if imported_module is None:
         return
     yield imported_module
     for alias in node.names:
         if alias.name != "*":
-            yield f"{imported_module}.{alias.name}"
+            imported_symbol = f"{imported_module}.{alias.name}"
+            yield imported_symbol
+            if resolved_reexport := ctx.reexport_index.get(imported_symbol):
+                yield resolved_reexport
+
+
+def _build_reexport_index(root: Path, package: str) -> dict[str, str]:
+    reexport_index: dict[str, str] = {}
+    for source_path in sorted(root.rglob("__init__.py")):
+        module_name = _module_name(root, package, source_path)
+        tree = ast.parse(
+            source_path.read_text(encoding="utf-8"), filename=str(source_path)
+        )
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom):
+                continue
+            imported_module = _resolve_import_from(
+                node, source_path, package, module_name
+            )
+            if imported_module is None:
+                continue
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                exported_name = alias.asname or alias.name
+                reexport_index[f"{module_name}.{exported_name}"] = (
+                    f"{imported_module}.{alias.name}"
+                )
+    return reexport_index
 
 
 def _resolve_import_from(

--- a/episodic/architecture/checker.py
+++ b/episodic/architecture/checker.py
@@ -1,14 +1,14 @@
 """Static import checker for hexagonal architecture boundaries."""
 
-from __future__ import annotations
-
 import argparse
 import ast
-import dataclasses
 import dataclasses as dc
 import sys
 import typing as typ
 from pathlib import Path
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
 
 
 @dc.dataclass(frozen=True, slots=True)
@@ -215,7 +215,7 @@ def fixture_policy(package: str) -> ArchitecturePolicy:
     )
 
 
-@dataclasses.dataclass(frozen=True)
+@dc.dataclass(frozen=True)
 class _ModuleContext:
     source_path: Path
     package: str
@@ -223,7 +223,7 @@ class _ModuleContext:
     reexport_index: dict[str, str]
 
 
-@dataclasses.dataclass(frozen=True)
+@dc.dataclass(frozen=True)
 class _ImportContext:
     source_path: Path
     package: str
@@ -296,7 +296,7 @@ def _module_name(root: Path, package: str, source_path: Path) -> str:
     return ".".join((package, *parts))
 
 
-def _iter_imported_modules(ctx: _ImportContext) -> typ.Iterator[str]:
+def _iter_imported_modules(ctx: _ImportContext) -> cabc.Iterator[str]:
     tree = ast.parse(
         ctx.source_path.read_text(encoding="utf-8"), filename=str(ctx.source_path)
     )
@@ -307,13 +307,13 @@ def _iter_imported_modules(ctx: _ImportContext) -> typ.Iterator[str]:
             yield from _iter_from_imports(node, ctx)
 
 
-def _iter_direct_imports(node: ast.Import, package: str) -> typ.Iterator[str]:
+def _iter_direct_imports(node: ast.Import, package: str) -> cabc.Iterator[str]:
     for alias in node.names:
         if alias.name == package or alias.name.startswith(f"{package}."):
             yield alias.name
 
 
-def _iter_from_imports(node: ast.ImportFrom, ctx: _ImportContext) -> typ.Iterator[str]:
+def _iter_from_imports(node: ast.ImportFrom, ctx: _ImportContext) -> cabc.Iterator[str]:
     imported_module = _resolve_import_from(
         node, ctx.source_path, ctx.package, ctx.module_name
     )

--- a/episodic/architecture/checker.py
+++ b/episodic/architecture/checker.py
@@ -82,6 +82,7 @@ _ALL_GROUPS: frozenset[str] = frozenset({
 
 
 def _composition_root_group() -> ModuleGroup:
+    """Return the group allowed to wire all architecture layers together."""
     return ModuleGroup(
         name="composition_root",
         module_prefixes=(
@@ -93,6 +94,7 @@ def _composition_root_group() -> ModuleGroup:
 
 
 def _domain_ports_group() -> ModuleGroup:
+    """Return the group for domain models and public port contracts."""
     return ModuleGroup(
         name="domain_ports",
         module_prefixes=(
@@ -108,6 +110,7 @@ def _domain_ports_group() -> ModuleGroup:
 
 
 def _application_group() -> ModuleGroup:
+    """Return the group for application services and workflows."""
     return ModuleGroup(
         name="application",
         module_prefixes=(
@@ -122,6 +125,7 @@ def _application_group() -> ModuleGroup:
 
 
 def _inbound_adapter_group() -> ModuleGroup:
+    """Return the group for API, worker task, and topology adapters."""
     return ModuleGroup(
         name="inbound_adapter",
         module_prefixes=(
@@ -138,6 +142,7 @@ def _inbound_adapter_group() -> ModuleGroup:
 
 
 def _outbound_adapter_group() -> ModuleGroup:
+    """Return the group for concrete persistence and provider adapters."""
     return ModuleGroup(
         name="outbound_adapter",
         module_prefixes=(
@@ -217,6 +222,8 @@ def fixture_policy(package: str) -> ArchitecturePolicy:
 
 @dc.dataclass(frozen=True, slots=True)
 class _ModuleContext:
+    """Import-scanning context for one module in a checked package tree."""
+
     source_path: Path
     package: str
     module_name: str
@@ -228,6 +235,7 @@ def _violations_for_module(
     importer_group: ModuleGroup,
     active_policy: ArchitecturePolicy,
 ) -> list[ArchitectureViolation]:
+    """Return the policy violations caused by imports in one module."""
     violations: list[ArchitectureViolation] = []
     for imported_module in _iter_imported_modules(ctx):
         imported_group = active_policy.group_for(imported_module)
@@ -274,6 +282,7 @@ def check_architecture(
 
 
 def _module_name(root: Path, package: str, source_path: Path) -> str:
+    """Return the importable module name for one source file."""
     relative = source_path.relative_to(root).with_suffix("")
     parts = tuple(part for part in relative.parts if part != "__init__")
     if not parts:
@@ -282,6 +291,7 @@ def _module_name(root: Path, package: str, source_path: Path) -> str:
 
 
 def _iter_imported_modules(ctx: _ModuleContext) -> cabc.Iterator[str]:
+    """Yield package-local modules imported by one source file."""
     tree = ast.parse(
         ctx.source_path.read_text(encoding="utf-8"), filename=str(ctx.source_path)
     )
@@ -293,12 +303,14 @@ def _iter_imported_modules(ctx: _ModuleContext) -> cabc.Iterator[str]:
 
 
 def _iter_direct_imports(node: ast.Import, package: str) -> cabc.Iterator[str]:
+    """Yield scoped module names from an ``import ...`` statement."""
     for alias in node.names:
         if alias.name == package or alias.name.startswith(f"{package}."):
             yield alias.name
 
 
 def _iter_from_imports(node: ast.ImportFrom, ctx: _ModuleContext) -> cabc.Iterator[str]:
+    """Yield scoped modules and symbols from a ``from ... import ...`` statement."""
     imported_module = _resolve_import_from(
         node, ctx.source_path, ctx.package, ctx.module_name
     )
@@ -318,6 +330,7 @@ def _iter_from_imports(node: ast.ImportFrom, ctx: _ModuleContext) -> cabc.Iterat
 def _iter_star_reexports(
     imported_module: str, reexport_index: dict[str, str]
 ) -> cabc.Iterator[str]:
+    """Yield barrel symbols exposed by a scoped star import."""
     prefix = f"{imported_module}."
     for exported_symbol, resolved_reexport in reexport_index.items():
         if exported_symbol.startswith(prefix):
@@ -326,6 +339,7 @@ def _iter_star_reexports(
 
 
 def _build_reexport_index(root: Path, package: str) -> dict[str, str]:
+    """Return package-barrel symbol mappings for ``__init__.py`` files."""
     reexport_index: dict[str, str] = {}
     for source_path in sorted(root.rglob("__init__.py")):
         module_name = _module_name(root, package, source_path)
@@ -359,6 +373,7 @@ def _collect_reexports_from_tree(
     package: str,
     module_name: str,
 ) -> dict[str, str]:
+    """Return re-export mappings declared by one parsed module tree."""
     reexports: dict[str, str] = {}
     for node in ast.walk(tree):
         if not isinstance(node, ast.ImportFrom):
@@ -381,6 +396,7 @@ def _resolve_import_from(
     package: str,
     module_name: str,
 ) -> str | None:
+    """Return the scoped module targeted by an ``ImportFrom`` node, if any."""
     if node.level:
         module_name = _relative_import_base(node, source_path, module_name)
         if node.module:
@@ -396,6 +412,7 @@ def _resolve_import_from(
 def _relative_import_base(
     node: ast.ImportFrom, source_path: Path, module_name: str
 ) -> str:
+    """Return the absolute module base for a relative ``from`` import."""
     parent_parts = module_name.split(".")
     if source_path.name == "__init__.py":
         module_parts = parent_parts

--- a/episodic/architecture/checker.py
+++ b/episodic/architecture/checker.py
@@ -1,45 +1,16 @@
 """Static import checker for hexagonal architecture boundaries."""
 
-import argparse
 import ast
 import dataclasses as dc
-import sys
 import typing as typ
 from pathlib import Path
 
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
 
-
-@dc.dataclass(frozen=True, slots=True)
-class ModuleGroup:
-    """One named architecture layer and the groups it may import."""
-
-    name: str
-    module_prefixes: tuple[str, ...]
-    allowed_groups: frozenset[str]
-
-    def contains(self, module_name: str) -> bool:
-        """Return True when a module belongs to this group."""
-        return any(
-            module_name == prefix or module_name.startswith(f"{prefix}.")
-            for prefix in self.module_prefixes
-        )
-
-
-@dc.dataclass(frozen=True, slots=True)
-class ArchitecturePolicy:
-    """Dependency-direction policy for a package tree."""
-
-    groups: tuple[ModuleGroup, ...]
-    rule_id: str = "ARCH001"
-
-    def group_for(self, module_name: str) -> ModuleGroup | None:
-        """Return the first matching module group, if the module is scoped."""
-        for group in self.groups:
-            if group.contains(module_name):
-                return group
-        return None
+from . import policy as architecture_policy
+from .policy import ArchitecturePolicy, ModuleGroup, default_policy
+from .reexports import _build_reexport_index
 
 
 @dc.dataclass(frozen=True, slots=True)
@@ -70,154 +41,6 @@ class ArchitectureCheckResult:
     def ok(self) -> bool:
         """Return True when no architecture violations were found."""
         return not self.violations
-
-
-_ALL_GROUPS: frozenset[str] = frozenset({
-    "domain_ports",
-    "application",
-    "inbound_adapter",
-    "outbound_adapter",
-    "composition_root",
-})
-
-
-def _composition_root_group() -> ModuleGroup:
-    """Return the composition-root ModuleGroup."""
-    return ModuleGroup(
-        name="composition_root",
-        module_prefixes=(
-            "episodic.api.runtime",
-            "episodic.worker.runtime",
-        ),
-        allowed_groups=_ALL_GROUPS,
-    )
-
-
-def _domain_ports_group() -> ModuleGroup:
-    """Return the domain-ports ModuleGroup."""
-    return ModuleGroup(
-        name="domain_ports",
-        module_prefixes=(
-            "episodic.canonical.domain",
-            "episodic.canonical.constraints",
-            "episodic.canonical.ingestion",
-            "episodic.canonical.ingestion_ports",
-            "episodic.canonical.ports",
-            "episodic.llm.ports",
-        ),
-        allowed_groups=frozenset({"domain_ports"}),
-    )
-
-
-def _application_group() -> ModuleGroup:
-    """Return the application ModuleGroup."""
-    return ModuleGroup(
-        name="application",
-        module_prefixes=(
-            "episodic.canonical.services",
-            "episodic.canonical.ingestion_service",
-            "episodic.canonical.profile_templates",
-            "episodic.canonical.reference_documents",
-            "episodic.generation",
-        ),
-        allowed_groups=frozenset({"domain_ports", "application"}),
-    )
-
-
-def _inbound_adapter_group() -> ModuleGroup:
-    """Return the inbound-adapter ModuleGroup."""
-    return ModuleGroup(
-        name="inbound_adapter",
-        module_prefixes=(
-            "episodic.api",
-            "episodic.worker.tasks",
-            "episodic.worker.topology",
-        ),
-        allowed_groups=frozenset({
-            "domain_ports",
-            "application",
-            "inbound_adapter",
-        }),
-    )
-
-
-def _outbound_adapter_group() -> ModuleGroup:
-    """Return the outbound-adapter ModuleGroup."""
-    return ModuleGroup(
-        name="outbound_adapter",
-        module_prefixes=(
-            "episodic.canonical.adapters",
-            "episodic.canonical.storage",
-            "episodic.llm.openai_adapter",
-            "episodic.llm.openai_client",
-        ),
-        allowed_groups=frozenset({
-            "domain_ports",
-            "application",
-            "outbound_adapter",
-        }),
-    )
-
-
-def default_policy() -> ArchitecturePolicy:
-    """Return the first-scope Episodic architecture policy."""
-    return ArchitecturePolicy(
-        groups=(
-            _composition_root_group(),
-            _domain_ports_group(),
-            _application_group(),
-            _inbound_adapter_group(),
-            _outbound_adapter_group(),
-        )
-    )
-
-
-def fixture_policy(package: str) -> ArchitecturePolicy:
-    """Return the generic fixture policy used by behavioural tests."""
-    all_groups = frozenset({
-        "domain",
-        "application",
-        "inbound_adapter",
-        "outbound_adapter",
-        "composition_root",
-    })
-    return ArchitecturePolicy(
-        groups=(
-            ModuleGroup(
-                name="composition_root",
-                module_prefixes=(f"{package}.runtime",),
-                allowed_groups=all_groups,
-            ),
-            ModuleGroup(
-                name="domain",
-                module_prefixes=(f"{package}.domain",),
-                allowed_groups=frozenset({"domain"}),
-            ),
-            ModuleGroup(
-                name="application",
-                module_prefixes=(f"{package}.service",),
-                allowed_groups=frozenset({"domain", "application"}),
-            ),
-            ModuleGroup(
-                name="inbound_adapter",
-                module_prefixes=(f"{package}.api",),
-                allowed_groups=frozenset({
-                    "domain",
-                    "application",
-                    "inbound_adapter",
-                }),
-            ),
-            ModuleGroup(
-                name="outbound_adapter",
-                module_prefixes=(f"{package}.storage",),
-                allowed_groups=frozenset({
-                    "domain",
-                    "application",
-                    "outbound_adapter",
-                }),
-            ),
-        )
-    )
 
 
 @dc.dataclass(frozen=True, slots=True)
@@ -291,6 +114,11 @@ def check_architecture(
     return ArchitectureCheckResult(violations=tuple(violations))
 
 
+def fixture_policy(package: str) -> ArchitecturePolicy:
+    """Return the generic fixture policy used by behavioural tests."""
+    return architecture_policy.fixture_policy(package)
+
+
 def _module_name(root: Path, package: str, source_path: Path) -> str:
     """Derive the dotted module name from a source path."""
     relative = source_path.relative_to(root).with_suffix("")
@@ -348,171 +176,6 @@ def _iter_star_reexports(
             yield resolved_reexport
 
 
-def _build_reexport_index(root: Path, package: str) -> dict[str, str]:
-    """Build a map of re-exported symbols to their origin modules."""
-    reexport_index: dict[str, str] = {}
-    for source_path in sorted(root.rglob("__init__.py")):
-        module_name = _module_name(root, package, source_path)
-        tree = ast.parse(
-            source_path.read_text(encoding="utf-8"), filename=str(source_path)
-        )
-        ctx = _ReexportContext(
-            root=root,
-            source_path=source_path,
-            package=package,
-            module_name=module_name,
-        )
-        reexport_index.update(_collect_reexports_from_tree(tree, ctx))
-    return reexport_index
-
-
-def _reexports_from_import_node(
-    node: ast.ImportFrom,
-    imported_module: str,
-    ctx: _ReexportContext,
-) -> dict[str, str]:
-    """Return the re-export mapping contributed by a single ``from … import`` node."""
-    reexports: dict[str, str] = {}
-    for alias in node.names:
-        if alias.name == "*":
-            for exported_name in _exported_names_from_module(
-                ctx.root, ctx.package, imported_module
-            ):
-                reexports[f"{ctx.module_name}.{exported_name}"] = (
-                    f"{imported_module}.{exported_name}"
-                )
-            continue
-        exported_name = alias.asname or alias.name
-        reexports[f"{ctx.module_name}.{exported_name}"] = (
-            f"{imported_module}.{alias.name}"
-        )
-    return reexports
-
-
-def _exported_names_from_module(
-    root: Path, package: str, module_name: str
-) -> tuple[str, ...]:
-    """Return exported symbol names declared by one module."""
-    source_path = _source_path_for_module(root, package, module_name)
-    if source_path is None:
-        return ()
-    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
-    if explicit_exports := _explicit_all_exports(tree):
-        return explicit_exports
-    return tuple(
-        sorted(
-            name for name in _public_names_from_tree(tree) if not name.startswith("_")
-        )
-    )
-
-
-def _source_path_for_module(root: Path, package: str, module_name: str) -> Path | None:
-    """Return the source path for a package-local module."""
-    if module_name == package:
-        relative_parts: tuple[str, ...] = ()
-    elif module_name.startswith(f"{package}."):
-        relative_parts = tuple(module_name.removeprefix(f"{package}.").split("."))
-    else:
-        return None
-
-    module_path = root.joinpath(*relative_parts)
-    source_path = module_path.with_suffix(".py")
-    if source_path.is_file():
-        return source_path
-    package_path = module_path / "__init__.py"
-    if package_path.is_file():
-        return package_path
-    return None
-
-
-def _explicit_all_exports(tree: ast.AST) -> tuple[str, ...]:
-    """Return literal string exports assigned to ``__all__``."""
-    for node in tree.body if isinstance(tree, ast.Module) else ():
-        if _is_all_assign(node):
-            return _string_sequence_values(node.value)
-        if _is_all_ann_assign(node):
-            return _string_sequence_values(node.value)
-    return ()
-
-
-def _is_all_assign(node: ast.stmt) -> typ.TypeIs[ast.Assign]:
-    """Return whether a statement assigns to ``__all__``."""
-    return isinstance(node, ast.Assign) and any(
-        isinstance(target, ast.Name) and target.id == "__all__"
-        for target in node.targets
-    )
-
-
-def _is_all_ann_assign(node: ast.stmt) -> typ.TypeIs[ast.AnnAssign]:
-    """Return whether a statement annotates and assigns ``__all__``."""
-    return isinstance(node, ast.AnnAssign) and _is_all_name(node.target)
-
-
-def _is_all_name(node: ast.AST) -> typ.TypeIs[ast.Name]:
-    """Return whether a node names ``__all__``."""
-    return isinstance(node, ast.Name) and node.id == "__all__"
-
-
-def _string_sequence_values(node: ast.AST | None) -> tuple[str, ...]:
-    """Return literal string values from a list or tuple node."""
-    if not isinstance(node, ast.List | ast.Tuple):
-        return ()
-    values = tuple(
-        element.value
-        for element in node.elts
-        if isinstance(element, ast.Constant) and isinstance(element.value, str)
-    )
-    return values if len(values) == len(node.elts) else ()
-
-
-def _public_names_from_tree(tree: ast.AST) -> set[str]:
-    """Return public names bound at module top level."""
-    if not isinstance(tree, ast.Module):
-        return set()
-    public_names: set[str] = set()
-    for node in tree.body:
-        public_names.update(_public_names_from_node(node))
-    return public_names
-
-
-def _public_names_from_node(node: ast.stmt) -> set[str]:
-    """Return public names bound by one module-level statement."""
-    if isinstance(node, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
-        return {node.name}
-    if isinstance(node, ast.Assign):
-        return {
-            target.id
-            for target in node.targets
-            if isinstance(target, ast.Name) and target.id != "__all__"
-        }
-    if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
-        return {node.target.id} if node.target.id != "__all__" else set()
-    if isinstance(node, ast.Import | ast.ImportFrom):
-        return {
-            alias.asname or alias.name.split(".", maxsplit=1)[0] for alias in node.names
-        }
-    return set()
-
-
-def _collect_reexports_from_tree(
-    tree: ast.AST,
-    ctx: _ReexportContext,
-) -> dict[str, str]:
-    """Collect re-export mappings from one parsed ``__init__`` tree."""
-    reexports: dict[str, str] = {}
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.ImportFrom):
-            continue
-        if (
-            imported_module := _resolve_import_from(
-                node, ctx.source_path, ctx.package, ctx.module_name
-            )
-        ) is None:
-            continue
-        reexports.update(_reexports_from_import_node(node, imported_module, ctx))
-    return reexports
-
-
 def _resolve_import_from(
     node: ast.ImportFrom,
     source_path: Path,
@@ -549,24 +212,6 @@ def _relative_import_base(
 
 def main(argv: list[str] | None = None) -> int:
     """Run the architecture checker from the command line."""
-    parser = argparse.ArgumentParser(
-        description="Check Episodic hexagonal architecture import boundaries."
-    )
-    parser.add_argument("--root", default="episodic", help="Package root to scan.")
-    parser.add_argument("--package", default="episodic", help="Import package name.")
-    parser.add_argument(
-        "--fixture-policy",
-        action="store_true",
-        help="Use the generic fixture policy for architecture BDD fixtures.",
-    )
-    args = parser.parse_args(argv)
+    from .cli import main as cli_main
 
-    policy = fixture_policy(args.package) if args.fixture_policy else default_policy()
-    result = check_architecture(
-        package_root=Path(args.root),
-        package=args.package,
-        policy=policy,
-    )
-    for violation in result.violations:
-        print(violation.render(), file=sys.stderr)
-    return 0 if result.ok else 1
+    return cli_main(argv)

--- a/episodic/architecture/checker.py
+++ b/episodic/architecture/checker.py
@@ -82,7 +82,7 @@ _ALL_GROUPS: frozenset[str] = frozenset({
 
 
 def _composition_root_group() -> ModuleGroup:
-    """Return the group allowed to wire all architecture layers together."""
+    """Return the composition-root ModuleGroup."""
     return ModuleGroup(
         name="composition_root",
         module_prefixes=(
@@ -94,7 +94,7 @@ def _composition_root_group() -> ModuleGroup:
 
 
 def _domain_ports_group() -> ModuleGroup:
-    """Return the group for domain models and public port contracts."""
+    """Return the domain-ports ModuleGroup."""
     return ModuleGroup(
         name="domain_ports",
         module_prefixes=(
@@ -110,7 +110,7 @@ def _domain_ports_group() -> ModuleGroup:
 
 
 def _application_group() -> ModuleGroup:
-    """Return the group for application services and workflows."""
+    """Return the application ModuleGroup."""
     return ModuleGroup(
         name="application",
         module_prefixes=(
@@ -125,7 +125,7 @@ def _application_group() -> ModuleGroup:
 
 
 def _inbound_adapter_group() -> ModuleGroup:
-    """Return the group for API, worker task, and topology adapters."""
+    """Return the inbound-adapter ModuleGroup."""
     return ModuleGroup(
         name="inbound_adapter",
         module_prefixes=(
@@ -142,7 +142,7 @@ def _inbound_adapter_group() -> ModuleGroup:
 
 
 def _outbound_adapter_group() -> ModuleGroup:
-    """Return the group for concrete persistence and provider adapters."""
+    """Return the outbound-adapter ModuleGroup."""
     return ModuleGroup(
         name="outbound_adapter",
         module_prefixes=(
@@ -222,7 +222,7 @@ def fixture_policy(package: str) -> ArchitecturePolicy:
 
 @dc.dataclass(frozen=True, slots=True)
 class _ModuleContext:
-    """Store source path, package, module name, and re-export index for a module."""
+    """Bundled per-module context for violation scanning."""
 
     source_path: Path
     package: str
@@ -235,7 +235,7 @@ def _violations_for_module(
     importer_group: ModuleGroup,
     active_policy: ArchitecturePolicy,
 ) -> list[ArchitectureViolation]:
-    """Collect violations for one module against the policy."""
+    """Return all boundary violations for one module's imports."""
     violations: list[ArchitectureViolation] = []
     for imported_module in _iter_imported_modules(ctx):
         imported_group = active_policy.group_for(imported_module)
@@ -291,7 +291,7 @@ def _module_name(root: Path, package: str, source_path: Path) -> str:
 
 
 def _iter_imported_modules(ctx: _ModuleContext) -> cabc.Iterator[str]:
-    """Yield package-local imports discovered in one source file."""
+    """Yield every imported module name found in one source file."""
     tree = ast.parse(
         ctx.source_path.read_text(encoding="utf-8"), filename=str(ctx.source_path)
     )
@@ -303,14 +303,14 @@ def _iter_imported_modules(ctx: _ModuleContext) -> cabc.Iterator[str]:
 
 
 def _iter_direct_imports(node: ast.Import, package: str) -> cabc.Iterator[str]:
-    """Yield scoped module names from an ``import ...`` node."""
+    """Yield scoped module names from a bare ``import`` statement."""
     for alias in node.names:
         if alias.name == package or alias.name.startswith(f"{package}."):
             yield alias.name
 
 
 def _iter_from_imports(node: ast.ImportFrom, ctx: _ModuleContext) -> cabc.Iterator[str]:
-    """Yield scoped modules and symbols from a ``from ... import ...`` node."""
+    """Yield scoped module names from a ``from … import`` statement."""
     imported_module = _resolve_import_from(
         node, ctx.source_path, ctx.package, ctx.module_name
     )
@@ -330,7 +330,7 @@ def _iter_from_imports(node: ast.ImportFrom, ctx: _ModuleContext) -> cabc.Iterat
 def _iter_star_reexports(
     imported_module: str, reexport_index: dict[str, str]
 ) -> cabc.Iterator[str]:
-    """Yield re-exported symbols exposed by a scoped star import."""
+    """Yield all re-export origins for a star import of one module."""
     prefix = f"{imported_module}."
     for exported_symbol, resolved_reexport in reexport_index.items():
         if exported_symbol.startswith(prefix):
@@ -339,7 +339,7 @@ def _iter_star_reexports(
 
 
 def _build_reexport_index(root: Path, package: str) -> dict[str, str]:
-    """Build package-barrel symbol mappings for ``__init__.py`` files."""
+    """Build a map of re-exported symbols to their origin modules."""
     reexport_index: dict[str, str] = {}
     for source_path in sorted(root.rglob("__init__.py")):
         module_name = _module_name(root, package, source_path)
@@ -373,7 +373,7 @@ def _collect_reexports_from_tree(
     package: str,
     module_name: str,
 ) -> dict[str, str]:
-    """Collect re-export mappings declared by one parsed module tree."""
+    """Collect re-export mappings from one parsed ``__init__`` tree."""
     reexports: dict[str, str] = {}
     for node in ast.walk(tree):
         if not isinstance(node, ast.ImportFrom):
@@ -396,7 +396,7 @@ def _resolve_import_from(
     package: str,
     module_name: str,
 ) -> str | None:
-    """Resolve the scoped module targeted by an ``ImportFrom`` node."""
+    """Resolve an ``ImportFrom`` node to an absolute module name."""
     if node.level:
         module_name = _relative_import_base(node, source_path, module_name)
         if node.module:
@@ -412,7 +412,7 @@ def _resolve_import_from(
 def _relative_import_base(
     node: ast.ImportFrom, source_path: Path, module_name: str
 ) -> str:
-    """Resolve the absolute module base for a relative ``from`` import."""
+    """Compute the base module for a relative import."""
     parent_parts = module_name.split(".")
     if source_path.name == "__init__.py":
         module_parts = parent_parts

--- a/episodic/architecture/checker.py
+++ b/episodic/architecture/checker.py
@@ -215,16 +215,8 @@ def fixture_policy(package: str) -> ArchitecturePolicy:
     )
 
 
-@dc.dataclass(frozen=True)
+@dc.dataclass(frozen=True, slots=True)
 class _ModuleContext:
-    source_path: Path
-    package: str
-    module_name: str
-    reexport_index: dict[str, str]
-
-
-@dc.dataclass(frozen=True)
-class _ImportContext:
     source_path: Path
     package: str
     module_name: str
@@ -237,14 +229,7 @@ def _violations_for_module(
     active_policy: ArchitecturePolicy,
 ) -> list[ArchitectureViolation]:
     violations: list[ArchitectureViolation] = []
-    for imported_module in _iter_imported_modules(
-        _ImportContext(
-            source_path=ctx.source_path,
-            package=ctx.package,
-            module_name=ctx.module_name,
-            reexport_index=ctx.reexport_index,
-        )
-    ):
+    for imported_module in _iter_imported_modules(ctx):
         imported_group = active_policy.group_for(imported_module)
         if imported_group is None:
             continue
@@ -296,7 +281,7 @@ def _module_name(root: Path, package: str, source_path: Path) -> str:
     return ".".join((package, *parts))
 
 
-def _iter_imported_modules(ctx: _ImportContext) -> cabc.Iterator[str]:
+def _iter_imported_modules(ctx: _ModuleContext) -> cabc.Iterator[str]:
     tree = ast.parse(
         ctx.source_path.read_text(encoding="utf-8"), filename=str(ctx.source_path)
     )
@@ -313,7 +298,7 @@ def _iter_direct_imports(node: ast.Import, package: str) -> cabc.Iterator[str]:
             yield alias.name
 
 
-def _iter_from_imports(node: ast.ImportFrom, ctx: _ImportContext) -> cabc.Iterator[str]:
+def _iter_from_imports(node: ast.ImportFrom, ctx: _ModuleContext) -> cabc.Iterator[str]:
     imported_module = _resolve_import_from(
         node, ctx.source_path, ctx.package, ctx.module_name
     )
@@ -335,22 +320,33 @@ def _build_reexport_index(root: Path, package: str) -> dict[str, str]:
         tree = ast.parse(
             source_path.read_text(encoding="utf-8"), filename=str(source_path)
         )
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.ImportFrom):
-                continue
-            imported_module = _resolve_import_from(
-                node, source_path, package, module_name
-            )
-            if imported_module is None:
-                continue
-            for alias in node.names:
-                if alias.name == "*":
-                    continue
-                exported_name = alias.asname or alias.name
-                reexport_index[f"{module_name}.{exported_name}"] = (
-                    f"{imported_module}.{alias.name}"
-                )
+        reexport_index.update(
+            _collect_reexports_from_tree(tree, source_path, package, module_name)
+        )
     return reexport_index
+
+
+def _collect_reexports_from_tree(
+    tree: ast.AST,
+    source_path: Path,
+    package: str,
+    module_name: str,
+) -> dict[str, str]:
+    reexports: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        imported_module = _resolve_import_from(node, source_path, package, module_name)
+        if imported_module is None:
+            continue
+        for alias in node.names:
+            if alias.name == "*":
+                continue
+            exported_name = alias.asname or alias.name
+            reexports[f"{module_name}.{exported_name}"] = (
+                f"{imported_module}.{alias.name}"
+            )
+    return reexports
 
 
 def _resolve_import_from(

--- a/episodic/architecture/checker.py
+++ b/episodic/architecture/checker.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import dataclasses
 import dataclasses as dc
 import sys
 import typing as typ
@@ -71,75 +72,97 @@ class ArchitectureCheckResult:
         return not self.violations
 
 
+_ALL_GROUPS: frozenset[str] = frozenset({
+    "domain_ports",
+    "application",
+    "inbound_adapter",
+    "outbound_adapter",
+    "composition_root",
+})
+
+
+def _composition_root_group() -> ModuleGroup:
+    return ModuleGroup(
+        name="composition_root",
+        module_prefixes=(
+            "episodic.api.runtime",
+            "episodic.worker.runtime",
+        ),
+        allowed_groups=_ALL_GROUPS,
+    )
+
+
+def _domain_ports_group() -> ModuleGroup:
+    return ModuleGroup(
+        name="domain_ports",
+        module_prefixes=(
+            "episodic.canonical.domain",
+            "episodic.canonical.constraints",
+            "episodic.canonical.ingestion",
+            "episodic.canonical.ingestion_ports",
+            "episodic.canonical.ports",
+            "episodic.llm.ports",
+        ),
+        allowed_groups=frozenset({"domain_ports"}),
+    )
+
+
+def _application_group() -> ModuleGroup:
+    return ModuleGroup(
+        name="application",
+        module_prefixes=(
+            "episodic.canonical.services",
+            "episodic.canonical.ingestion_service",
+            "episodic.canonical.profile_templates",
+            "episodic.canonical.reference_documents",
+            "episodic.generation",
+        ),
+        allowed_groups=frozenset({"domain_ports", "application"}),
+    )
+
+
+def _inbound_adapter_group() -> ModuleGroup:
+    return ModuleGroup(
+        name="inbound_adapter",
+        module_prefixes=(
+            "episodic.api",
+            "episodic.worker.tasks",
+            "episodic.worker.topology",
+        ),
+        allowed_groups=frozenset({
+            "domain_ports",
+            "application",
+            "inbound_adapter",
+        }),
+    )
+
+
+def _outbound_adapter_group() -> ModuleGroup:
+    return ModuleGroup(
+        name="outbound_adapter",
+        module_prefixes=(
+            "episodic.canonical.adapters",
+            "episodic.canonical.storage",
+            "episodic.llm.openai_adapter",
+            "episodic.llm.openai_client",
+        ),
+        allowed_groups=frozenset({
+            "domain_ports",
+            "application",
+            "outbound_adapter",
+        }),
+    )
+
+
 def default_policy() -> ArchitecturePolicy:
     """Return the first-scope Episodic architecture policy."""
-    all_groups = frozenset({
-        "domain_ports",
-        "application",
-        "inbound_adapter",
-        "outbound_adapter",
-        "composition_root",
-    })
     return ArchitecturePolicy(
         groups=(
-            ModuleGroup(
-                name="composition_root",
-                module_prefixes=(
-                    "episodic.api.runtime",
-                    "episodic.worker.runtime",
-                ),
-                allowed_groups=all_groups,
-            ),
-            ModuleGroup(
-                name="domain_ports",
-                module_prefixes=(
-                    "episodic.canonical.domain",
-                    "episodic.canonical.constraints",
-                    "episodic.canonical.ingestion",
-                    "episodic.canonical.ingestion_ports",
-                    "episodic.canonical.ports",
-                    "episodic.llm.ports",
-                ),
-                allowed_groups=frozenset({"domain_ports"}),
-            ),
-            ModuleGroup(
-                name="application",
-                module_prefixes=(
-                    "episodic.canonical.services",
-                    "episodic.canonical.ingestion_service",
-                    "episodic.canonical.profile_templates",
-                    "episodic.canonical.reference_documents",
-                    "episodic.generation",
-                ),
-                allowed_groups=frozenset({"domain_ports", "application"}),
-            ),
-            ModuleGroup(
-                name="inbound_adapter",
-                module_prefixes=(
-                    "episodic.api",
-                    "episodic.worker.tasks",
-                    "episodic.worker.topology",
-                ),
-                allowed_groups=frozenset({
-                    "domain_ports",
-                    "application",
-                    "inbound_adapter",
-                }),
-            ),
-            ModuleGroup(
-                name="outbound_adapter",
-                module_prefixes=(
-                    "episodic.canonical.adapters",
-                    "episodic.canonical.storage",
-                    "episodic.llm.openai_adapter",
-                    "episodic.llm.openai_client",
-                ),
-                allowed_groups=frozenset({
-                    "domain_ports",
-                    "application",
-                    "outbound_adapter",
-                }),
-            ),
+            _composition_root_group(),
+            _domain_ports_group(),
+            _application_group(),
+            _inbound_adapter_group(),
+            _outbound_adapter_group(),
         )
     )
 
@@ -192,15 +215,24 @@ def fixture_policy(package: str) -> ArchitecturePolicy:
     )
 
 
-def _violations_for_module(  # noqa: PLR0913, PLR0917
-    source_path: Path,
-    package: str,
-    module_name: str,
+@dataclasses.dataclass(frozen=True)
+class _ModuleContext:
+    source_path: Path
+    package: str
+    module_name: str
+
+
+def _violations_for_module(
+    ctx: _ModuleContext,
     importer_group: ModuleGroup,
     active_policy: ArchitecturePolicy,
 ) -> list[ArchitectureViolation]:
     violations: list[ArchitectureViolation] = []
-    for imported_module in _iter_imported_modules(source_path, package, module_name):
+    for imported_module in _iter_imported_modules(
+        ctx.source_path,
+        ctx.package,
+        ctx.module_name,
+    ):
         imported_group = active_policy.group_for(imported_module)
         if imported_group is None:
             continue
@@ -209,7 +241,7 @@ def _violations_for_module(  # noqa: PLR0913, PLR0917
         violations.append(
             ArchitectureViolation(
                 rule_id=active_policy.rule_id,
-                importer=module_name,
+                importer=ctx.module_name,
                 imported=imported_module,
                 importer_group=importer_group.name,
                 imported_group=imported_group.name,
@@ -233,11 +265,12 @@ def check_architecture(
         importer_group = active_policy.group_for(module_name)
         if importer_group is None:
             continue
-        violations.extend(
-            _violations_for_module(
-                source_path, package, module_name, importer_group, active_policy
-            )
+        ctx = _ModuleContext(
+            source_path=source_path,
+            package=package,
+            module_name=module_name,
         )
+        violations.extend(_violations_for_module(ctx, importer_group, active_policy))
     return ArchitectureCheckResult(violations=tuple(violations))
 
 

--- a/episodic/architecture/checker.py
+++ b/episodic/architecture/checker.py
@@ -306,11 +306,23 @@ def _iter_from_imports(node: ast.ImportFrom, ctx: _ModuleContext) -> cabc.Iterat
         return
     yield imported_module
     for alias in node.names:
-        if alias.name != "*":
-            imported_symbol = f"{imported_module}.{alias.name}"
-            yield imported_symbol
-            if resolved_reexport := ctx.reexport_index.get(imported_symbol):
-                yield resolved_reexport
+        if alias.name == "*":
+            yield from _iter_star_reexports(imported_module, ctx.reexport_index)
+            continue
+        imported_symbol = f"{imported_module}.{alias.name}"
+        yield imported_symbol
+        if resolved_reexport := ctx.reexport_index.get(imported_symbol):
+            yield resolved_reexport
+
+
+def _iter_star_reexports(
+    imported_module: str, reexport_index: dict[str, str]
+) -> cabc.Iterator[str]:
+    prefix = f"{imported_module}."
+    for exported_symbol, resolved_reexport in reexport_index.items():
+        if exported_symbol.startswith(prefix):
+            yield exported_symbol
+            yield resolved_reexport
 
 
 def _build_reexport_index(root: Path, package: str) -> dict[str, str]:
@@ -336,17 +348,26 @@ def _collect_reexports_from_tree(
     for node in ast.walk(tree):
         if not isinstance(node, ast.ImportFrom):
             continue
-        imported_module = _resolve_import_from(node, source_path, package, module_name)
-        if imported_module is None:
-            continue
-        for alias in node.names:
-            if alias.name == "*":
-                continue
-            exported_name = alias.asname or alias.name
-            reexports[f"{module_name}.{exported_name}"] = (
-                f"{imported_module}.{alias.name}"
-            )
+        reexports.update(
+            _iter_reexports_from_importfrom(node, source_path, package, module_name)
+        )
     return reexports
+
+
+def _iter_reexports_from_importfrom(
+    node: ast.ImportFrom,
+    source_path: Path,
+    package: str,
+    module_name: str,
+) -> cabc.Iterator[tuple[str, str]]:
+    imported_module = _resolve_import_from(node, source_path, package, module_name)
+    if imported_module is None:
+        return
+    for alias in node.names:
+        if alias.name == "*":
+            continue
+        exported_name = alias.asname or alias.name
+        yield f"{module_name}.{exported_name}", f"{imported_module}.{alias.name}"
 
 
 def _resolve_import_from(

--- a/episodic/architecture/checker.py
+++ b/episodic/architecture/checker.py
@@ -192,6 +192,32 @@ def fixture_policy(package: str) -> ArchitecturePolicy:
     )
 
 
+def _violations_for_module(  # noqa: PLR0913, PLR0917
+    source_path: Path,
+    package: str,
+    module_name: str,
+    importer_group: ModuleGroup,
+    active_policy: ArchitecturePolicy,
+) -> list[ArchitectureViolation]:
+    violations: list[ArchitectureViolation] = []
+    for imported_module in _iter_imported_modules(source_path, package, module_name):
+        imported_group = active_policy.group_for(imported_module)
+        if imported_group is None:
+            continue
+        if imported_group.name in importer_group.allowed_groups:
+            continue
+        violations.append(
+            ArchitectureViolation(
+                rule_id=active_policy.rule_id,
+                importer=module_name,
+                imported=imported_module,
+                importer_group=importer_group.name,
+                imported_group=imported_group.name,
+            )
+        )
+    return violations
+
+
 def check_architecture(
     *,
     package_root: Path | str = Path("episodic"),
@@ -207,23 +233,11 @@ def check_architecture(
         importer_group = active_policy.group_for(module_name)
         if importer_group is None:
             continue
-        for imported_module in _iter_imported_modules(
-            source_path, package, module_name
-        ):
-            imported_group = active_policy.group_for(imported_module)
-            if imported_group is None:
-                continue
-            if imported_group.name in importer_group.allowed_groups:
-                continue
-            violations.append(
-                ArchitectureViolation(
-                    rule_id=active_policy.rule_id,
-                    importer=module_name,
-                    imported=imported_module,
-                    importer_group=importer_group.name,
-                    imported_group=imported_group.name,
-                )
+        violations.extend(
+            _violations_for_module(
+                source_path, package, module_name, importer_group, active_policy
             )
+        )
     return ArchitectureCheckResult(violations=tuple(violations))
 
 

--- a/episodic/architecture/checker.py
+++ b/episodic/architecture/checker.py
@@ -338,6 +338,21 @@ def _build_reexport_index(root: Path, package: str) -> dict[str, str]:
     return reexport_index
 
 
+def _reexports_from_import_node(
+    node: ast.ImportFrom,
+    imported_module: str,
+    module_name: str,
+) -> dict[str, str]:
+    """Return the re-export mapping contributed by a single ``from … import`` node."""
+    reexports: dict[str, str] = {}
+    for alias in node.names:
+        if alias.name == "*":
+            continue
+        exported_name = alias.asname or alias.name
+        reexports[f"{module_name}.{exported_name}"] = f"{imported_module}.{alias.name}"
+    return reexports
+
+
 def _collect_reexports_from_tree(
     tree: ast.AST,
     source_path: Path,
@@ -348,26 +363,16 @@ def _collect_reexports_from_tree(
     for node in ast.walk(tree):
         if not isinstance(node, ast.ImportFrom):
             continue
+        if (
+            imported_module := _resolve_import_from(
+                node, source_path, package, module_name
+            )
+        ) is None:
+            continue
         reexports.update(
-            _iter_reexports_from_importfrom(node, source_path, package, module_name)
+            _reexports_from_import_node(node, imported_module, module_name)
         )
     return reexports
-
-
-def _iter_reexports_from_importfrom(
-    node: ast.ImportFrom,
-    source_path: Path,
-    package: str,
-    module_name: str,
-) -> cabc.Iterator[tuple[str, str]]:
-    imported_module = _resolve_import_from(node, source_path, package, module_name)
-    if imported_module is None:
-        return
-    for alias in node.names:
-        if alias.name == "*":
-            continue
-        exported_name = alias.asname or alias.name
-        yield f"{module_name}.{exported_name}", f"{imported_module}.{alias.name}"
 
 
 def _resolve_import_from(

--- a/episodic/architecture/cli.py
+++ b/episodic/architecture/cli.py
@@ -1,0 +1,33 @@
+"""Command-line wiring for architecture enforcement."""
+
+import argparse
+import sys
+from pathlib import Path
+
+from .checker import check_architecture
+from .policy import default_policy, fixture_policy
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the architecture checker from the command line."""
+    parser = argparse.ArgumentParser(
+        description="Check Episodic hexagonal architecture import boundaries."
+    )
+    parser.add_argument("--root", default="episodic", help="Package root to scan.")
+    parser.add_argument("--package", default="episodic", help="Import package name.")
+    parser.add_argument(
+        "--fixture-policy",
+        action="store_true",
+        help="Use the generic fixture policy for architecture BDD fixtures.",
+    )
+    args = parser.parse_args(argv)
+
+    policy = fixture_policy(args.package) if args.fixture_policy else default_policy()
+    result = check_architecture(
+        package_root=Path(args.root),
+        package=args.package,
+        policy=policy,
+    )
+    for violation in result.violations:
+        print(violation.render(), file=sys.stderr)
+    return 0 if result.ok else 1

--- a/episodic/architecture/policy.py
+++ b/episodic/architecture/policy.py
@@ -136,6 +136,20 @@ def default_policy() -> ArchitecturePolicy:
     )
 
 
+def _make_fixture_group(
+    package: str,
+    name: str,
+    suffix: str,
+    allowed_groups: frozenset[str],
+) -> ModuleGroup:
+    """Return one fixture ModuleGroup for a package suffix."""
+    return ModuleGroup(
+        name=name,
+        module_prefixes=(f"{package}.{suffix}",),
+        allowed_groups=allowed_groups,
+    )
+
+
 def fixture_policy(package: str) -> ArchitecturePolicy:
     """Return the generic fixture policy used by behavioural tests."""
     all_groups = frozenset({
@@ -147,34 +161,39 @@ def fixture_policy(package: str) -> ArchitecturePolicy:
     })
     return ArchitecturePolicy(
         groups=(
-            ModuleGroup(
-                name="composition_root",
-                module_prefixes=(f"{package}.runtime",),
-                allowed_groups=all_groups,
+            _make_fixture_group(
+                package,
+                "composition_root",
+                "runtime",
+                all_groups,
             ),
-            ModuleGroup(
-                name="domain",
-                module_prefixes=(f"{package}.domain",),
-                allowed_groups=frozenset({"domain"}),
+            _make_fixture_group(
+                package,
+                "domain",
+                "domain",
+                frozenset({"domain"}),
             ),
-            ModuleGroup(
-                name="application",
-                module_prefixes=(f"{package}.service",),
-                allowed_groups=frozenset({"domain", "application"}),
+            _make_fixture_group(
+                package,
+                "application",
+                "service",
+                frozenset({"domain", "application"}),
             ),
-            ModuleGroup(
-                name="inbound_adapter",
-                module_prefixes=(f"{package}.api",),
-                allowed_groups=frozenset({
+            _make_fixture_group(
+                package,
+                "inbound_adapter",
+                "api",
+                frozenset({
                     "domain",
                     "application",
                     "inbound_adapter",
                 }),
             ),
-            ModuleGroup(
-                name="outbound_adapter",
-                module_prefixes=(f"{package}.storage",),
-                allowed_groups=frozenset({
+            _make_fixture_group(
+                package,
+                "outbound_adapter",
+                "storage",
+                frozenset({
                     "domain",
                     "application",
                     "outbound_adapter",

--- a/episodic/architecture/policy.py
+++ b/episodic/architecture/policy.py
@@ -86,38 +86,40 @@ def _application_group() -> ModuleGroup:
     )
 
 
+def _make_adapter_group(
+    name: str,
+    module_prefixes: tuple[str, ...],
+) -> ModuleGroup:
+    """Return an adapter ModuleGroup allowing domain_ports, application, and self."""
+    return ModuleGroup(
+        name=name,
+        module_prefixes=module_prefixes,
+        allowed_groups=frozenset({"domain_ports", "application", name}),
+    )
+
+
 def _inbound_adapter_group() -> ModuleGroup:
     """Return the inbound-adapter ModuleGroup."""
-    return ModuleGroup(
-        name="inbound_adapter",
-        module_prefixes=(
+    return _make_adapter_group(
+        "inbound_adapter",
+        (
             "episodic.api",
             "episodic.worker.tasks",
             "episodic.worker.topology",
         ),
-        allowed_groups=frozenset({
-            "domain_ports",
-            "application",
-            "inbound_adapter",
-        }),
     )
 
 
 def _outbound_adapter_group() -> ModuleGroup:
     """Return the outbound-adapter ModuleGroup."""
-    return ModuleGroup(
-        name="outbound_adapter",
-        module_prefixes=(
+    return _make_adapter_group(
+        "outbound_adapter",
+        (
             "episodic.canonical.adapters",
             "episodic.canonical.storage",
             "episodic.llm.openai_adapter",
             "episodic.llm.openai_client",
         ),
-        allowed_groups=frozenset({
-            "domain_ports",
-            "application",
-            "outbound_adapter",
-        }),
     )
 
 

--- a/episodic/architecture/policy.py
+++ b/episodic/architecture/policy.py
@@ -1,0 +1,182 @@
+"""Architecture policies for hexagonal boundary enforcement."""
+
+import dataclasses as dc
+
+
+@dc.dataclass(frozen=True, slots=True)
+class ModuleGroup:
+    """One named architecture layer and the groups it may import."""
+
+    name: str
+    module_prefixes: tuple[str, ...]
+    allowed_groups: frozenset[str]
+
+    def contains(self, module_name: str) -> bool:
+        """Return True when a module belongs to this group."""
+        return any(
+            module_name == prefix or module_name.startswith(f"{prefix}.")
+            for prefix in self.module_prefixes
+        )
+
+
+@dc.dataclass(frozen=True, slots=True)
+class ArchitecturePolicy:
+    """Dependency-direction policy for a package tree."""
+
+    groups: tuple[ModuleGroup, ...]
+    rule_id: str = "ARCH001"
+
+    def group_for(self, module_name: str) -> ModuleGroup | None:
+        """Return the first matching module group, if the module is scoped."""
+        for group in self.groups:
+            if group.contains(module_name):
+                return group
+        return None
+
+
+_ALL_GROUPS: frozenset[str] = frozenset({
+    "domain_ports",
+    "application",
+    "inbound_adapter",
+    "outbound_adapter",
+    "composition_root",
+})
+
+
+def _composition_root_group() -> ModuleGroup:
+    """Return the composition-root ModuleGroup."""
+    return ModuleGroup(
+        name="composition_root",
+        module_prefixes=(
+            "episodic.api.runtime",
+            "episodic.worker.runtime",
+        ),
+        allowed_groups=_ALL_GROUPS,
+    )
+
+
+def _domain_ports_group() -> ModuleGroup:
+    """Return the domain-ports ModuleGroup."""
+    return ModuleGroup(
+        name="domain_ports",
+        module_prefixes=(
+            "episodic.canonical.domain",
+            "episodic.canonical.constraints",
+            "episodic.canonical.ingestion",
+            "episodic.canonical.ingestion_ports",
+            "episodic.canonical.ports",
+            "episodic.llm.ports",
+        ),
+        allowed_groups=frozenset({"domain_ports"}),
+    )
+
+
+def _application_group() -> ModuleGroup:
+    """Return the application ModuleGroup."""
+    return ModuleGroup(
+        name="application",
+        module_prefixes=(
+            "episodic.canonical.services",
+            "episodic.canonical.ingestion_service",
+            "episodic.canonical.profile_templates",
+            "episodic.canonical.reference_documents",
+            "episodic.generation",
+        ),
+        allowed_groups=frozenset({"domain_ports", "application"}),
+    )
+
+
+def _inbound_adapter_group() -> ModuleGroup:
+    """Return the inbound-adapter ModuleGroup."""
+    return ModuleGroup(
+        name="inbound_adapter",
+        module_prefixes=(
+            "episodic.api",
+            "episodic.worker.tasks",
+            "episodic.worker.topology",
+        ),
+        allowed_groups=frozenset({
+            "domain_ports",
+            "application",
+            "inbound_adapter",
+        }),
+    )
+
+
+def _outbound_adapter_group() -> ModuleGroup:
+    """Return the outbound-adapter ModuleGroup."""
+    return ModuleGroup(
+        name="outbound_adapter",
+        module_prefixes=(
+            "episodic.canonical.adapters",
+            "episodic.canonical.storage",
+            "episodic.llm.openai_adapter",
+            "episodic.llm.openai_client",
+        ),
+        allowed_groups=frozenset({
+            "domain_ports",
+            "application",
+            "outbound_adapter",
+        }),
+    )
+
+
+def default_policy() -> ArchitecturePolicy:
+    """Return the first-scope Episodic architecture policy."""
+    return ArchitecturePolicy(
+        groups=(
+            _composition_root_group(),
+            _domain_ports_group(),
+            _application_group(),
+            _inbound_adapter_group(),
+            _outbound_adapter_group(),
+        )
+    )
+
+
+def fixture_policy(package: str) -> ArchitecturePolicy:
+    """Return the generic fixture policy used by behavioural tests."""
+    all_groups = frozenset({
+        "domain",
+        "application",
+        "inbound_adapter",
+        "outbound_adapter",
+        "composition_root",
+    })
+    return ArchitecturePolicy(
+        groups=(
+            ModuleGroup(
+                name="composition_root",
+                module_prefixes=(f"{package}.runtime",),
+                allowed_groups=all_groups,
+            ),
+            ModuleGroup(
+                name="domain",
+                module_prefixes=(f"{package}.domain",),
+                allowed_groups=frozenset({"domain"}),
+            ),
+            ModuleGroup(
+                name="application",
+                module_prefixes=(f"{package}.service",),
+                allowed_groups=frozenset({"domain", "application"}),
+            ),
+            ModuleGroup(
+                name="inbound_adapter",
+                module_prefixes=(f"{package}.api",),
+                allowed_groups=frozenset({
+                    "domain",
+                    "application",
+                    "inbound_adapter",
+                }),
+            ),
+            ModuleGroup(
+                name="outbound_adapter",
+                module_prefixes=(f"{package}.storage",),
+                allowed_groups=frozenset({
+                    "domain",
+                    "application",
+                    "outbound_adapter",
+                }),
+            ),
+        )
+    )

--- a/episodic/architecture/reexports.py
+++ b/episodic/architecture/reexports.py
@@ -49,13 +49,14 @@ def _reexports_from_import_node(
     node: ast.ImportFrom,
     imported_module: str,
     ctx: _ReexportScanContext,
+    seen_modules: frozenset[str] | None = None,
 ) -> dict[str, str]:
     """Return the re-export mapping contributed by a single ``from … import`` node."""
     reexports: dict[str, str] = {}
     for alias in node.names:
         if alias.name == "*":
             for exported_name, origin in _exported_symbols_from_module(
-                ctx.root, ctx.package, imported_module
+                ctx.root, ctx.package, imported_module, seen_modules
             ).items():
                 reexports[f"{ctx.module_name}.{exported_name}"] = origin
             continue
@@ -74,16 +75,29 @@ def _exported_names_from_module(
 
 
 def _exported_symbols_from_module(
-    root: Path, package: str, module_name: str
+    root: Path,
+    package: str,
+    module_name: str,
+    seen_modules: frozenset[str] | None = None,
 ) -> dict[str, str]:
     """Return exported symbol names mapped to their origin modules."""
+    if seen_modules is None:
+        seen_modules = frozenset()
+    if module_name in seen_modules:
+        return {}
+    seen_modules |= {module_name}
+
     source_path = _source_path_for_module(root, package, module_name)
     if source_path is None:
         return {}
-    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
-    public_symbols = _fallback_public_symbols_from_tree(
-        tree, root, package, module_name
+    ctx = _ReexportScanContext(
+        root=root,
+        source_path=source_path,
+        package=package,
+        module_name=module_name,
     )
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    public_symbols = _fallback_public_symbols_from_tree(tree, ctx, seen_modules)
     explicit_exports = _explicit_all_exports(tree)
     if explicit_exports is not None:
         return {
@@ -159,24 +173,31 @@ def _string_sequence_values(node: ast.AST | None) -> tuple[str, ...] | None:
 
 
 def _fallback_public_symbols_from_tree(
-    tree: ast.AST, root: Path, package: str, module_name: str
+    tree: ast.AST,
+    ctx: _ReexportScanContext,
+    seen_modules: frozenset[str] | None = None,
 ) -> dict[str, str]:
     """Return public symbols, expanding module-level star imports."""
-    public_symbols = _public_symbols_from_tree(tree, root, package, module_name)
     if not isinstance(tree, ast.Module):
-        return public_symbols
-    source_path = _source_path_for_module(root, package, module_name)
-    if source_path is None:
-        return public_symbols
+        return {}
+
+    public_symbols: dict[str, str] = {}
     for node in tree.body:
         if isinstance(node, ast.ImportFrom) and _has_star_alias(node):
             imported_module = _resolve_import_from(
-                node, source_path, package, module_name
+                node, ctx.source_path, ctx.package, ctx.module_name
             )
             if imported_module is not None:
                 public_symbols.update(
-                    _exported_symbols_from_module(root, package, imported_module)
+                    _exported_symbols_from_module(
+                        ctx.root, ctx.package, imported_module, seen_modules
+                    )
                 )
+        public_symbols.update(
+            _public_symbols_from_node(
+                node, ctx.source_path, ctx.package, ctx.module_name
+            )
+        )
     return public_symbols
 
 
@@ -301,7 +322,11 @@ def _collect_reexports_from_tree(
             )
         ) is None:
             continue
-        reexports.update(_reexports_from_import_node(node, imported_module, ctx))
+        reexports.update(
+            _reexports_from_import_node(
+                node, imported_module, ctx, frozenset({ctx.module_name})
+            )
+        )
     return reexports
 
 

--- a/episodic/architecture/reexports.py
+++ b/episodic/architecture/reexports.py
@@ -134,12 +134,13 @@ def _source_path_for_module(root: Path, package: str, module_name: str) -> Path 
 
 def _explicit_all_exports(tree: ast.AST) -> tuple[str, ...] | None:
     """Return literal string exports assigned to ``__all__``."""
-    for node in reversed(tree.body) if isinstance(tree, ast.Module) else ():
+    last_exports: tuple[str, ...] | None = None
+    for node in tree.body if isinstance(tree, ast.Module) else ():
         if _is_all_assign(node) or _is_all_ann_assign(node):
             values = _string_sequence_values(node.value)
             if values is not None:
-                return values
-    return None
+                last_exports = values
+    return last_exports
 
 
 def _is_all_assign(node: ast.stmt) -> typ.TypeIs[ast.Assign]:

--- a/episodic/architecture/reexports.py
+++ b/episodic/architecture/reexports.py
@@ -1,0 +1,302 @@
+"""Package barrel re-export discovery for architecture checks."""
+
+import ast
+import dataclasses as dc
+import typing as typ
+
+if typ.TYPE_CHECKING:
+    from pathlib import Path
+
+
+@dc.dataclass(frozen=True, slots=True)
+class _ReexportScanContext:
+    """Bundled package context for re-export index scanning."""
+
+    root: Path
+    source_path: Path
+    package: str
+    module_name: str
+
+
+def _module_name(root: Path, package: str, source_path: Path) -> str:
+    """Derive the dotted module name from a source path."""
+    relative = source_path.relative_to(root).with_suffix("")
+    parts = tuple(part for part in relative.parts if part != "__init__")
+    if not parts:
+        return package
+    return ".".join((package, *parts))
+
+
+def _build_reexport_index(root: Path, package: str) -> dict[str, str]:
+    """Build a map of re-exported symbols to their origin modules."""
+    reexport_index: dict[str, str] = {}
+    for source_path in sorted(root.rglob("__init__.py")):
+        module_name = _module_name(root, package, source_path)
+        tree = ast.parse(
+            source_path.read_text(encoding="utf-8"), filename=str(source_path)
+        )
+        ctx = _ReexportScanContext(
+            root=root,
+            source_path=source_path,
+            package=package,
+            module_name=module_name,
+        )
+        reexport_index.update(_collect_reexports_from_tree(tree, ctx))
+    return reexport_index
+
+
+def _reexports_from_import_node(
+    node: ast.ImportFrom,
+    imported_module: str,
+    ctx: _ReexportScanContext,
+) -> dict[str, str]:
+    """Return the re-export mapping contributed by a single ``from … import`` node."""
+    reexports: dict[str, str] = {}
+    for alias in node.names:
+        if alias.name == "*":
+            for exported_name, origin in _exported_symbols_from_module(
+                ctx.root, ctx.package, imported_module
+            ).items():
+                reexports[f"{ctx.module_name}.{exported_name}"] = origin
+            continue
+        exported_name = alias.asname or alias.name
+        reexports[f"{ctx.module_name}.{exported_name}"] = (
+            f"{imported_module}.{alias.name}"
+        )
+    return reexports
+
+
+def _exported_names_from_module(
+    root: Path, package: str, module_name: str
+) -> tuple[str, ...]:
+    """Return exported symbol names declared by one module."""
+    return tuple(sorted(_exported_symbols_from_module(root, package, module_name)))
+
+
+def _exported_symbols_from_module(
+    root: Path, package: str, module_name: str
+) -> dict[str, str]:
+    """Return exported symbol names mapped to their origin modules."""
+    source_path = _source_path_for_module(root, package, module_name)
+    if source_path is None:
+        return {}
+    tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+    public_symbols = _fallback_public_symbols_from_tree(
+        tree, root, package, module_name
+    )
+    if explicit_exports := _explicit_all_exports(tree):
+        return {
+            exported_name: public_symbols.get(
+                exported_name, f"{module_name}.{exported_name}"
+            )
+            for exported_name in explicit_exports
+        }
+    return {
+        exported_name: origin
+        for exported_name, origin in public_symbols.items()
+        if not exported_name.startswith("_")
+    }
+
+
+def _source_path_for_module(root: Path, package: str, module_name: str) -> Path | None:
+    """Return the source path for a package-local module."""
+    if module_name == package:
+        relative_parts: tuple[str, ...] = ()
+    elif module_name.startswith(f"{package}."):
+        relative_parts = tuple(module_name.removeprefix(f"{package}.").split("."))
+    else:
+        return None
+
+    module_path = root.joinpath(*relative_parts)
+    source_path = module_path.with_suffix(".py")
+    if source_path.is_file():
+        return source_path
+    package_path = module_path / "__init__.py"
+    if package_path.is_file():
+        return package_path
+    return None
+
+
+def _explicit_all_exports(tree: ast.AST) -> tuple[str, ...]:
+    """Return literal string exports assigned to ``__all__``."""
+    for node in tree.body if isinstance(tree, ast.Module) else ():
+        if _is_all_assign(node):
+            return _string_sequence_values(node.value)
+        if _is_all_ann_assign(node):
+            return _string_sequence_values(node.value)
+    return ()
+
+
+def _is_all_assign(node: ast.stmt) -> typ.TypeIs[ast.Assign]:
+    """Return whether a statement assigns to ``__all__``."""
+    return isinstance(node, ast.Assign) and any(
+        isinstance(target, ast.Name) and target.id == "__all__"
+        for target in node.targets
+    )
+
+
+def _is_all_ann_assign(node: ast.stmt) -> typ.TypeIs[ast.AnnAssign]:
+    """Return whether a statement annotates and assigns ``__all__``."""
+    return isinstance(node, ast.AnnAssign) and _is_all_name(node.target)
+
+
+def _is_all_name(node: ast.AST) -> typ.TypeIs[ast.Name]:
+    """Return whether a node names ``__all__``."""
+    return isinstance(node, ast.Name) and node.id == "__all__"
+
+
+def _string_sequence_values(node: ast.AST | None) -> tuple[str, ...]:
+    """Return literal string values from a list or tuple node."""
+    if not isinstance(node, ast.List | ast.Tuple):
+        return ()
+    values = tuple(
+        element.value
+        for element in node.elts
+        if isinstance(element, ast.Constant) and isinstance(element.value, str)
+    )
+    return values if len(values) == len(node.elts) else ()
+
+
+def _fallback_public_symbols_from_tree(
+    tree: ast.AST, root: Path, package: str, module_name: str
+) -> dict[str, str]:
+    """Return public symbols, expanding module-level star imports."""
+    public_symbols = _public_symbols_from_tree(tree, root, package, module_name)
+    if not isinstance(tree, ast.Module):
+        return public_symbols
+    source_path = _source_path_for_module(root, package, module_name)
+    if source_path is None:
+        return public_symbols
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom) and _has_star_alias(node):
+            imported_module = _resolve_import_from(
+                node, source_path, package, module_name
+            )
+            if imported_module is not None:
+                public_symbols.update(
+                    _exported_symbols_from_module(root, package, imported_module)
+                )
+    return public_symbols
+
+
+def _public_names_from_tree(tree: ast.AST) -> set[str]:
+    """Return public names bound at module top level."""
+    if not isinstance(tree, ast.Module):
+        return set()
+    public_names: set[str] = set()
+    for node in tree.body:
+        public_names.update(_public_names_from_node(node))
+    return public_names
+
+
+def _public_symbols_from_tree(
+    tree: ast.AST, root: Path, package: str, module_name: str
+) -> dict[str, str]:
+    """Return public symbols bound at module top level."""
+    if not isinstance(tree, ast.Module):
+        return {}
+    public_symbols: dict[str, str] = {}
+    source_path = _source_path_for_module(root, package, module_name)
+    for node in tree.body:
+        public_symbols.update(
+            _public_symbols_from_node(node, source_path, package, module_name)
+        )
+    return public_symbols
+
+
+def _public_names_from_node(node: ast.stmt) -> set[str]:
+    """Return public names bound by one module-level statement."""
+    return set(_public_symbols_from_node(node, None, "", ""))
+
+
+def _public_symbols_from_node(
+    node: ast.stmt,
+    source_path: Path | None,
+    package: str,
+    module_name: str,
+) -> dict[str, str]:
+    """Return public symbols bound by one module-level statement."""
+    public_symbols: dict[str, str] = {}
+    if isinstance(node, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
+        public_symbols = {node.name: f"{module_name}.{node.name}"}
+    elif isinstance(node, ast.Assign):
+        public_symbols = {
+            target.id: f"{module_name}.{target.id}"
+            for target in node.targets
+            if isinstance(target, ast.Name) and target.id != "__all__"
+        }
+    elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+        if node.target.id != "__all__":
+            public_symbols = {node.target.id: f"{module_name}.{node.target.id}"}
+    elif isinstance(node, ast.Import):
+        public_symbols = {
+            alias.asname or alias.name.split(".", maxsplit=1)[0]: alias.name
+            for alias in node.names
+        }
+    elif isinstance(node, ast.ImportFrom) and source_path is not None:
+        imported_module = _resolve_import_from(node, source_path, package, module_name)
+        if imported_module is not None:
+            public_symbols = {
+                alias.asname or alias.name: f"{imported_module}.{alias.name}"
+                for alias in node.names
+                if alias.name != "*"
+            }
+    return public_symbols
+
+
+def _has_star_alias(node: ast.ImportFrom) -> bool:
+    """Return whether an import-from node contains a star alias."""
+    return any(alias.name == "*" for alias in node.names)
+
+
+def _collect_reexports_from_tree(
+    tree: ast.AST,
+    ctx: _ReexportScanContext,
+) -> dict[str, str]:
+    """Collect re-export mappings from one parsed ``__init__`` tree."""
+    reexports: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        if (
+            imported_module := _resolve_import_from(
+                node, ctx.source_path, ctx.package, ctx.module_name
+            )
+        ) is None:
+            continue
+        reexports.update(_reexports_from_import_node(node, imported_module, ctx))
+    return reexports
+
+
+def _resolve_import_from(
+    node: ast.ImportFrom,
+    source_path: Path,
+    package: str,
+    module_name: str,
+) -> str | None:
+    """Resolve an ``ImportFrom`` node to an absolute module name."""
+    if node.level:
+        module_name = _relative_import_base(node, source_path, module_name)
+        if node.module:
+            module_name = f"{module_name}.{node.module}" if module_name else node.module
+    else:
+        module_name = node.module or ""
+
+    if module_name == package or module_name.startswith(f"{package}."):
+        return module_name
+    return None
+
+
+def _relative_import_base(
+    node: ast.ImportFrom, source_path: Path, module_name: str
+) -> str:
+    """Compute the base module for a relative import."""
+    parent_parts = module_name.split(".")
+    if source_path.name == "__init__.py":
+        module_parts = parent_parts
+    else:
+        module_parts = parent_parts[:-1]
+    drop_count = node.level - 1
+    if drop_count:
+        module_parts = module_parts[:-drop_count]
+    return ".".join(module_parts)

--- a/episodic/architecture/reexports.py
+++ b/episodic/architecture/reexports.py
@@ -231,16 +231,16 @@ def _public_names_from_node(node: ast.stmt) -> set[str]:
     return set(_public_symbols_from_node(node, None, "", ""))
 
 
-def _public_from_class_or_func(
+def _symbols_from_definition(
     node: ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef,
     module_name: str,
 ) -> dict[str, str]:
-    """Return the public symbol bound by a class or function definition."""
+    """Return the symbol introduced by a class or function definition."""
     return {node.name: f"{module_name}.{node.name}"}
 
 
-def _public_from_assign(node: ast.Assign, module_name: str) -> dict[str, str]:
-    """Return public symbols bound by a simple assignment."""
+def _symbols_from_assign(node: ast.Assign, module_name: str) -> dict[str, str]:
+    """Return public symbols introduced by a simple assignment statement."""
     return {
         target.id: f"{module_name}.{target.id}"
         for target in node.targets
@@ -248,30 +248,28 @@ def _public_from_assign(node: ast.Assign, module_name: str) -> dict[str, str]:
     }
 
 
-def _public_from_annassign(node: ast.AnnAssign, module_name: str) -> dict[str, str]:
-    """Return the public symbol bound by an annotated assignment."""
+def _symbols_from_ann_assign(node: ast.AnnAssign, module_name: str) -> dict[str, str]:
+    """Return the public symbol introduced by an annotated assignment, if any."""
     if isinstance(node.target, ast.Name) and node.target.id != "__all__":
         return {node.target.id: f"{module_name}.{node.target.id}"}
     return {}
 
 
-def _public_from_import(node: ast.Import) -> dict[str, str]:
-    """Return public symbols bound by a bare import."""
+def _symbols_from_import(node: ast.Import) -> dict[str, str]:
+    """Return public symbols introduced by a bare import statement."""
     return {
         alias.asname or alias.name.split(".", maxsplit=1)[0]: alias.name
         for alias in node.names
     }
 
 
-def _public_from_importfrom(
+def _symbols_from_import_from(
     node: ast.ImportFrom,
-    source_path: Path | None,
+    source_path: Path,
     package: str,
     module_name: str,
 ) -> dict[str, str]:
-    """Return public symbols bound by an import-from statement."""
-    if source_path is None:
-        return {}
+    """Return public symbols introduced by a ``from … import`` statement."""
     imported_module = _resolve_import_from(node, source_path, package, module_name)
     if imported_module is None:
         return {}
@@ -290,15 +288,15 @@ def _public_symbols_from_node(
 ) -> dict[str, str]:
     """Return public symbols bound by one module-level statement."""
     if isinstance(node, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
-        return _public_from_class_or_func(node, module_name)
+        return _symbols_from_definition(node, module_name)
     if isinstance(node, ast.Assign):
-        return _public_from_assign(node, module_name)
+        return _symbols_from_assign(node, module_name)
     if isinstance(node, ast.AnnAssign):
-        return _public_from_annassign(node, module_name)
+        return _symbols_from_ann_assign(node, module_name)
     if isinstance(node, ast.Import):
-        return _public_from_import(node)
-    if isinstance(node, ast.ImportFrom):
-        return _public_from_importfrom(node, source_path, package, module_name)
+        return _symbols_from_import(node)
+    if isinstance(node, ast.ImportFrom) and source_path is not None:
+        return _symbols_from_import_from(node, source_path, package, module_name)
     return {}
 
 

--- a/episodic/architecture/reexports.py
+++ b/episodic/architecture/reexports.py
@@ -151,8 +151,9 @@ def _explicit_all_exports(tree: ast.AST) -> tuple[str, ...] | None:
     for node in tree.body if isinstance(tree, ast.Module) else ():
         if _is_all_assign(node) or _is_all_ann_assign(node):
             values = _string_sequence_values(node.value)
-            if values is not None:
-                last_exports = values
+            if values is None:
+                return None
+            last_exports = values
     return last_exports
 
 

--- a/episodic/architecture/reexports.py
+++ b/episodic/architecture/reexports.py
@@ -84,7 +84,8 @@ def _exported_symbols_from_module(
     public_symbols = _fallback_public_symbols_from_tree(
         tree, root, package, module_name
     )
-    if explicit_exports := _explicit_all_exports(tree):
+    explicit_exports = _explicit_all_exports(tree)
+    if explicit_exports is not None:
         return {
             exported_name: public_symbols.get(
                 exported_name, f"{module_name}.{exported_name}"
@@ -117,14 +118,14 @@ def _source_path_for_module(root: Path, package: str, module_name: str) -> Path 
     return None
 
 
-def _explicit_all_exports(tree: ast.AST) -> tuple[str, ...]:
+def _explicit_all_exports(tree: ast.AST) -> tuple[str, ...] | None:
     """Return literal string exports assigned to ``__all__``."""
     for node in tree.body if isinstance(tree, ast.Module) else ():
-        if _is_all_assign(node):
-            return _string_sequence_values(node.value)
-        if _is_all_ann_assign(node):
-            return _string_sequence_values(node.value)
-    return ()
+        if _is_all_assign(node) or _is_all_ann_assign(node):
+            values = _string_sequence_values(node.value)
+            if values is not None:
+                return values
+    return None
 
 
 def _is_all_assign(node: ast.stmt) -> typ.TypeIs[ast.Assign]:
@@ -145,16 +146,16 @@ def _is_all_name(node: ast.AST) -> typ.TypeIs[ast.Name]:
     return isinstance(node, ast.Name) and node.id == "__all__"
 
 
-def _string_sequence_values(node: ast.AST | None) -> tuple[str, ...]:
+def _string_sequence_values(node: ast.AST | None) -> tuple[str, ...] | None:
     """Return literal string values from a list or tuple node."""
     if not isinstance(node, ast.List | ast.Tuple):
-        return ()
+        return None
     values = tuple(
         element.value
         for element in node.elts
         if isinstance(element, ast.Constant) and isinstance(element.value, str)
     )
-    return values if len(values) == len(node.elts) else ()
+    return values if len(values) == len(node.elts) else None
 
 
 def _fallback_public_symbols_from_tree(
@@ -209,6 +210,57 @@ def _public_names_from_node(node: ast.stmt) -> set[str]:
     return set(_public_symbols_from_node(node, None, "", ""))
 
 
+def _public_from_class_or_func(
+    node: ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef,
+    module_name: str,
+) -> dict[str, str]:
+    """Return the public symbol bound by a class or function definition."""
+    return {node.name: f"{module_name}.{node.name}"}
+
+
+def _public_from_assign(node: ast.Assign, module_name: str) -> dict[str, str]:
+    """Return public symbols bound by a simple assignment."""
+    return {
+        target.id: f"{module_name}.{target.id}"
+        for target in node.targets
+        if isinstance(target, ast.Name) and target.id != "__all__"
+    }
+
+
+def _public_from_annassign(node: ast.AnnAssign, module_name: str) -> dict[str, str]:
+    """Return the public symbol bound by an annotated assignment."""
+    if isinstance(node.target, ast.Name) and node.target.id != "__all__":
+        return {node.target.id: f"{module_name}.{node.target.id}"}
+    return {}
+
+
+def _public_from_import(node: ast.Import) -> dict[str, str]:
+    """Return public symbols bound by a bare import."""
+    return {
+        alias.asname or alias.name.split(".", maxsplit=1)[0]: alias.name
+        for alias in node.names
+    }
+
+
+def _public_from_importfrom(
+    node: ast.ImportFrom,
+    source_path: Path | None,
+    package: str,
+    module_name: str,
+) -> dict[str, str]:
+    """Return public symbols bound by an import-from statement."""
+    if source_path is None:
+        return {}
+    imported_module = _resolve_import_from(node, source_path, package, module_name)
+    if imported_module is None:
+        return {}
+    return {
+        alias.asname or alias.name: f"{imported_module}.{alias.name}"
+        for alias in node.names
+        if alias.name != "*"
+    }
+
+
 def _public_symbols_from_node(
     node: ast.stmt,
     source_path: Path | None,
@@ -216,32 +268,17 @@ def _public_symbols_from_node(
     module_name: str,
 ) -> dict[str, str]:
     """Return public symbols bound by one module-level statement."""
-    public_symbols: dict[str, str] = {}
     if isinstance(node, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef):
-        public_symbols = {node.name: f"{module_name}.{node.name}"}
-    elif isinstance(node, ast.Assign):
-        public_symbols = {
-            target.id: f"{module_name}.{target.id}"
-            for target in node.targets
-            if isinstance(target, ast.Name) and target.id != "__all__"
-        }
-    elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
-        if node.target.id != "__all__":
-            public_symbols = {node.target.id: f"{module_name}.{node.target.id}"}
-    elif isinstance(node, ast.Import):
-        public_symbols = {
-            alias.asname or alias.name.split(".", maxsplit=1)[0]: alias.name
-            for alias in node.names
-        }
-    elif isinstance(node, ast.ImportFrom) and source_path is not None:
-        imported_module = _resolve_import_from(node, source_path, package, module_name)
-        if imported_module is not None:
-            public_symbols = {
-                alias.asname or alias.name: f"{imported_module}.{alias.name}"
-                for alias in node.names
-                if alias.name != "*"
-            }
-    return public_symbols
+        return _public_from_class_or_func(node, module_name)
+    if isinstance(node, ast.Assign):
+        return _public_from_assign(node, module_name)
+    if isinstance(node, ast.AnnAssign):
+        return _public_from_annassign(node, module_name)
+    if isinstance(node, ast.Import):
+        return _public_from_import(node)
+    if isinstance(node, ast.ImportFrom):
+        return _public_from_importfrom(node, source_path, package, module_name)
+    return {}
 
 
 def _has_star_alias(node: ast.ImportFrom) -> bool:
@@ -255,7 +292,7 @@ def _collect_reexports_from_tree(
 ) -> dict[str, str]:
     """Collect re-export mappings from one parsed ``__init__`` tree."""
     reexports: dict[str, str] = {}
-    for node in ast.walk(tree):
+    for node in tree.body if isinstance(tree, ast.Module) else ():
         if not isinstance(node, ast.ImportFrom):
             continue
         if (

--- a/episodic/architecture/reexports.py
+++ b/episodic/architecture/reexports.py
@@ -1,4 +1,17 @@
-"""Package barrel re-export discovery for architecture checks."""
+"""Resolve package barrel re-exports for architecture checks.
+
+This module discovers symbols exposed from package ``__init__`` files and maps
+those package-level imports back to their concrete origin modules. Callers
+should import the resolver API from ``episodic.architecture.reexports`` and use
+``_build_reexport_index(root, package)`` with a package root and dotted package
+name to receive a mapping of exported symbol paths to origin symbol paths.
+``episodic.architecture.checker`` relies on that mapping when validating
+package-level imports for ``make check-architecture``.
+
+The resolver handles explicit ``from … import name`` re-exports, star
+re-exports, nested package barrels, and literal ``__all__`` declarations without
+importing application modules or executing package code.
+"""
 
 import ast
 import dataclasses as dc

--- a/episodic/architecture/reexports.py
+++ b/episodic/architecture/reexports.py
@@ -134,7 +134,7 @@ def _source_path_for_module(root: Path, package: str, module_name: str) -> Path 
 
 def _explicit_all_exports(tree: ast.AST) -> tuple[str, ...] | None:
     """Return literal string exports assigned to ``__all__``."""
-    for node in tree.body if isinstance(tree, ast.Module) else ():
+    for node in reversed(tree.body) if isinstance(tree, ast.Module) else ():
         if _is_all_assign(node) or _is_all_ann_assign(node):
             values = _string_sequence_values(node.value)
             if values is not None:

--- a/episodic/canonical/constraints.py
+++ b/episodic/canonical/constraints.py
@@ -1,0 +1,18 @@
+"""Domain-level persistence constraint names shared across adapters."""
+
+UQ_SERIES_PROFILE_HISTORY_REVISION = "uq_series_profile_history_revision"
+UQ_EPISODE_TEMPLATE_HISTORY_REVISION = "uq_episode_template_history_revision"
+REVISION_CONSTRAINT_NAMES = (
+    UQ_SERIES_PROFILE_HISTORY_REVISION,
+    UQ_EPISODE_TEMPLATE_HISTORY_REVISION,
+)
+CK_REFERENCE_BINDINGS_TARGET = "ck_reference_document_bindings_target"
+CK_REFERENCE_BINDINGS_EFFECTIVE_EPISODE = (
+    "ck_reference_document_bindings_effective_episode"
+)
+UQ_REF_DOC_BINDINGS_SERIES_REV_EFFECTIVE = "uq_ref_doc_bindings_series_rev_effective"
+UQ_REF_DOC_BINDINGS_SERIES_REV_NO_EFFECTIVE = (
+    "uq_ref_doc_bindings_series_rev_no_effective"
+)
+UQ_REF_DOC_BINDINGS_TEMPLATE_REV = "uq_ref_doc_bindings_template_rev"
+UQ_REF_DOC_BINDINGS_JOB_REV = "uq_ref_doc_bindings_job_rev"

--- a/episodic/canonical/ingestion_ports.py
+++ b/episodic/canonical/ingestion_ports.py
@@ -26,6 +26,7 @@ if typ.TYPE_CHECKING:
     )
 
 
+@typ.runtime_checkable
 class SourceNormalizer(typ.Protocol):
     """Normalizes a raw source into a TEI fragment with quality scores.
 
@@ -59,6 +60,7 @@ class SourceNormalizer(typ.Protocol):
         ...
 
 
+@typ.runtime_checkable
 class WeightingStrategy(typ.Protocol):
     """Computes weights for normalized sources using series configuration.
 
@@ -95,6 +97,7 @@ class WeightingStrategy(typ.Protocol):
         ...
 
 
+@typ.runtime_checkable
 class ConflictResolver(typ.Protocol):
     """Resolves conflicts between weighted sources into canonical TEI.
 

--- a/episodic/canonical/ports.py
+++ b/episodic/canonical/ports.py
@@ -544,6 +544,7 @@ class EpisodeTemplateHistoryRepository(typ.Protocol):
         ...
 
 
+@typ.runtime_checkable
 class CanonicalUnitOfWork(typ.Protocol):
     """Unit-of-work boundary for canonical persistence.
 

--- a/episodic/canonical/profile_templates/helpers.py
+++ b/episodic/canonical/profile_templates/helpers.py
@@ -17,7 +17,7 @@ import uuid
 
 from sqlalchemy.exc import IntegrityError
 
-from episodic.canonical.storage.models import REVISION_CONSTRAINT_NAMES
+from episodic.canonical.constraints import REVISION_CONSTRAINT_NAMES
 
 from .types import (
     AuditMetadata,

--- a/episodic/canonical/reference_documents/bindings.py
+++ b/episodic/canonical/reference_documents/bindings.py
@@ -7,13 +7,13 @@ import uuid
 
 from sqlalchemy.exc import IntegrityError
 
-from episodic.canonical.domain import ReferenceBinding, ReferenceBindingTargetKind
-from episodic.canonical.storage.models import (
+from episodic.canonical.constraints import (
     UQ_REF_DOC_BINDINGS_JOB_REV,
     UQ_REF_DOC_BINDINGS_SERIES_REV_EFFECTIVE,
     UQ_REF_DOC_BINDINGS_SERIES_REV_NO_EFFECTIVE,
     UQ_REF_DOC_BINDINGS_TEMPLATE_REV,
 )
+from episodic.canonical.domain import ReferenceBinding, ReferenceBindingTargetKind
 
 from .helpers import (
     _BindingTargetAlignment,

--- a/episodic/canonical/storage/models.py
+++ b/episodic/canonical/storage/models.py
@@ -13,6 +13,10 @@ import sqlalchemy as sa
 from sqlalchemy import orm
 from sqlalchemy.dialects import postgresql
 
+from episodic.canonical.constraints import (
+    UQ_EPISODE_TEMPLATE_HISTORY_REVISION,
+    UQ_SERIES_PROFILE_HISTORY_REVISION,
+)
 from episodic.canonical.domain import (
     ApprovalState,
     EpisodeStatus,
@@ -70,23 +74,6 @@ REFERENCE_BINDING_TARGET_KIND = sa.Enum(
     name="reference_binding_target_kind",
     values_callable=lambda enum_cls: [item.value for item in enum_cls],
 )
-
-UQ_SERIES_PROFILE_HISTORY_REVISION = "uq_series_profile_history_revision"
-UQ_EPISODE_TEMPLATE_HISTORY_REVISION = "uq_episode_template_history_revision"
-REVISION_CONSTRAINT_NAMES = (
-    UQ_SERIES_PROFILE_HISTORY_REVISION,
-    UQ_EPISODE_TEMPLATE_HISTORY_REVISION,
-)
-CK_REFERENCE_BINDINGS_TARGET = "ck_reference_document_bindings_target"
-CK_REFERENCE_BINDINGS_EFFECTIVE_EPISODE = (
-    "ck_reference_document_bindings_effective_episode"
-)
-UQ_REF_DOC_BINDINGS_SERIES_REV_EFFECTIVE = "uq_ref_doc_bindings_series_rev_effective"
-UQ_REF_DOC_BINDINGS_SERIES_REV_NO_EFFECTIVE = (
-    "uq_ref_doc_bindings_series_rev_no_effective"
-)
-UQ_REF_DOC_BINDINGS_TEMPLATE_REV = "uq_ref_doc_bindings_template_rev"
-UQ_REF_DOC_BINDINGS_JOB_REV = "uq_ref_doc_bindings_job_rev"
 
 
 class SeriesProfileRecord(Base):

--- a/episodic/canonical/storage/reference_models.py
+++ b/episodic/canonical/storage/reference_models.py
@@ -7,6 +7,14 @@ import sqlalchemy as sa
 from sqlalchemy import orm
 from sqlalchemy.dialects import postgresql
 
+from episodic.canonical.constraints import (
+    CK_REFERENCE_BINDINGS_EFFECTIVE_EPISODE,
+    CK_REFERENCE_BINDINGS_TARGET,
+    UQ_REF_DOC_BINDINGS_JOB_REV,
+    UQ_REF_DOC_BINDINGS_SERIES_REV_EFFECTIVE,
+    UQ_REF_DOC_BINDINGS_SERIES_REV_NO_EFFECTIVE,
+    UQ_REF_DOC_BINDINGS_TEMPLATE_REV,
+)
 from episodic.canonical.domain import (
     ReferenceBindingTargetKind,
     ReferenceDocumentKind,
@@ -18,15 +26,9 @@ from episodic.canonical.storage.reference_document_schema import (
 )
 
 from .models import (
-    CK_REFERENCE_BINDINGS_EFFECTIVE_EPISODE,
-    CK_REFERENCE_BINDINGS_TARGET,
     REFERENCE_BINDING_TARGET_KIND,
     REFERENCE_DOCUMENT_KIND,
     REFERENCE_DOCUMENT_LIFECYCLE_STATE,
-    UQ_REF_DOC_BINDINGS_JOB_REV,
-    UQ_REF_DOC_BINDINGS_SERIES_REV_EFFECTIVE,
-    UQ_REF_DOC_BINDINGS_SERIES_REV_NO_EFFECTIVE,
-    UQ_REF_DOC_BINDINGS_TEMPLATE_REV,
     Base,
 )
 

--- a/episodic/llm/ports.py
+++ b/episodic/llm/ports.py
@@ -110,6 +110,7 @@ class LLMTransientProviderError(LLMError):
     """Raised when a provider fails transiently after retries are exhausted."""
 
 
+@typ.runtime_checkable
 class LLMPort(typ.Protocol):
     """Protocol for outbound LLM adapter implementations."""
 

--- a/tests/features/architecture_enforcement.feature
+++ b/tests/features/architecture_enforcement.feature
@@ -1,0 +1,22 @@
+Feature: Architecture enforcement
+
+  Scenario: A violating domain module is rejected with a clear diagnostic
+    Given the architecture fixture package "domain_imports_storage"
+    When the architecture checker runs
+    Then the architecture check fails
+    And the architecture diagnostic mentions "ARCH001"
+    And the architecture diagnostic mentions "domain"
+    And the architecture diagnostic mentions "storage"
+
+  Scenario: A violating inbound adapter is rejected with a clear diagnostic
+    Given the architecture fixture package "api_imports_outbound_adapter"
+    When the architecture checker runs
+    Then the architecture check fails
+    And the architecture diagnostic mentions "ARCH001"
+    And the architecture diagnostic mentions "api"
+    And the architecture diagnostic mentions "storage"
+
+  Scenario: A composition root that wires adapters is accepted
+    Given the architecture fixture package "composition_root_allows_wiring"
+    When the architecture checker runs
+    Then the architecture check passes

--- a/tests/fixtures/architecture/__init__.py
+++ b/tests/fixtures/architecture/__init__.py
@@ -1,0 +1,1 @@
+"""Architecture-checker fixture packages."""

--- a/tests/fixtures/architecture/allowed_case/__init__.py
+++ b/tests/fixtures/architecture/allowed_case/__init__.py
@@ -1,0 +1,1 @@
+"""Fixture package with an allowed dependency graph."""

--- a/tests/fixtures/architecture/allowed_case/api.py
+++ b/tests/fixtures/architecture/allowed_case/api.py
@@ -1,0 +1,5 @@
+"""Allowed inbound-adapter fixture."""
+
+from tests.fixtures.architecture.allowed_case import service
+
+VALUE = service.VALUE

--- a/tests/fixtures/architecture/allowed_case/domain.py
+++ b/tests/fixtures/architecture/allowed_case/domain.py
@@ -1,0 +1,3 @@
+"""Allowed domain fixture."""
+
+VALUE = "domain"

--- a/tests/fixtures/architecture/allowed_case/service.py
+++ b/tests/fixtures/architecture/allowed_case/service.py
@@ -1,0 +1,5 @@
+"""Allowed application-service fixture."""
+
+from tests.fixtures.architecture.allowed_case import domain
+
+VALUE = domain.VALUE

--- a/tests/fixtures/architecture/allowed_case/storage.py
+++ b/tests/fixtures/architecture/allowed_case/storage.py
@@ -1,0 +1,5 @@
+"""Allowed outbound-adapter fixture."""
+
+from tests.fixtures.architecture.allowed_case import domain
+
+VALUE = domain.VALUE

--- a/tests/fixtures/architecture/api_imports_cyclic_star_reexported_outbound_adapter/__init__.py
+++ b/tests/fixtures/architecture/api_imports_cyclic_star_reexported_outbound_adapter/__init__.py
@@ -1,0 +1,3 @@
+"""Fixture package that star-re-exports through a cyclic barrel."""
+
+from .b import *  # noqa: F403

--- a/tests/fixtures/architecture/api_imports_cyclic_star_reexported_outbound_adapter/a.py
+++ b/tests/fixtures/architecture/api_imports_cyclic_star_reexported_outbound_adapter/a.py
@@ -1,0 +1,4 @@
+"""Cyclic star barrel that also exposes a concrete outbound adapter."""
+
+from .b import *  # noqa: F403
+from .storage import StorageAdapter  # noqa: F401

--- a/tests/fixtures/architecture/api_imports_cyclic_star_reexported_outbound_adapter/api.py
+++ b/tests/fixtures/architecture/api_imports_cyclic_star_reexported_outbound_adapter/api.py
@@ -1,0 +1,5 @@
+"""Violating inbound adapter that imports from a cyclic star barrel."""
+
+from . import StorageAdapter
+
+ADAPTER = StorageAdapter()

--- a/tests/fixtures/architecture/api_imports_cyclic_star_reexported_outbound_adapter/b.py
+++ b/tests/fixtures/architecture/api_imports_cyclic_star_reexported_outbound_adapter/b.py
@@ -1,0 +1,3 @@
+"""Cyclic star barrel that forwards exports from module a."""
+
+from .a import *  # noqa: F403

--- a/tests/fixtures/architecture/api_imports_cyclic_star_reexported_outbound_adapter/storage.py
+++ b/tests/fixtures/architecture/api_imports_cyclic_star_reexported_outbound_adapter/storage.py
@@ -1,0 +1,5 @@
+"""Outbound storage adapter re-exported through a cyclic star import."""
+
+
+class StorageAdapter:
+    """Concrete outbound adapter used to test cyclic package star re-exports."""

--- a/tests/fixtures/architecture/api_imports_nested_star_reexported_outbound_adapter/__init__.py
+++ b/tests/fixtures/architecture/api_imports_nested_star_reexported_outbound_adapter/__init__.py
@@ -1,3 +1,3 @@
 """Fixture package that star-re-exports an outbound adapter."""
 
-from .storage import *  # noqa: F403
+from .barrel import *  # noqa: F403

--- a/tests/fixtures/architecture/api_imports_nested_star_reexported_outbound_adapter/__init__.py
+++ b/tests/fixtures/architecture/api_imports_nested_star_reexported_outbound_adapter/__init__.py
@@ -1,0 +1,3 @@
+"""Fixture package that star-re-exports an outbound adapter."""
+
+from .storage import *  # noqa: F403

--- a/tests/fixtures/architecture/api_imports_nested_star_reexported_outbound_adapter/api.py
+++ b/tests/fixtures/architecture/api_imports_nested_star_reexported_outbound_adapter/api.py
@@ -1,0 +1,5 @@
+"""Violating inbound adapter that imports a star-re-exported outbound adapter."""
+
+from . import StorageAdapter
+
+ADAPTER = StorageAdapter()

--- a/tests/fixtures/architecture/api_imports_nested_star_reexported_outbound_adapter/barrel.py
+++ b/tests/fixtures/architecture/api_imports_nested_star_reexported_outbound_adapter/barrel.py
@@ -1,0 +1,3 @@
+"""Star-only barrel that forwards public storage exports."""
+
+from .storage import *  # noqa: F403

--- a/tests/fixtures/architecture/api_imports_nested_star_reexported_outbound_adapter/storage.py
+++ b/tests/fixtures/architecture/api_imports_nested_star_reexported_outbound_adapter/storage.py
@@ -1,0 +1,7 @@
+"""Outbound storage adapter re-exported through a star import."""
+
+__all__ = ["StorageAdapter"]
+
+
+class StorageAdapter:
+    """Concrete outbound adapter used to test nested package star re-exports."""

--- a/tests/fixtures/architecture/api_imports_nested_star_reexported_outbound_adapter/storage.py
+++ b/tests/fixtures/architecture/api_imports_nested_star_reexported_outbound_adapter/storage.py
@@ -1,7 +1,5 @@
 """Outbound storage adapter re-exported through a star import."""
 
-__all__ = ["StorageAdapter"]
-
 
 class StorageAdapter:
     """Concrete outbound adapter used to test nested package star re-exports."""

--- a/tests/fixtures/architecture/api_imports_outbound_adapter/__init__.py
+++ b/tests/fixtures/architecture/api_imports_outbound_adapter/__init__.py
@@ -1,0 +1,1 @@
+"""Fixture package where an inbound adapter imports outbound storage."""

--- a/tests/fixtures/architecture/api_imports_outbound_adapter/api.py
+++ b/tests/fixtures/architecture/api_imports_outbound_adapter/api.py
@@ -1,0 +1,5 @@
+"""Violating inbound-adapter fixture."""
+
+from tests.fixtures.architecture.api_imports_outbound_adapter import storage
+
+VALUE = storage.VALUE

--- a/tests/fixtures/architecture/api_imports_outbound_adapter/storage.py
+++ b/tests/fixtures/architecture/api_imports_outbound_adapter/storage.py
@@ -1,0 +1,3 @@
+"""Outbound storage fixture."""
+
+VALUE = "storage"

--- a/tests/fixtures/architecture/api_imports_reexported_outbound_adapter/__init__.py
+++ b/tests/fixtures/architecture/api_imports_reexported_outbound_adapter/__init__.py
@@ -1,0 +1,5 @@
+"""Fixture package that re-exports an outbound adapter."""
+
+from .storage import StorageAdapter
+
+__all__ = ["StorageAdapter"]

--- a/tests/fixtures/architecture/api_imports_reexported_outbound_adapter/api.py
+++ b/tests/fixtures/architecture/api_imports_reexported_outbound_adapter/api.py
@@ -1,0 +1,7 @@
+"""Violating inbound adapter that imports a re-exported outbound adapter."""
+
+from tests.fixtures.architecture.api_imports_reexported_outbound_adapter import (
+    StorageAdapter,
+)
+
+ADAPTER = StorageAdapter()

--- a/tests/fixtures/architecture/api_imports_reexported_outbound_adapter/storage.py
+++ b/tests/fixtures/architecture/api_imports_reexported_outbound_adapter/storage.py
@@ -1,0 +1,5 @@
+"""Outbound storage adapter re-exported through the fixture package."""
+
+
+class StorageAdapter:
+    """Concrete outbound adapter used to test package barrel imports."""

--- a/tests/fixtures/architecture/api_imports_star_reexported_outbound_adapter/__init__.py
+++ b/tests/fixtures/architecture/api_imports_star_reexported_outbound_adapter/__init__.py
@@ -1,0 +1,5 @@
+"""Fixture package that re-exports an outbound adapter for star imports."""
+
+from .storage import StorageAdapter
+
+__all__ = ["StorageAdapter"]

--- a/tests/fixtures/architecture/api_imports_star_reexported_outbound_adapter/api.py
+++ b/tests/fixtures/architecture/api_imports_star_reexported_outbound_adapter/api.py
@@ -1,0 +1,5 @@
+"""Violating inbound adapter that star-imports a re-exported outbound adapter."""
+
+from tests.fixtures.architecture.api_imports_star_reexported_outbound_adapter import *  # noqa: F403
+
+ADAPTER = StorageAdapter()  # noqa: F405

--- a/tests/fixtures/architecture/api_imports_star_reexported_outbound_adapter/storage.py
+++ b/tests/fixtures/architecture/api_imports_star_reexported_outbound_adapter/storage.py
@@ -1,0 +1,5 @@
+"""Outbound storage adapter re-exported through the fixture package."""
+
+
+class StorageAdapter:
+    """Concrete outbound adapter used to test package barrel star imports."""

--- a/tests/fixtures/architecture/composition_root_allows_wiring/__init__.py
+++ b/tests/fixtures/architecture/composition_root_allows_wiring/__init__.py
@@ -1,0 +1,1 @@
+"""Fixture package where a composition root wires concrete adapters."""

--- a/tests/fixtures/architecture/composition_root_allows_wiring/api.py
+++ b/tests/fixtures/architecture/composition_root_allows_wiring/api.py
@@ -1,0 +1,3 @@
+"""Inbound-adapter fixture."""
+
+VALUE = "api"

--- a/tests/fixtures/architecture/composition_root_allows_wiring/runtime.py
+++ b/tests/fixtures/architecture/composition_root_allows_wiring/runtime.py
@@ -1,0 +1,5 @@
+"""Composition-root fixture."""
+
+from tests.fixtures.architecture.composition_root_allows_wiring import api, storage
+
+VALUE = (api.VALUE, storage.VALUE)

--- a/tests/fixtures/architecture/composition_root_allows_wiring/storage.py
+++ b/tests/fixtures/architecture/composition_root_allows_wiring/storage.py
@@ -1,0 +1,3 @@
+"""Outbound-adapter fixture."""
+
+VALUE = "storage"

--- a/tests/fixtures/architecture/domain_imports_storage/__init__.py
+++ b/tests/fixtures/architecture/domain_imports_storage/__init__.py
@@ -1,0 +1,1 @@
+"""Fixture package where domain code imports storage."""

--- a/tests/fixtures/architecture/domain_imports_storage/domain.py
+++ b/tests/fixtures/architecture/domain_imports_storage/domain.py
@@ -1,0 +1,5 @@
+"""Violating domain fixture."""
+
+from tests.fixtures.architecture.domain_imports_storage import storage
+
+VALUE = storage.VALUE

--- a/tests/fixtures/architecture/domain_imports_storage/storage.py
+++ b/tests/fixtures/architecture/domain_imports_storage/storage.py
@@ -1,0 +1,3 @@
+"""Outbound storage fixture."""
+
+VALUE = "storage"

--- a/tests/fixtures/architecture/explicit_empty_all/__init__.py
+++ b/tests/fixtures/architecture/explicit_empty_all/__init__.py
@@ -1,0 +1,3 @@
+"""Fixture package that explicitly exports no package-level names."""
+
+__all__ = []

--- a/tests/fixtures/architecture/explicit_empty_all/api.py
+++ b/tests/fixtures/architecture/explicit_empty_all/api.py
@@ -1,0 +1,5 @@
+"""Violating inbound adapter in a package with an empty export list."""
+
+from tests.fixtures.architecture.explicit_empty_all.storage import StorageAdapter
+
+ADAPTER = StorageAdapter()

--- a/tests/fixtures/architecture/explicit_empty_all/storage.py
+++ b/tests/fixtures/architecture/explicit_empty_all/storage.py
@@ -1,0 +1,5 @@
+"""Outbound storage adapter in an explicit-empty-__all__ fixture."""
+
+
+class StorageAdapter:
+    """Concrete outbound adapter used to test empty package exports."""

--- a/tests/steps/test_architecture_enforcement_steps.py
+++ b/tests/steps/test_architecture_enforcement_steps.py
@@ -1,0 +1,109 @@
+"""BDD steps for architecture-enforcement behaviour."""
+
+from __future__ import annotations
+
+import dataclasses as dc
+import subprocess  # noqa: S404  # BDD scenarios validate the public CLI.
+import sys
+from pathlib import Path
+
+import pytest
+from pytest_bdd import given, parsers, scenario, then, when
+
+
+@dc.dataclass(slots=True)
+class ArchitectureContext:
+    """State shared by architecture-enforcement BDD steps."""
+
+    package_name: str = ""
+    completed_process: subprocess.CompletedProcess[str] | None = None
+
+
+@pytest.fixture
+def context() -> ArchitectureContext:
+    """Provide scenario-local architecture-checker state."""
+    return ArchitectureContext()
+
+
+@scenario(
+    "../features/architecture_enforcement.feature",
+    "A violating domain module is rejected with a clear diagnostic",
+)
+def test_domain_violation_is_rejected() -> None:
+    """Run the domain-violation scenario."""
+
+
+@scenario(
+    "../features/architecture_enforcement.feature",
+    "A violating inbound adapter is rejected with a clear diagnostic",
+)
+def test_inbound_adapter_violation_is_rejected() -> None:
+    """Run the inbound-adapter violation scenario."""
+
+
+@scenario(
+    "../features/architecture_enforcement.feature",
+    "A composition root that wires adapters is accepted",
+)
+def test_composition_root_wiring_is_accepted() -> None:
+    """Run the composition-root acceptance scenario."""
+
+
+@given(parsers.parse('the architecture fixture package "{package_name}"'))
+def architecture_fixture_package(
+    context: ArchitectureContext,
+    package_name: str,
+) -> None:
+    """Select a fixture package for the architecture checker."""
+    context.package_name = package_name
+
+
+@when("the architecture checker runs")
+def architecture_checker_runs(context: ArchitectureContext) -> None:
+    """Run the architecture checker through its command-line entrypoint."""
+    package = f"tests.fixtures.architecture.{context.package_name}"
+    package_root = Path("tests/fixtures/architecture") / context.package_name
+    context.completed_process = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-m",
+            "episodic.architecture",
+            "--package",
+            package,
+            "--root",
+            str(package_root),
+            "--fixture-policy",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+@then("the architecture check fails")
+def architecture_check_fails(context: ArchitectureContext) -> None:
+    """Assert the checker rejected the selected fixture package."""
+    completed_process = context.completed_process
+    assert completed_process is not None
+    assert completed_process.returncode == 1
+
+
+@then("the architecture check passes")
+def architecture_check_passes(context: ArchitectureContext) -> None:
+    """Assert the checker accepted the selected fixture package."""
+    completed_process = context.completed_process
+    assert completed_process is not None
+    assert completed_process.returncode == 0
+    assert completed_process.stderr == ""
+
+
+@then(parsers.parse('the architecture diagnostic mentions "{expected_text}"'))
+def architecture_diagnostic_mentions(
+    context: ArchitectureContext,
+    expected_text: str,
+) -> None:
+    """Assert a stable diagnostic substring was emitted."""
+    completed_process = context.completed_process
+    assert completed_process is not None
+    output = f"{completed_process.stdout}\n{completed_process.stderr}"
+    assert expected_text in output

--- a/tests/steps/test_architecture_enforcement_steps.py
+++ b/tests/steps/test_architecture_enforcement_steps.py
@@ -84,17 +84,20 @@ def architecture_checker_runs(context: ArchitectureContext) -> None:
 def architecture_check_fails(context: ArchitectureContext) -> None:
     """Assert the checker rejected the selected fixture package."""
     completed_process = context.completed_process
-    assert completed_process is not None
-    assert completed_process.returncode == 1
+    assert completed_process is not None, "checker did not run"
+    assert completed_process.returncode == 1, (
+        f"expected exit 1, got {completed_process.returncode}"
+    )
 
 
 @then("the architecture check passes")
 def architecture_check_passes(context: ArchitectureContext) -> None:
     """Assert the checker accepted the selected fixture package."""
     completed_process = context.completed_process
-    assert completed_process is not None
-    assert completed_process.returncode == 0
-    assert completed_process.stderr == ""
+    assert completed_process is not None, "checker did not run"
+    assert completed_process.returncode == 0, (
+        f"expected exit 0, got {completed_process.returncode}"
+    )
 
 
 @then(parsers.parse('the architecture diagnostic mentions "{expected_text}"'))
@@ -104,6 +107,6 @@ def architecture_diagnostic_mentions(
 ) -> None:
     """Assert a stable diagnostic substring was emitted."""
     completed_process = context.completed_process
-    assert completed_process is not None
+    assert completed_process is not None, "checker did not run"
     output = f"{completed_process.stdout}\n{completed_process.stderr}"
-    assert expected_text in output
+    assert expected_text in output, f"expected {expected_text!r} in {output!r}"

--- a/tests/test_architecture_enforcement.py
+++ b/tests/test_architecture_enforcement.py
@@ -1,0 +1,130 @@
+"""Tests for hexagonal architecture enforcement."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from episodic.architecture import (
+    ArchitecturePolicy,
+    ModuleGroup,
+    check_architecture,
+)
+
+FIXTURE_ROOT = Path("tests/fixtures/architecture")
+
+
+def _fixture_policy(package_name: str) -> ArchitecturePolicy:
+    package = f"tests.fixtures.architecture.{package_name}"
+    return ArchitecturePolicy(
+        groups=(
+            ModuleGroup(
+                name="domain",
+                module_prefixes=(f"{package}.domain",),
+                allowed_groups=frozenset({"domain"}),
+            ),
+            ModuleGroup(
+                name="application",
+                module_prefixes=(f"{package}.service",),
+                allowed_groups=frozenset({"domain", "application"}),
+            ),
+            ModuleGroup(
+                name="inbound_adapter",
+                module_prefixes=(f"{package}.api",),
+                allowed_groups=frozenset({
+                    "domain",
+                    "application",
+                    "inbound_adapter",
+                }),
+            ),
+            ModuleGroup(
+                name="outbound_adapter",
+                module_prefixes=(f"{package}.storage",),
+                allowed_groups=frozenset({"domain", "application", "outbound_adapter"}),
+            ),
+            ModuleGroup(
+                name="composition_root",
+                module_prefixes=(f"{package}.runtime",),
+                allowed_groups=frozenset({
+                    "domain",
+                    "application",
+                    "inbound_adapter",
+                    "outbound_adapter",
+                    "composition_root",
+                }),
+            ),
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    ("package_name", "expected_message_parts"),
+    [
+        (
+            "domain_imports_storage",
+            (
+                "ARCH001",
+                "tests.fixtures.architecture.domain_imports_storage.domain",
+                "tests.fixtures.architecture.domain_imports_storage.storage",
+            ),
+        ),
+        (
+            "api_imports_outbound_adapter",
+            (
+                "ARCH001",
+                "tests.fixtures.architecture.api_imports_outbound_adapter.api",
+                "tests.fixtures.architecture.api_imports_outbound_adapter.storage",
+            ),
+        ),
+    ],
+)
+def test_checker_reports_fixture_boundary_violations(
+    package_name: str,
+    expected_message_parts: tuple[str, ...],
+) -> None:
+    """Forbidden fixture imports produce stable architecture diagnostics."""
+    result = check_architecture(
+        package_root=FIXTURE_ROOT / package_name,
+        package=f"tests.fixtures.architecture.{package_name}",
+        policy=_fixture_policy(package_name),
+    )
+
+    assert not result.ok
+    rendered = "\n".join(violation.render() for violation in result.violations)
+    for expected_message_part in expected_message_parts:
+        assert expected_message_part in rendered
+
+
+def test_checker_accepts_allowed_fixture_graph() -> None:
+    """Allowed fixture imports do not produce architecture violations."""
+    package_name = "allowed_case"
+
+    result = check_architecture(
+        package_root=FIXTURE_ROOT / package_name,
+        package=f"tests.fixtures.architecture.{package_name}",
+        policy=_fixture_policy(package_name),
+    )
+
+    assert result.ok
+
+
+def test_checker_accepts_composition_root_fixture_wiring() -> None:
+    """Composition roots can wire concrete inbound and outbound adapters."""
+    package_name = "composition_root_allows_wiring"
+
+    result = check_architecture(
+        package_root=FIXTURE_ROOT / package_name,
+        package=f"tests.fixtures.architecture.{package_name}",
+        policy=_fixture_policy(package_name),
+    )
+
+    assert result.ok
+
+
+def test_production_checker_accepts_scoped_packages() -> None:
+    """The scoped production package graph follows the enforced boundaries."""
+    result = check_architecture()
+
+    rendered = "\n".join(violation.render() for violation in result.violations)
+    assert result.ok, rendered

--- a/tests/test_architecture_enforcement.py
+++ b/tests/test_architecture_enforcement.py
@@ -63,6 +63,14 @@ FIXTURE_ROOT = Path(__file__).resolve().parent / "fixtures" / "architecture"
                 "tests.fixtures.architecture.api_imports_cyclic_star_reexported_outbound_adapter.storage",
             ),
         ),
+        (
+            "explicit_empty_all",
+            (
+                "ARCH001",
+                "tests.fixtures.architecture.explicit_empty_all.api",
+                "tests.fixtures.architecture.explicit_empty_all.storage",
+            ),
+        ),
     ],
 )
 def test_checker_reports_fixture_boundary_violations(

--- a/tests/test_architecture_enforcement.py
+++ b/tests/test_architecture_enforcement.py
@@ -1,7 +1,5 @@
 """Tests for hexagonal architecture enforcement."""
 
-from __future__ import annotations
-
 from pathlib import Path
 
 import pytest

--- a/tests/test_architecture_enforcement.py
+++ b/tests/test_architecture_enforcement.py
@@ -47,6 +47,14 @@ FIXTURE_ROOT = Path("tests/fixtures/architecture")
                 "tests.fixtures.architecture.api_imports_star_reexported_outbound_adapter.storage",
             ),
         ),
+        (
+            "api_imports_nested_star_reexported_outbound_adapter",
+            (
+                "ARCH001",
+                "tests.fixtures.architecture.api_imports_nested_star_reexported_outbound_adapter.api",
+                "tests.fixtures.architecture.api_imports_nested_star_reexported_outbound_adapter.storage",
+            ),
+        ),
     ],
 )
 def test_checker_reports_fixture_boundary_violations(

--- a/tests/test_architecture_enforcement.py
+++ b/tests/test_architecture_enforcement.py
@@ -9,7 +9,7 @@ from episodic.architecture import (
 )
 from episodic.architecture.checker import fixture_policy
 
-FIXTURE_ROOT = Path("tests/fixtures/architecture")
+FIXTURE_ROOT = Path(__file__).resolve().parent / "fixtures" / "architecture"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_architecture_enforcement.py
+++ b/tests/test_architecture_enforcement.py
@@ -55,6 +55,14 @@ FIXTURE_ROOT = Path("tests/fixtures/architecture")
                 "tests.fixtures.architecture.api_imports_nested_star_reexported_outbound_adapter.storage",
             ),
         ),
+        (
+            "api_imports_cyclic_star_reexported_outbound_adapter",
+            (
+                "ARCH001",
+                "tests.fixtures.architecture.api_imports_cyclic_star_reexported_outbound_adapter.api",
+                "tests.fixtures.architecture.api_imports_cyclic_star_reexported_outbound_adapter.storage",
+            ),
+        ),
     ],
 )
 def test_checker_reports_fixture_boundary_violations(

--- a/tests/test_architecture_enforcement.py
+++ b/tests/test_architecture_enforcement.py
@@ -77,6 +77,14 @@ def _fixture_policy(package_name: str) -> ArchitecturePolicy:
                 "tests.fixtures.architecture.api_imports_outbound_adapter.storage",
             ),
         ),
+        (
+            "api_imports_reexported_outbound_adapter",
+            (
+                "ARCH001",
+                "tests.fixtures.architecture.api_imports_reexported_outbound_adapter.api",
+                "tests.fixtures.architecture.api_imports_reexported_outbound_adapter.storage",
+            ),
+        ),
     ],
 )
 def test_checker_reports_fixture_boundary_violations(

--- a/tests/test_architecture_enforcement.py
+++ b/tests/test_architecture_enforcement.py
@@ -39,6 +39,14 @@ FIXTURE_ROOT = Path("tests/fixtures/architecture")
                 "tests.fixtures.architecture.api_imports_reexported_outbound_adapter.storage",
             ),
         ),
+        (
+            "api_imports_star_reexported_outbound_adapter",
+            (
+                "ARCH001",
+                "tests.fixtures.architecture.api_imports_star_reexported_outbound_adapter.api",
+                "tests.fixtures.architecture.api_imports_star_reexported_outbound_adapter.storage",
+            ),
+        ),
     ],
 )
 def test_checker_reports_fixture_boundary_violations(
@@ -54,10 +62,12 @@ def test_checker_reports_fixture_boundary_violations(
         policy=fixture_policy(package),
     )
 
-    assert not result.ok
     rendered = "\n".join(violation.render() for violation in result.violations)
+    assert not result.ok, rendered
     for expected_message_part in expected_message_parts:
-        assert expected_message_part in rendered
+        assert expected_message_part in rendered, (
+            f"expected {expected_message_part!r} in {rendered!r}"
+        )
 
 
 def test_checker_accepts_allowed_fixture_graph() -> None:
@@ -71,7 +81,8 @@ def test_checker_accepts_allowed_fixture_graph() -> None:
         policy=fixture_policy(package),
     )
 
-    assert result.ok
+    rendered = "\n".join(violation.render() for violation in result.violations)
+    assert result.ok, rendered
 
 
 def test_checker_accepts_composition_root_fixture_wiring() -> None:
@@ -85,7 +96,8 @@ def test_checker_accepts_composition_root_fixture_wiring() -> None:
         policy=fixture_policy(package),
     )
 
-    assert result.ok
+    rendered = "\n".join(violation.render() for violation in result.violations)
+    assert result.ok, rendered
 
 
 def test_production_checker_accepts_scoped_packages() -> None:

--- a/tests/test_architecture_enforcement.py
+++ b/tests/test_architecture_enforcement.py
@@ -5,55 +5,11 @@ from pathlib import Path
 import pytest
 
 from episodic.architecture import (
-    ArchitecturePolicy,
-    ModuleGroup,
     check_architecture,
 )
+from episodic.architecture.checker import fixture_policy
 
 FIXTURE_ROOT = Path("tests/fixtures/architecture")
-
-
-def _fixture_policy(package_name: str) -> ArchitecturePolicy:
-    package = f"tests.fixtures.architecture.{package_name}"
-    return ArchitecturePolicy(
-        groups=(
-            ModuleGroup(
-                name="domain",
-                module_prefixes=(f"{package}.domain",),
-                allowed_groups=frozenset({"domain"}),
-            ),
-            ModuleGroup(
-                name="application",
-                module_prefixes=(f"{package}.service",),
-                allowed_groups=frozenset({"domain", "application"}),
-            ),
-            ModuleGroup(
-                name="inbound_adapter",
-                module_prefixes=(f"{package}.api",),
-                allowed_groups=frozenset({
-                    "domain",
-                    "application",
-                    "inbound_adapter",
-                }),
-            ),
-            ModuleGroup(
-                name="outbound_adapter",
-                module_prefixes=(f"{package}.storage",),
-                allowed_groups=frozenset({"domain", "application", "outbound_adapter"}),
-            ),
-            ModuleGroup(
-                name="composition_root",
-                module_prefixes=(f"{package}.runtime",),
-                allowed_groups=frozenset({
-                    "domain",
-                    "application",
-                    "inbound_adapter",
-                    "outbound_adapter",
-                    "composition_root",
-                }),
-            ),
-        )
-    )
 
 
 @pytest.mark.parametrize(
@@ -90,10 +46,12 @@ def test_checker_reports_fixture_boundary_violations(
     expected_message_parts: tuple[str, ...],
 ) -> None:
     """Forbidden fixture imports produce stable architecture diagnostics."""
+    package = f"tests.fixtures.architecture.{package_name}"
+
     result = check_architecture(
         package_root=FIXTURE_ROOT / package_name,
-        package=f"tests.fixtures.architecture.{package_name}",
-        policy=_fixture_policy(package_name),
+        package=package,
+        policy=fixture_policy(package),
     )
 
     assert not result.ok
@@ -105,11 +63,12 @@ def test_checker_reports_fixture_boundary_violations(
 def test_checker_accepts_allowed_fixture_graph() -> None:
     """Allowed fixture imports do not produce architecture violations."""
     package_name = "allowed_case"
+    package = f"tests.fixtures.architecture.{package_name}"
 
     result = check_architecture(
         package_root=FIXTURE_ROOT / package_name,
-        package=f"tests.fixtures.architecture.{package_name}",
-        policy=_fixture_policy(package_name),
+        package=package,
+        policy=fixture_policy(package),
     )
 
     assert result.ok
@@ -118,11 +77,12 @@ def test_checker_accepts_allowed_fixture_graph() -> None:
 def test_checker_accepts_composition_root_fixture_wiring() -> None:
     """Composition roots can wire concrete inbound and outbound adapters."""
     package_name = "composition_root_allows_wiring"
+    package = f"tests.fixtures.architecture.{package_name}"
 
     result = check_architecture(
         package_root=FIXTURE_ROOT / package_name,
-        package=f"tests.fixtures.architecture.{package_name}",
-        policy=_fixture_policy(package_name),
+        package=package,
+        policy=fixture_policy(package),
     )
 
     assert result.ok

--- a/tests/test_port_contracts.py
+++ b/tests/test_port_contracts.py
@@ -1,0 +1,74 @@
+"""Architecture tests for concrete adapter port conformance."""
+
+from __future__ import annotations
+
+import inspect
+import typing as typ
+
+import httpx
+import pytest
+
+from episodic.canonical.adapters.normalizer import InMemorySourceNormalizer
+from episodic.canonical.adapters.resolver import HighestWeightConflictResolver
+from episodic.canonical.adapters.weighting import DefaultWeightingStrategy
+from episodic.canonical.ingestion_ports import (
+    ConflictResolver,
+    SourceNormalizer,
+    WeightingStrategy,
+)
+from episodic.canonical.ports import CanonicalUnitOfWork
+from episodic.canonical.storage import SqlAlchemyUnitOfWork
+from episodic.llm import OpenAICompatibleLLMAdapter, OpenAICompatibleLLMConfig
+from episodic.llm.ports import LLMPort
+
+if typ.TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+
+@pytest.mark.asyncio
+async def test_sqlalchemy_unit_of_work_satisfies_canonical_port(
+    session_factory: object,
+) -> None:
+    """The SQLAlchemy UoW exposes the canonical persistence port surface."""
+    factory = typ.cast("async_sessionmaker[AsyncSession]", session_factory)
+
+    async with SqlAlchemyUnitOfWork(factory) as uow:
+        assert isinstance(uow, CanonicalUnitOfWork)
+        assert inspect.iscoroutinefunction(uow.commit)
+        assert inspect.iscoroutinefunction(uow.rollback)
+        assert inspect.iscoroutinefunction(uow.flush)
+        assert uow.series_profiles is not None
+        assert uow.reference_bindings is not None
+
+
+def test_ingestion_adapters_satisfy_public_ports() -> None:
+    """Concrete ingestion adapters satisfy their public protocol contracts."""
+    normalizer = InMemorySourceNormalizer()
+    weighting_strategy = DefaultWeightingStrategy(min_parallel_items=999_999)
+    resolver = HighestWeightConflictResolver()
+
+    assert isinstance(normalizer, SourceNormalizer)
+    assert inspect.iscoroutinefunction(normalizer.normalize)
+    assert isinstance(weighting_strategy, WeightingStrategy)
+    assert inspect.iscoroutinefunction(weighting_strategy.compute_weights)
+    assert isinstance(resolver, ConflictResolver)
+    assert inspect.iscoroutinefunction(resolver.resolve)
+
+
+@pytest.mark.asyncio
+async def test_openai_compatible_adapter_satisfies_llm_port() -> None:
+    """The OpenAI-compatible adapter exposes the provider-neutral LLM port."""
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda _request: httpx.Response(200, json={})),
+        base_url="https://example.test/v1",
+    ) as client:
+        adapter = OpenAICompatibleLLMAdapter(
+            config=OpenAICompatibleLLMConfig(
+                base_url="https://example.test/v1",
+                api_key="test-key",
+            ),
+            client=client,
+        )
+
+        assert isinstance(adapter, LLMPort)
+        assert inspect.iscoroutinefunction(adapter.generate)

--- a/tests/test_port_contracts.py
+++ b/tests/test_port_contracts.py
@@ -31,12 +31,16 @@ async def test_sqlalchemy_unit_of_work_satisfies_canonical_port(
     factory = typ.cast("async_sessionmaker[AsyncSession]", session_factory)
 
     async with SqlAlchemyUnitOfWork(factory) as uow:
-        assert isinstance(uow, CanonicalUnitOfWork)
-        assert inspect.iscoroutinefunction(uow.commit)
-        assert inspect.iscoroutinefunction(uow.rollback)
-        assert inspect.iscoroutinefunction(uow.flush)
-        assert uow.series_profiles is not None
-        assert uow.reference_bindings is not None
+        assert isinstance(uow, CanonicalUnitOfWork), "uow must be a CanonicalUnitOfWork"
+        assert inspect.iscoroutinefunction(uow.commit), "uow.commit must be a coroutine"
+        assert inspect.iscoroutinefunction(uow.rollback), (
+            "uow.rollback must be a coroutine"
+        )
+        assert inspect.iscoroutinefunction(uow.flush), "uow.flush must be a coroutine"
+        assert uow.series_profiles is not None, "uow.series_profiles must be exposed"
+        assert uow.reference_bindings is not None, (
+            "uow.reference_bindings must be exposed"
+        )
 
 
 def test_ingestion_adapters_satisfy_public_ports() -> None:
@@ -45,12 +49,22 @@ def test_ingestion_adapters_satisfy_public_ports() -> None:
     weighting_strategy = DefaultWeightingStrategy(min_parallel_items=999_999)
     resolver = HighestWeightConflictResolver()
 
-    assert isinstance(normalizer, SourceNormalizer)
-    assert inspect.iscoroutinefunction(normalizer.normalize)
-    assert isinstance(weighting_strategy, WeightingStrategy)
-    assert inspect.iscoroutinefunction(weighting_strategy.compute_weights)
-    assert isinstance(resolver, ConflictResolver)
-    assert inspect.iscoroutinefunction(resolver.resolve)
+    assert isinstance(normalizer, SourceNormalizer), (
+        "normalizer must be a SourceNormalizer"
+    )
+    assert inspect.iscoroutinefunction(normalizer.normalize), (
+        "normalizer.normalize must be a coroutine"
+    )
+    assert isinstance(weighting_strategy, WeightingStrategy), (
+        "weighting_strategy must be a WeightingStrategy"
+    )
+    assert inspect.iscoroutinefunction(weighting_strategy.compute_weights), (
+        "weighting_strategy.compute_weights must be a coroutine"
+    )
+    assert isinstance(resolver, ConflictResolver), "resolver must be a ConflictResolver"
+    assert inspect.iscoroutinefunction(resolver.resolve), (
+        "resolver.resolve must be a coroutine"
+    )
 
 
 @pytest.mark.asyncio
@@ -68,5 +82,7 @@ async def test_openai_compatible_adapter_satisfies_llm_port() -> None:
             client=client,
         )
 
-        assert isinstance(adapter, LLMPort)
-        assert inspect.iscoroutinefunction(adapter.generate)
+        assert isinstance(adapter, LLMPort), "adapter must be an LLMPort"
+        assert inspect.iscoroutinefunction(adapter.generate), (
+            "adapter.generate must be a coroutine"
+        )

--- a/tests/test_port_contracts.py
+++ b/tests/test_port_contracts.py
@@ -1,7 +1,5 @@
 """Architecture tests for concrete adapter port conformance."""
 
-from __future__ import annotations
-
 import inspect
 import typing as typ
 


### PR DESCRIPTION
## Summary
Adds ExecPlan 1-5-4: Implement architectural enforcement for hexagonal boundaries. This plan introduces a repo-local architecture-checking layer and an associated execution plan to automate boundary enforcement across Episodic’s hexagonal architecture. The plan outlines constraints, tolerances, risks, staged milestones, and documentation updates to guide implementation and validation.

## Changes
- Add docs/execplans/1-5-4-architectural-enforcement-for-hexagonal-boundaries.md containing the full execution plan for hexagonal-architecture enforcement, including constraints, tolerances, risks, progress, decision log, and outcomes.

## Rationale
- Move from convention-based enforcement to automated, reproducible checks that verify adapters conform to published port contracts and respect hexagonal boundaries.
- Establish a staged rollout (1.5.4 core checker, with 2.4.5 extending to orchestration) to align with existing roadmap sequencing.
- Integrate with existing CI/lint/test gates once implemented, providing clear diagnostics for violations and wiring issues.

## Implementation plan (Stage A–F)
- Stage A: Define first enforced module map and red tests
  - Create initial unit tests and architecture-fixture packages to express allowed and forbidden import graphs.
  - Add a red-phase example highlighting current boundary leaks (e.g., canonical/profile_templates/helpers.py and canonical/reference_documents/bindings.py).
- Stage B: Implement repo-local architecture checker and Makefile wiring
  - Build a self-contained checker (using ast) to analyze repo-local imports and enforce the first policy set.
  - Add a Makefile target (check-architecture) and integrate with make lint.
- Stage C: Remove current boundary leaks and enable the scoped production gate
  - Address leaks identified in Stage A and justify any temporary allowlists with ADRs.
  - Ensure production packages pass the checker locally.
- Stage D: Add runtime-checkable port contract tests
  - Mark relevant public ports as @runtime_checkable and add tests to verify adapters satisfy port contracts.
- Stage E: Wire CI and update documentation set
  - Expose architecture checks in CI, add ADR documenting the approach, and update design/guides to reflect the new enforcement model.
- Stage F: Run full validation gates
  - Execute the complete gate sequence (fmt, typecheck, lint, test, markdownlint, nixie) and update docs accordingly.

## Progress and milestones (as planned in the ExecPlan)
- The ExecPlan specifies a staged path with clear entry points for tests, checker implementation, and CI integration.
- It also documents the expected outcomes, decision logs, and risk mitigations to guide future work and governance.

## Risks and mitigations
- Boundary leaks in current canonical helpers may trigger early failures; mitigations include targeted refactors and explicit allowlists tied to ADRs.
- Composition-root exceptions must be modeled accurately to avoid false positives; plan uses explicit exception groups and staged rollout.
- Public ports may require runtime assertions; ADRs will clarify which protocols are runtime-checkable.

## Documentation impact
- Plan calls for ADR ADR-005 hexagonal-architecture-enforcement and updates to relevant docs (system design, developers guide, users guide, and roadmap) once Stage E completes.

## Testing plan
- Stage A/B will introduce red tests and fixture scenarios validated against the checker.
- Stage D will add runtime port-contract tests and ensure adapters satisfy public ports without regressions.
- CI will surface the architecture gate once implemented.

## Acceptance criteria
- The ExecPlan is committed and visible in the repo.
- The architecture checker is designed to run locally and in CI, wired into linting workflow.
- Planned tests (architecture tests and BDD scenarios) are defined and ready for Stage A.
- Documentation updates (ADR and guides) are outlined for Stage E.

## How to review
- Review the proposed module map, the first set of rules, and the staged rollout.
- Pay particular attention to explicit composition-root exceptions and the proposed diagnostic messages.
- Confirm alignment with the hexagonal-architecture constraints already described in existing design documents and roadmap.

## Context
This ExecPlan aligns with roadmap items for architectural enforcement and aims to provide a solid foundation for future, deeper enforcement (e.g., LangGraph nodes, Celery tasks) in Stage 2.4.5, while delivering a practical, repo-local checker in Stage 1.5.4.


◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/413d8de9-8c8a-4e9e-b15f-3911cc991a44

## Summary by Sourcery

Documentation:
- Add an ExecPlan document detailing staged implementation, risks, constraints, and validation steps for hexagonal-architecture enforcement checks.