### PR TITLE
Implement LangGraph suspend-and-resume orchestration (2.4.2)

### DIFF
--- a/alembic/versions/20260508_000008_add_workflow_checkpoints.py
+++ b/alembic/versions/20260508_000008_add_workflow_checkpoints.py
@@ -1,0 +1,60 @@
+"""Add workflow checkpoints for resumable orchestration."""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "20260508_000008"
+down_revision = "20260322_000007"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create the workflow_checkpoints table."""
+    op.create_table(
+        "workflow_checkpoints",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("workflow_id", sa.String(length=160), nullable=False),
+        sa.Column("workflow_type", sa.String(length=120), nullable=False),
+        sa.Column("step_name", sa.String(length=120), nullable=False),
+        sa.Column("idempotency_key", sa.String(length=512), nullable=False),
+        sa.Column("payload", postgresql.JSONB, nullable=False),
+        sa.Column(
+            "status",
+            sa.String(length=80),
+            server_default="suspended",
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "idempotency_key",
+            name="uq_workflow_checkpoints_idempotency_key",
+        ),
+    )
+    op.create_index(
+        "ix_workflow_checkpoints_workflow_id",
+        "workflow_checkpoints",
+        ["workflow_id"],
+    )
+
+
+def downgrade() -> None:
+    """Drop the workflow_checkpoints table."""
+    op.drop_index(
+        "ix_workflow_checkpoints_workflow_id",
+        table_name="workflow_checkpoints",
+    )
+    op.drop_table("workflow_checkpoints")

--- a/alembic/versions/20260508_000008_add_workflow_checkpoints.py
+++ b/alembic/versions/20260508_000008_add_workflow_checkpoints.py
@@ -11,8 +11,18 @@ branch_labels = None
 depends_on = None
 
 
+def _workflow_checkpoint_status_enum() -> postgresql.ENUM:
+    return postgresql.ENUM(
+        "suspended",
+        "resumed",
+        name="workflow_checkpoint_status",
+        create_type=False,
+    )
+
+
 def upgrade() -> None:
     """Create the workflow_checkpoints table."""
+    _workflow_checkpoint_status_enum().create(op.get_bind(), checkfirst=True)
     op.create_table(
         "workflow_checkpoints",
         sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
@@ -23,7 +33,7 @@ def upgrade() -> None:
         sa.Column("payload", postgresql.JSONB, nullable=False),
         sa.Column(
             "status",
-            sa.String(length=80),
+            _workflow_checkpoint_status_enum(),
             server_default="suspended",
             nullable=False,
         ),
@@ -49,12 +59,37 @@ def upgrade() -> None:
         "workflow_checkpoints",
         ["workflow_id"],
     )
+    op.execute(
+        """
+        CREATE FUNCTION update_workflow_checkpoints_updated_at()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            NEW.updated_at = NOW();
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+    op.execute(
+        """
+        CREATE TRIGGER update_workflow_checkpoints_updated_at
+        BEFORE UPDATE ON workflow_checkpoints
+        FOR EACH ROW
+        EXECUTE FUNCTION update_workflow_checkpoints_updated_at();
+        """
+    )
 
 
 def downgrade() -> None:
     """Drop the workflow_checkpoints table."""
+    op.execute(
+        "DROP TRIGGER IF EXISTS update_workflow_checkpoints_updated_at "
+        "ON workflow_checkpoints;"
+    )
+    op.execute("DROP FUNCTION IF EXISTS update_workflow_checkpoints_updated_at();")
     op.drop_index(
         "ix_workflow_checkpoints_workflow_id",
         table_name="workflow_checkpoints",
     )
     op.drop_table("workflow_checkpoints")
+    _workflow_checkpoint_status_enum().drop(op.get_bind(), checkfirst=True)

--- a/docs/adr/adr-007-durable-generation-checkpoints.md
+++ b/docs/adr/adr-007-durable-generation-checkpoints.md
@@ -1,0 +1,53 @@
+# ADR-007: Durable generation checkpoints
+
+## Status
+
+Accepted
+
+## Context
+
+Roadmap item `2.4.2` requires LangGraph orchestration to suspend and resume
+reliably. The existing `2.4.1` implementation has a narrow in-process graph
+that plans, executes one tool step, and aggregates the result. It does not
+persist graph state or provide an idempotency contract around suspendable steps.
+
+The design documents already name `CheckpointPort` and `TaskResumePort` as the
+orchestration boundaries. The implementation must keep LangGraph, SQLAlchemy,
+Celery, and provider adapters separated by those ports.
+
+## Decision
+
+Persist suspended generation workflows as platform-owned `WorkflowCheckpoint`
+records in the `workflow_checkpoints` table.
+
+The graph stores a checkpoint after planning and before the first
+side-effecting execution step. The checkpoint payload contains the
+orchestration request metadata and planner result as provider-neutral fields.
+The graph returns `SuspendedWorkflowResult` with the checkpoint id, workflow
+id, step name, and idempotency key. Resume accepts `ResumeWorkflowCommand`,
+obtains the external task result through `TaskResumePort`, rebuilds the planner
+state from the checkpoint, and aggregates a `GenerationOrchestrationResult`.
+
+Idempotency keys are deterministic strings built from workflow id, workflow
+type, step name, action id, and retry attempt. `CheckpointPort.save(...)`
+preserves the first checkpoint recorded for a key and returns it to repeated
+callers.
+
+## Consequences
+
+- The graph can prove suspend/resume behaviour without exposing LangGraph
+  checkpoint classes in public contracts.
+- Durable checkpoint state survives fresh unit-of-work and graph instances.
+- Queue routing remains a later concern; `TaskResumePort` is the seam that
+  future Celery callbacks will use.
+- Planning may run again on repeated suspend attempts in this slice, but the
+  side-effecting execution step is deduplicated by the checkpoint key.
+
+## References
+
+- Roadmap item `2.4.2` — `docs/roadmap.md`
+- ExecPlan —
+  `docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md`
+- Implementation — `episodic/orchestration/langgraph.py`,
+  `episodic/orchestration/checkpoints.py`,
+  `episodic/canonical/storage/workflow_checkpoints.py`

--- a/docs/adr/adr-007-durable-generation-checkpoints.md
+++ b/docs/adr/adr-007-durable-generation-checkpoints.md
@@ -30,17 +30,17 @@ state from the checkpoint, and aggregates a `GenerationOrchestrationResult`.
 Idempotency keys are deterministic strings built from workflow id, workflow
 type, step name, action id, and retry attempt. The key fields are grouped in
 `WorkflowStepIdentity` so step identity validation stays explicit without long
-argument lists. `CheckpointPort.save(...)` preserves the first checkpoint
-recorded for a key and returns it to repeated callers. After a successful
-resume, `CheckpointPort.mark_resumed(...)` moves the checkpoint status from
-`suspended` to `resumed` so cleanup and monitoring code can distinguish active
-work from completed resume handoffs.
+argument lists. `CheckpointPort.save_or_reuse(...)` preserves the first
+checkpoint recorded for a key and returns it to repeated callers. After a
+successful resume, `CheckpointPort.mark_resumed(...)` moves the checkpoint
+status from `suspended` to `resumed` so cleanup and monitoring code can
+distinguish active work from completed resume handoffs.
 
-The in-memory adapter serialises `save(...)` mutations with an `asyncio.Lock`
-and uses an injected clock. The durable SQLAlchemy adapter lets the database
-unique constraint arbitrate concurrency: it attempts to insert the checkpoint
-inside a savepoint, then loads the existing checkpoint only when the insert
-hits the idempotency-key constraint.
+The in-memory adapter serialises `save_or_reuse(...)` mutations with an
+`asyncio.Lock` and uses an injected clock. The durable SQLAlchemy adapter lets
+the database unique constraint arbitrate concurrency: it attempts to insert the
+checkpoint inside a savepoint, then loads the existing checkpoint only when the
+insert hits the idempotency-key constraint.
 
 ## Consequences
 
@@ -63,6 +63,7 @@ hits the idempotency-key constraint.
   `episodic/orchestration/checkpoints.py`,
   `episodic/canonical/storage/workflow_checkpoints.py`
 
+# ADR-007: Durable generation checkpoints
 # ADR-007: Durable generation checkpoints
 
 # ADR-007: Durable generation checkpoints

--- a/docs/adr/adr-007-durable-generation-checkpoints.md
+++ b/docs/adr/adr-007-durable-generation-checkpoints.md
@@ -1,4 +1,4 @@
-# ADR-007: Durable generation checkpoints
+# Architecture Decision Record (ADR)-007: Durable generation checkpoints
 
 ## Status
 

--- a/docs/adr/adr-007-durable-generation-checkpoints.md
+++ b/docs/adr/adr-007-durable-generation-checkpoints.md
@@ -1,4 +1,5 @@
 # ADR-007: Durable generation checkpoints
+
 ## Status
 
 Accepted
@@ -62,8 +63,3 @@ insert hits the idempotency-key constraint.
 - Implementation — `episodic/orchestration/langgraph.py`,
   `episodic/orchestration/checkpoints.py`,
   `episodic/canonical/storage/workflow_checkpoints.py`
-
-# ADR-007: Durable generation checkpoints
-# ADR-007: Durable generation checkpoints
-
-# ADR-007: Durable generation checkpoints

--- a/docs/adr/adr-007-durable-generation-checkpoints.md
+++ b/docs/adr/adr-007-durable-generation-checkpoints.md
@@ -1,5 +1,4 @@
 # ADR-007: Durable generation checkpoints
-
 ## Status
 
 Accepted
@@ -30,9 +29,12 @@ state from the checkpoint, and aggregates a `GenerationOrchestrationResult`.
 
 Idempotency keys are deterministic strings built from workflow id, workflow
 type, step name, action id, and retry attempt. The key fields are grouped in
-`WorkflowStepIdentity` so step identity validation stays explicit without
-long argument lists. `CheckpointPort.save(...)` preserves the first checkpoint
-recorded for a key and returns it to repeated callers.
+`WorkflowStepIdentity` so step identity validation stays explicit without long
+argument lists. `CheckpointPort.save(...)` preserves the first checkpoint
+recorded for a key and returns it to repeated callers. After a successful
+resume, `CheckpointPort.mark_resumed(...)` moves the checkpoint status from
+`suspended` to `resumed` so cleanup and monitoring code can distinguish active
+work from completed resume handoffs.
 
 The in-memory adapter serialises `save(...)` mutations with an `asyncio.Lock`
 and uses an injected clock. The durable SQLAlchemy adapter lets the database
@@ -60,5 +62,7 @@ hits the idempotency-key constraint.
 - Implementation — `episodic/orchestration/langgraph.py`,
   `episodic/orchestration/checkpoints.py`,
   `episodic/canonical/storage/workflow_checkpoints.py`
+
+# ADR-007: Durable generation checkpoints
 
 # ADR-007: Durable generation checkpoints

--- a/docs/adr/adr-007-durable-generation-checkpoints.md
+++ b/docs/adr/adr-007-durable-generation-checkpoints.md
@@ -29,9 +29,16 @@ obtains the external task result through `TaskResumePort`, rebuilds the planner
 state from the checkpoint, and aggregates a `GenerationOrchestrationResult`.
 
 Idempotency keys are deterministic strings built from workflow id, workflow
-type, step name, action id, and retry attempt. `CheckpointPort.save(...)`
-preserves the first checkpoint recorded for a key and returns it to repeated
-callers.
+type, step name, action id, and retry attempt. The key fields are grouped in
+`WorkflowStepIdentity` so step identity validation stays explicit without
+long argument lists. `CheckpointPort.save(...)` preserves the first checkpoint
+recorded for a key and returns it to repeated callers.
+
+The in-memory adapter serialises `save(...)` mutations with an `asyncio.Lock`
+and uses an injected clock. The durable SQLAlchemy adapter lets the database
+unique constraint arbitrate concurrency: it attempts to insert the checkpoint
+inside a savepoint, then loads the existing checkpoint only when the insert
+hits the idempotency-key constraint.
 
 ## Consequences
 
@@ -42,6 +49,8 @@ callers.
   future Celery callbacks will use.
 - Planning may run again on repeated suspend attempts in this slice, but the
   side-effecting execution step is deduplicated by the checkpoint key.
+- The in-memory adapter is suitable for tests and local demos only. It has no
+  eviction policy and no cross-process coordination.
 
 ## References
 
@@ -51,3 +60,5 @@ callers.
 - Implementation — `episodic/orchestration/langgraph.py`,
   `episodic/orchestration/checkpoints.py`,
   `episodic/canonical/storage/workflow_checkpoints.py`
+
+# ADR-007: Durable generation checkpoints

--- a/docs/adr/adr-007-durable-generation-checkpoints.md
+++ b/docs/adr/adr-007-durable-generation-checkpoints.md
@@ -37,7 +37,7 @@ successful resume, `CheckpointPort.mark_resumed(...)` moves the checkpoint
 status from `suspended` to `resumed` so cleanup and monitoring code can
 distinguish active work from completed resume handoffs.
 
-The in-memory adapter serialises `save_or_reuse(...)` mutations with an
+The in-memory adapter serializes `save_or_reuse(...)` mutations with an
 `asyncio.Lock` and uses an injected clock. The durable SQLAlchemy adapter lets
 the database unique constraint arbitrate concurrency: it attempts to insert the
 checkpoint inside a savepoint, then loads the existing checkpoint only when the

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -659,7 +659,7 @@ Roadmap item `2.4.1` introduces a dedicated orchestration package in
 - `episodic/orchestration/_dto.py` contains the orchestration DTOs and shared
   checkpoint DTOs.
 - `episodic/orchestration/_protocols.py` contains the planner, executor,
-  checkpoint, and resume ports that keep graph policy independent from storage,
+  checkpoint, and resume ports that keep graph policy independent of storage,
   queue, and provider adapters.
 - `episodic/orchestration/generation.py` implements and exports
   `StructuredGenerationPlanner`, `StructuredPlanningOrchestrator`, and the

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -657,11 +657,14 @@ Roadmap item `2.4.1` introduces a dedicated orchestration package in
 ### Package structure
 
 - `episodic/orchestration/_dto.py` contains the orchestration DTOs and shared
-  port protocols.
+  checkpoint DTOs.
+- `episodic/orchestration/_protocols.py` contains the planner, executor,
+  checkpoint, and resume ports that keep graph policy independent from storage,
+  queue, and provider adapters.
 - `episodic/orchestration/generation.py` implements and exports
   `StructuredGenerationPlanner`, `StructuredPlanningOrchestrator`, and the
-  orchestration result builder. It also re-exports `ToolExecutorPort` from the
-  DTO module.
+  orchestration result builder. It also re-exports the orchestration ports and
+  checkpoint DTOs.
 - `episodic/orchestration/_show_notes_executor.py` contains the concrete
   `ShowNotesToolExecutor` implementation.
 - `episodic/orchestration/langgraph.py` contains the in-process LangGraph path
@@ -685,7 +688,14 @@ Roadmap item `2.4.1` introduces a dedicated orchestration package in
   results through `TaskResumePort`. Do not import SQLAlchemy, Celery, Falcon,
   or provider adapters into graph nodes.
 - Build idempotency keys with `build_workflow_step_idempotency_key(...)` from
-  workflow id, workflow type, step name, action id, and retry attempt.
+  a `WorkflowStepIdentity` and retry attempt.
+- In-memory checkpoints are for tests only. They use an injected clock and an
+  `asyncio.Lock` to model first-write-wins idempotency, but they do not evict
+  entries or coordinate across processes.
+- Durable checkpoints rely on the `workflow_checkpoints.idempotency_key`
+  uniqueness constraint. The SQLAlchemy adapter attempts the insert first and
+  falls back to loading the existing row only when the database reports a
+  duplicate key.
 - Treat `ShowNotesToolExecutor` as the first tool adapter, not as a special
   case that other orchestration code may import around.
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -687,8 +687,10 @@ Roadmap item `2.4.1` introduces a dedicated orchestration package in
 - Persist suspend state through `CheckpointPort` and resume external task
   results through `TaskResumePort`. Do not import SQLAlchemy, Celery, Falcon,
   or provider adapters into graph nodes.
-- Build idempotency keys with `build_workflow_step_idempotency_key(...)` from
-  a `WorkflowStepIdentity` and retry attempt.
+- Build idempotency keys by constructing a `WorkflowStepIdentity` containing
+  the workflow id, workflow type, step name, and action id, then passing that
+  identity plus a separate `attempt` retry count to
+  `build_workflow_step_idempotency_key(...)`.
 - In-memory checkpoints are for tests only. They use an injected clock and an
   `asyncio.Lock` to model first-write-wins idempotency, but they do not evict
   entries or coordinate across processes.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -665,7 +665,12 @@ Roadmap item `2.4.1` introduces a dedicated orchestration package in
 - `episodic/orchestration/_show_notes_executor.py` contains the concrete
   `ShowNotesToolExecutor` implementation.
 - `episodic/orchestration/langgraph.py` contains the in-process LangGraph path
-  used for `plan -> execute -> finish`.
+  used for `plan -> execute -> finish` and the checkpointing path that pauses
+  after planning.
+- `episodic/orchestration/checkpoints.py` contains the in-memory checkpoint
+  adapter used by fast tests.
+- `episodic/canonical/storage/workflow_checkpoints.py` contains the SQLAlchemy
+  adapter for durable checkpoint persistence.
 
 ### Maintainer rules
 
@@ -676,6 +681,11 @@ Roadmap item `2.4.1` introduces a dedicated orchestration package in
 - Keep LangGraph nodes dependent on ports and orchestration DTOs only. Tool
   implementations may call generation services, but the graph should see only
   `ToolExecutorPort`.
+- Persist suspend state through `CheckpointPort` and resume external task
+  results through `TaskResumePort`. Do not import SQLAlchemy, Celery, Falcon,
+  or provider adapters into graph nodes.
+- Build idempotency keys with `build_workflow_step_idempotency_key(...)` from
+  workflow id, workflow type, step name, action id, and retry attempt.
 - Treat `ShowNotesToolExecutor` as the first tool adapter, not as a special
   case that other orchestration code may import around.
 
@@ -694,6 +704,9 @@ Roadmap item `2.4.1` introduces a dedicated orchestration package in
   responses from one OpenAI-compatible endpoint: the first for structured
   planning, and the second for the show-notes tool call. Keep that fixture
   model-driven so prompt wording can evolve without breaking the scenario.
+- Durable checkpoint coverage lives in
+  `tests/canonical_storage/test_workflow_checkpoints.py` and uses py-pglite via
+  the migrated SQLAlchemy fixtures.
 
 ## LLM adapter boundary
 

--- a/docs/episodic-podcast-generation-system-design.md
+++ b/docs/episodic-podcast-generation-system-design.md
@@ -548,6 +548,61 @@ duplicate-key conflict. The in-memory checkpoint adapter models the same
 first-write-wins contract for tests with an `asyncio.Lock` and an injected
 clock, but remains unbounded and process-local.
 
+```mermaid
+sequenceDiagram
+    actor Client
+    participant Orchestrator as StructuredPlanningOrchestrator
+    participant LangGraph as GenerationGraph
+    participant Planner as PlannerPort
+    participant Checkpoints as CheckpointPort
+
+    Client->>Orchestrator: start_generation(request)
+    Orchestrator->>LangGraph: run(request, checkpoint_port)
+
+    LangGraph->>Planner: plan(request)
+    Planner-->>LangGraph: PlannerResult
+
+    LangGraph->>Checkpoints: get_by_idempotency_key(step_idempotency_key)
+    Checkpoints-->>LangGraph: WorkflowCheckpoint | None
+
+    alt checkpoint does not exist
+        LangGraph->>Checkpoints: save(WorkflowCheckpoint)
+        Checkpoints-->>LangGraph: WorkflowCheckpoint
+    end
+
+    LangGraph-->>Orchestrator: SuspendedWorkflowResult
+    Orchestrator-->>Client: SuspendedWorkflowResult
+```
+
+Figure: Suspend flow for a generation workflow that persists or reuses a
+checkpoint before side-effecting execution.
+
+```mermaid
+sequenceDiagram
+    actor Client
+    participant Orchestrator as GenerationOrchestrationLayer
+    participant Checkpoints as CheckpointPort
+    participant ResumePort as TaskResumePort
+
+    Client->>Orchestrator: resume_generation(ResumeWorkflowCommand)
+
+    Orchestrator->>Checkpoints: get(checkpoint_id)
+    Checkpoints-->>Orchestrator: WorkflowCheckpoint | None
+
+    alt checkpoint unknown
+        Orchestrator-->>Client: ValueError
+    else checkpoint found
+        Orchestrator->>ResumePort: resume(ResumeWorkflowCommand)
+        ResumePort-->>Orchestrator: ActionExecutionResult
+
+        Orchestrator->>Orchestrator: build_generation_result(PlannerResult, ActionExecutionResult)
+        Orchestrator-->>Client: GenerationOrchestrationResult
+    end
+```
+
+Figure: Resume flow for a suspended generation workflow that either rejects an
+unknown checkpoint or aggregates the resumed action result.
+
 #### Inference strategy and tool integration
 
 Planning uses structured output to produce a task plan with explicit

--- a/docs/episodic-podcast-generation-system-design.md
+++ b/docs/episodic-podcast-generation-system-design.md
@@ -564,13 +564,8 @@ sequenceDiagram
     LangGraph->>Planner: plan(request)
     Planner-->>LangGraph: PlannerResult
 
-    LangGraph->>Checkpoints: get_by_idempotency_key(step_idempotency_key)
-    Checkpoints-->>LangGraph: WorkflowCheckpoint | None
-
-    alt checkpoint does not exist
-        LangGraph->>Checkpoints: save(WorkflowCheckpoint)
-        Checkpoints-->>LangGraph: WorkflowCheckpoint
-    end
+    LangGraph->>Checkpoints: save_or_reuse(WorkflowCheckpoint)
+    Checkpoints-->>LangGraph: WorkflowCheckpoint
 
     LangGraph-->>Orchestrator: SuspendedWorkflowResult
     Orchestrator-->>Client: SuspendedWorkflowResult

--- a/docs/episodic-podcast-generation-system-design.md
+++ b/docs/episodic-podcast-generation-system-design.md
@@ -546,7 +546,9 @@ own repositories. Durable checkpoint writes rely on the database uniqueness
 constraint for idempotency and query the existing checkpoint only after a
 duplicate-key conflict. The in-memory checkpoint adapter models the same
 first-write-wins contract for tests with an `asyncio.Lock` and an injected
-clock, but remains unbounded and process-local.
+clock, but remains unbounded and process-local. Successful resume calls mark
+the stored checkpoint as `resumed` through `CheckpointPort` after the action
+result has been folded into the generation result.
 
 ```mermaid
 sequenceDiagram
@@ -596,6 +598,8 @@ sequenceDiagram
         ResumePort-->>Orchestrator: ActionExecutionResult
 
         Orchestrator->>Orchestrator: build_generation_result(PlannerResult, ActionExecutionResult)
+        Orchestrator->>Checkpoints: mark_resumed(checkpoint_id)
+        Checkpoints-->>Orchestrator: WorkflowCheckpoint
         Orchestrator-->>Client: GenerationOrchestrationResult
     end
 ```

--- a/docs/episodic-podcast-generation-system-design.md
+++ b/docs/episodic-podcast-generation-system-design.md
@@ -542,7 +542,11 @@ step, returns a `SuspendedWorkflowResult`, and later accepts a
 `ResumeWorkflowCommand` through `TaskResumePort` to aggregate the final
 generation result. Checkpoint payloads contain orchestration state and
 provider-neutral DTO fields only; canonical episode artefacts remain in their
-own repositories.
+own repositories. Durable checkpoint writes rely on the database uniqueness
+constraint for idempotency and query the existing checkpoint only after a
+duplicate-key conflict. The in-memory checkpoint adapter models the same
+first-write-wins contract for tests with an `asyncio.Lock` and an injected
+clock, but remains unbounded and process-local.
 
 #### Inference strategy and tool integration
 

--- a/docs/episodic-podcast-generation-system-design.md
+++ b/docs/episodic-podcast-generation-system-design.md
@@ -550,6 +550,9 @@ clock, but remains unbounded and process-local. Successful resume calls mark
 the stored checkpoint as `resumed` through `CheckpointPort` after the action
 result has been folded into the generation result.
 
+Screen reader description: Suspend flow that persists or reuses a checkpoint
+before side-effecting execution.
+
 ```mermaid
 sequenceDiagram
     actor Client
@@ -573,6 +576,10 @@ sequenceDiagram
 
 Figure: Suspend flow for a generation workflow that persists or reuses a
 checkpoint before side-effecting execution.
+
+Screen reader description: Resume path where checkpoint lookup rejects unknown
+IDs, known checkpoints resume through `TaskResumePort`, and the final
+generation result is built before marking the checkpoint resumed.
 
 ```mermaid
 sequenceDiagram

--- a/docs/episodic-podcast-generation-system-design.md
+++ b/docs/episodic-podcast-generation-system-design.md
@@ -13,6 +13,7 @@ Accepted decision records:
 - [ADR 004: Show-notes TEI representation](adr/adr-004-show-notes-tei-representation.md)
 - [ADR 005: Structured planning and tool execution for generation orchestration](adr/adr-005-structured-planning-and-tool-execution.md)
 - [ADR 006: Hexagonal architecture enforcement](adr/adr-006-hexagonal-architecture-enforcement.md)
+- [ADR 007: Durable generation checkpoints](adr/adr-007-durable-generation-checkpoints.md)
 
 ## Overview
 
@@ -533,6 +534,15 @@ In the current worker scaffold, representative Celery tasks use injected
 callable seams instead of importing concrete adapters directly. Future task
 implementations should preserve this pattern by resolving storage, LLM, and
 other infrastructure through ports or composition-root-owned dependencies.
+
+The first durable content-generation checkpoint implementation stores
+`WorkflowCheckpoint` records in `workflow_checkpoints`. The graph persists the
+planner result and routing metadata before the first side-effecting execution
+step, returns a `SuspendedWorkflowResult`, and later accepts a
+`ResumeWorkflowCommand` through `TaskResumePort` to aggregate the final
+generation result. Checkpoint payloads contain orchestration state and
+provider-neutral DTO fields only; canonical episode artefacts remain in their
+own repositories.
 
 #### Inference strategy and tool integration
 

--- a/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md
+++ b/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md
@@ -747,7 +747,7 @@ payload keys to the documented `TypeError` contract. Validation passed with
 focused orchestration tests, `make check-fmt`, `make typecheck`, `make lint`,
 and `make test`; the full test suite reported 461 passed and 3 skipped tests.
 
-Revision note 2026-05-13: Review follow-up verified and fixed the remaining
+Revision note 2026-05-12: Review follow-up verified and fixed the remaining
 checkpoint persistence issues: the migration now creates a DB-side
 `updated_at` trigger, checkpoint status is backed by the
 `WorkflowCheckpointStatus` enum in the domain and SQLAlchemy model, plan

--- a/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md
+++ b/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md
@@ -427,8 +427,8 @@ class TaskResumePort(typ.Protocol):
     async def resume(
         self,
         command: ResumeWorkflowCommand,
-    ) -> GenerationOrchestrationResult | SuspendedWorkflowResult:
-        """Resume a suspended generation workflow from a checkpoint."""
+    ) -> ActionExecutionResult:
+        """Return the externally supplied result for a suspended task."""
 ```
 
 The exact signatures may evolve during implementation, but the key boundary is
@@ -656,8 +656,8 @@ class TaskResumePort(typ.Protocol):
     async def resume(
         self,
         command: ResumeWorkflowCommand,
-    ) -> GenerationOrchestrationResult | SuspendedWorkflowResult:
-        """Resume a suspended generation workflow from a checkpoint."""
+    ) -> ActionExecutionResult:
+        """Return the externally supplied result for a suspended task."""
 ```
 
 The exact method names may change if the implementation discovers a cleaner
@@ -675,3 +675,11 @@ Revision note 2026-05-08: Added validation evidence for the planning-only
 change and recorded the formatter-target discovery. This does not change the
 implementation sequence, but it gives the next implementer the exact branch
 gate status and a known documentation tooling caveat.
+
+Revision note 2026-05-10: Follow-up review fixes added richer suspend/resume
+module documentation, documented `resume_generation_orchestration` error
+paths, injected the in-memory checkpoint clock, serialised in-memory
+checkpoint saves with an `asyncio.Lock`, and changed the SQLAlchemy checkpoint
+adapter to insert first and query only after duplicate-key conflicts. Added
+missing unknown-checkpoint, concurrent in-memory save, checkpoint payload
+property, and checkpoint payload snapshot coverage.

--- a/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md
+++ b/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md
@@ -1,0 +1,608 @@
+# Add LangGraph suspend-and-resume orchestration
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+## Purpose / big picture
+
+Roadmap item `2.4.2` adds durable LangGraph suspend-and-resume orchestration to
+the Content Generation Orchestrator. After this change, a generation workflow
+can save a checkpoint before pausing, return a typed suspended result to the
+caller, and later resume from the persisted checkpoint without repeating
+already-dispatched side effects.
+
+This builds directly on roadmap item `2.4.1`, which introduced structured
+planning, tool execution, and the in-process LangGraph seam in
+`episodic/orchestration/`. It does not implement Celery queue routing from
+`2.4.3`, cost ledger persistence from `2.4.4`, budget enforcement from `2.5.x`,
+or public generation-run checkpoint APIs from `2.6.x`. It must, however, leave
+clean ports and storage contracts for those later items.
+
+Success is observable in these behaviours:
+
+1. A LangGraph generation run can execute until a suspendable step, persist a
+   durable checkpoint, and return a state that identifies the checkpoint,
+   workflow step, and idempotency key.
+2. Re-invoking the same suspendable step with the same idempotency key returns
+   the existing checkpoint or recorded outcome instead of dispatching duplicate
+   work.
+3. A resume call loads the saved checkpoint, injects the task or editor result
+   through a `TaskResumePort`, and continues the graph to the next node.
+4. Checkpoint state survives a fresh graph instance and a fresh repository or
+   unit-of-work instance, proving that state is persisted rather than held only
+   in memory.
+5. Unit tests, behavioural tests using Vidai Mock for inference calls, and
+   property tests demonstrate the suspend/resume and idempotency invariants.
+6. Documentation explains the new internal orchestration interface, user-visible
+   behaviour, and design decision. Roadmap item `2.4.2` is marked done only
+   after implementation and validation succeed.
+
+## Constraints
+
+- Preserve hexagonal architecture boundaries. Domain and application code may
+  depend on ports, data transfer objects (DTOs), and orchestration helpers, but
+  must not import Falcon resources, SQLAlchemy adapters, concrete OpenAI
+  clients, or Celery workers directly.
+- Keep LangGraph an internal orchestration mechanism. No public API may expose
+  LangGraph classes, checkpoint implementation types, or framework-specific
+  command objects.
+- Add checkpoint persistence through ports owned by the orchestration or
+  canonical boundary. Adapters must implement those ports; graph nodes must
+  call the ports rather than concrete SQLAlchemy sessions or tables.
+- Keep canonical artefacts out of checkpoint blobs where a canonical repository
+  already owns them. Checkpoints may store orchestration state, node routing
+  data, provider-neutral DTOs, and references to canonical artefact identifiers.
+- Define idempotency keys for every suspendable workflow step before adding the
+  persistence adapter. Keys must be deterministic from run identity, workflow
+  type, step identity, action identity, and retry attempt where retry changes
+  semantics.
+- Use Vidai Mock for behavioural tests that exercise inference calls. Do not
+  call live LLM providers.
+- Add pytest unit tests for every new code unit, pytest-bdd behavioural tests
+  for the observable suspend/resume workflow, and Hypothesis property tests for
+  idempotency-key and state-transition invariants.
+- Update `docs/episodic-podcast-generation-system-design.md`,
+  `docs/users-guide.md`, and `docs/developers-guide.md` for the implemented
+  behaviour. Add or update an ADR in `docs/adr/` for the durable design
+  decision if the existing ADR does not already cover it.
+- Do not mark `docs/roadmap.md` item `2.4.2` done until the implementation,
+  documentation, and validation gates all pass.
+- Run validation commands sequentially, not in parallel:
+  `make check-fmt`, `make typecheck`, `make lint`, `make test`,
+  `make markdownlint`, and `make nixie`.
+
+## Tolerances (exception triggers)
+
+- Scope: stop and escalate if the implementation requires more than 22 files or
+  1500 net new lines before tests pass.
+- Interface: stop and escalate if public signatures for `LLMPort`,
+  `LLMRequest`, `LLMResponse`, `StructuredGenerationPlanner.plan(...)`,
+  `ToolExecutorPort.execute(...)`, or the existing public orchestration DTOs
+  must change incompatibly.
+- Storage: stop and escalate if checkpoint persistence cannot be implemented
+  without a database migration touching unrelated canonical tables.
+- Dependency: stop and escalate if a new runtime dependency is required beyond
+  packages already declared in `pyproject.toml`.
+- Boundary: stop and escalate if a practical implementation requires graph
+  nodes to import SQLAlchemy, Falcon, Celery tasks, or concrete provider
+  adapters.
+- Behaviour: stop and escalate if the same suspend/resume test cluster still
+  fails after three implementation attempts.
+- Ambiguity: stop and present options if checkpoint scope could reasonably mean
+  either a pure LangGraph checkpointer only or a platform-owned
+  `workflow_checkpoints` repository with materially different APIs.
+- Roadmap coupling: stop and escalate if satisfying `2.4.2` requires landing
+  queue routing from `2.4.3`, cost-ledger storage from `2.4.4`, or REST
+  checkpoint endpoints from `2.6.x` in the same change.
+
+## Risks
+
+- Risk: LangGraph checkpoint APIs can leak into application or domain code.
+  Severity: high. Likelihood: medium. Mitigation: keep framework-specific
+  objects in `episodic/orchestration/langgraph.py` and expose provider-neutral
+  DTOs and protocols from the orchestration package.
+
+- Risk: idempotency keys may omit a field that distinguishes semantically
+  different steps, causing false deduplication. Severity: high. Likelihood:
+  medium. Mitigation: introduce a dedicated key builder with Hypothesis tests
+  over workflow identifiers, action identifiers, step names, and retry values.
+
+- Risk: checkpoint blobs may accidentally become a second canonical content
+  store. Severity: high. Likelihood: medium. Mitigation: persist canonical
+  artefacts through existing repositories and keep checkpoint payloads limited
+  to graph control state and references.
+
+- Risk: storage tests may become slow or brittle if they require a live
+  Postgres service. Severity: medium. Likelihood: medium. Mitigation: follow
+  `docs/testing-sqlalchemy-with-pytest-and-py-pglite.md` and existing
+  `tests/canonical_storage/` fixtures for py-pglite-backed integration tests.
+
+- Risk: behavioural tests with Vidai Mock may overfit to prompt wording rather
+  than workflow behaviour. Severity: medium. Likelihood: medium. Mitigation:
+  assert model ordering, suspend/resume state, and final output, but avoid
+  matching full prompts.
+
+- Risk: later queue routing may need Celery-specific metadata that `2.4.2`
+  does not yet know. Severity: medium. Likelihood: medium. Mitigation: store a
+  generic task envelope with optional `external_task_id`, `queue_name`, and
+  `resume_token` fields without implementing routing.
+
+## Progress
+
+- [x] (2026-05-07 23:54Z) Loaded the `execplans`, `hexagonal-architecture`,
+  `leta`, `vidai-mock`, `commit-message`, and `pr-creation` skills relevant to
+  this planning task.
+- [x] (2026-05-07 23:54Z) Confirmed the current branch is
+  `feat/langgraph-resume-plan`, not the main branch.
+- [x] (2026-05-07 23:54Z) Reviewed roadmap item `2.4.2`, adjacent roadmap
+  items, the LangGraph integration principles, checkpointing design, cost
+  accounting boundary, Vidai Mock behavioural test pattern, and the existing
+  `2.4.1` ExecPlan.
+- [x] (2026-05-07 23:54Z) Inspected the existing orchestration seam in
+  `episodic/orchestration/generation.py`,
+  `episodic/orchestration/langgraph.py`, `episodic/orchestration/_dto.py`, and
+  `episodic/orchestration/_protocols.py`.
+- [x] (2026-05-07 23:54Z) Drafted this pre-implementation ExecPlan for roadmap
+  item `2.4.2`.
+- [x] (2026-05-08 00:04Z) Ran planning-change validation gates:
+  `make check-fmt`, `make typecheck`, `make lint`, `make test`,
+  `make markdownlint`, and `make nixie` all passed.
+- [ ] Await explicit approval before implementing the feature.
+- [ ] Stage A: add fail-first tests for checkpoint DTOs, idempotency keys,
+  persistence, graph suspension, graph resumption, Vidai Mock behaviour, and
+  Hypothesis invariants.
+- [ ] Stage B: implement orchestration DTOs and ports for checkpoint persistence
+  and task resumption.
+- [ ] Stage C: implement the in-memory adapter used by fast unit tests.
+- [ ] Stage D: implement the durable SQLAlchemy checkpoint adapter and wire it
+  through composition roots without leaking adapter types into graph nodes.
+- [ ] Stage E: update LangGraph orchestration to suspend, persist checkpoints,
+  resume from saved state, and deduplicate repeated step invocations.
+- [ ] Stage F: update design, user, developer, and ADR documentation.
+- [ ] Stage G: run all validation gates, mark roadmap item `2.4.2` done, and
+  commit the implementation.
+
+## Surprises & Discoveries
+
+- Observation: `docs/episodic-podcast-generation-system-design.md` already
+  names `CheckpointPort` and `TaskResumePort` as orchestration ports. Evidence:
+  the "Orchestration ports and adapters" section lists both ports. Impact: the
+  implementation should use those names rather than inventing alternative
+  abstractions.
+
+- Observation: the existing generation graph is intentionally minimal and
+  in-process. Evidence: `episodic/orchestration/langgraph.py` compiles a
+  `plan -> execute -> finish` graph without checkpointer configuration. Impact:
+  `2.4.2` should extend this seam narrowly and avoid redesigning the whole
+  content-generation workflow.
+
+- Observation: `workflow_checkpoints` exists in the design document but not in
+  the current SQLAlchemy model set. Evidence:
+  `docs/episodic-podcast-generation-system-design.md` describes the table,
+  while `episodic/canonical/storage/models.py` currently exposes canonical
+  tables such as `approval_events` and `episode_templates`. Impact: the
+  implementation probably needs a small migration and repository adapter
+  dedicated to checkpoint records.
+
+- Observation: `langgraph` is already declared as a runtime dependency.
+  Evidence: `pyproject.toml` contains `langgraph>=1.1,<2.0`. Impact: the
+  feature should not need a new orchestration dependency.
+
+- Observation: Vidai Mock is already used by the generation orchestration BDD
+  test to serve distinct planning and execution responses. Evidence:
+  `tests/steps/test_generation_orchestration_steps.py` starts `vidaimock` and
+  records `LLMRequest` values. Impact: the new behavioural test can extend the
+  existing scenario style instead of introducing another mock server pattern.
+
+- Observation: the planning-change gates pass, but `make fmt` currently invokes
+  a legacy `markdownlint --fix` path that reports repository-wide MD013
+  findings in existing documents. Evidence: `/tmp/fmt-episodic-2-4-2-plan.out`
+  reported existing long-line findings, while `make check-fmt` and
+  `make markdownlint` both passed afterward. Impact: implementation work should
+  rely on the explicit gate commands unless the formatter target is repaired in
+  a separate change.
+
+## Decision Log
+
+- Decision: Treat this document as a pre-implementation draft and do not begin
+  feature implementation until explicit approval is given. Rationale: the
+  `execplans` skill requires an approval gate after drafting an initial
+  ExecPlan. Date/Author: 2026-05-07, Codex.
+
+- Decision: Define checkpoint persistence and task resumption as ports in the
+  orchestration boundary, with SQLAlchemy and in-memory implementations as
+  adapters. Rationale: this follows the hexagonal dependency rule and matches
+  the design document's `CheckpointPort` and `TaskResumePort` language.
+  Date/Author: 2026-05-07, Codex.
+
+- Decision: Keep `2.4.2` focused on durable checkpointing, resume, and
+  idempotency, without implementing Celery queue routing, cost ledger storage,
+  or public checkpoint REST endpoints. Rationale: those concerns have separate
+  roadmap items and would blur the acceptance criteria for this vertical slice.
+  Date/Author: 2026-05-07, Codex.
+
+- Decision: Use a platform-owned checkpoint record as the durable system of
+  record, even if LangGraph's native checkpointer participates internally.
+  Rationale: the design requires auditable checkpoint events, TTL policies, and
+  future API exposure. A port-owned record keeps those behaviours independent
+  of any one LangGraph persistence implementation. Date/Author: 2026-05-07,
+  Codex.
+
+## Outcomes & Retrospective
+
+This section is intentionally empty while the plan remains in draft. Update it
+after each implementation milestone with the behaviour achieved, validation
+evidence, gaps, and follow-up work.
+
+## Context and orientation
+
+The project is a Python 3.14 service for podcast generation. The generation
+orchestration code lives in `episodic/orchestration/`. Roadmap item `2.4.1`
+introduced a structured planner and tool executor:
+
+- `episodic/orchestration/generation.py` contains
+  `StructuredGenerationPlanner` and `StructuredPlanningOrchestrator`.
+- `episodic/orchestration/langgraph.py` builds a small LangGraph graph with
+  `GenerationGraphState`, `_plan_node`, `_execute_node`, `_finish_node`, and
+  `build_generation_orchestration_graph(...)`.
+- `episodic/orchestration/_dto.py` contains immutable DTOs such as
+  `GenerationOrchestrationRequest`, `ExecutionPlan`, `PlannedAction`,
+  `PlannerResult`, `ActionExecutionResult`, and `GenerationOrchestrationResult`.
+- `episodic/orchestration/_protocols.py` currently defines `PlannerPort` and
+  `ToolExecutorPort`.
+- `episodic/generation/show_notes.py` provides the first concrete enrichment
+  service used by the tool executor.
+- `episodic/llm/ports.py` defines the provider-neutral `LLMPort` boundary.
+
+"Suspend" means that the graph reaches a node that cannot complete immediately,
+saves its state, records the external work or human decision it is waiting for,
+and returns control to the caller. "Resume" means that a later input loads that
+checkpoint and continues the graph from the paused point. "Idempotency" means
+that retrying the same logical step with the same key does not duplicate side
+effects, dispatches, or charges.
+
+The canonical persistence layer lives under `episodic/canonical/storage/`.
+Existing SQLAlchemy models are in `episodic/canonical/storage/models.py`,
+repositories are in `episodic/canonical/storage/repositories.py` and related
+files, and the unit-of-work is in `episodic/canonical/storage/uow.py`. Storage
+ports are defined in `episodic/canonical/ports.py`. The implementation should
+either extend this canonical storage boundary for workflow checkpoints or add a
+small orchestration storage boundary that follows the same style.
+
+Relevant documentation:
+
+- `docs/roadmap.md` contains the `2.4.2` acceptance bullet.
+- `docs/episodic-podcast-generation-system-design.md` contains the LangGraph
+  integration principles, orchestration ports, checkpoint persistence, and cost
+  accounting boundary.
+- `docs/agentic-systems-with-langgraph-and-celery.md` explains the
+  interrupt/resume pattern and callback shape.
+- `docs/langgraph-and-celery-in-hexagonal-architecture.md` describes boundary
+  risks between graphs, queues, domain logic, and adapters.
+- `docs/async-sqlalchemy-with-pg-and-falcon.md`,
+  `docs/testing-async-falcon-endpoints.md`, and
+  `docs/testing-sqlalchemy-with-pytest-and-py-pglite.md` define persistence and
+  endpoint testing patterns.
+
+## Plan of work
+
+Stage A is test-first scaffolding. Add unit tests in new or existing files such
+as `tests/test_orchestration_checkpointing.py`,
+`tests/test_orchestration_resume.py`, and
+`tests/test_orchestration_properties.py`. The first tests should describe the
+DTOs and ports before implementation exists:
+
+- checkpoint records reject blank run, workflow, step, and idempotency fields;
+- the idempotency-key builder is deterministic for identical inputs and changes
+  when workflow, step, action, or retry fields change;
+- a checkpoint repository can save, fetch, and mark checkpoints resumed;
+- a resume service rejects unknown, expired, or already-resumed checkpoints;
+- the graph returns a suspended result before a suspendable action and resumes
+  after a matching payload arrives;
+- property tests prove repeated save/resume calls for the same idempotency key
+  converge on one checkpoint state.
+
+Extend `tests/features/generation_orchestration.feature` or add
+`tests/features/generation_suspend_resume.feature` with a pytest-bdd scenario
+using Vidai Mock. The scenario should start Vidai Mock, run a generation
+request that reaches a suspendable inference-backed action, observe a suspended
+checkpoint result, construct a fresh graph/repository instance, resume the
+checkpoint, and assert that the final orchestration result includes one planner
+call and no duplicate execution dispatch for the idempotent step.
+
+Stage B defines the internal contracts. Add DTOs to
+`episodic/orchestration/_dto.py` or a focused
+`episodic/orchestration/checkpointing.py` module:
+
+- `WorkflowCheckpoint` with `checkpoint_id`, `run_id`, `episode_id`,
+  `workflow_type`, `step_name`, `action_id`, `idempotency_key`, `status`,
+  `state_payload`, `external_task_id`, `resume_payload`, `created_at`,
+  `updated_at`, and `expires_at`;
+- `WorkflowCheckpointStatus` with values such as `pending`, `resumed`,
+  `expired`, and `failed`;
+- `SuspendedWorkflowResult` with the checkpoint identifier, idempotency key,
+  waiting reason, and optional task envelope;
+- `ResumeWorkflowCommand` with checkpoint identifier, idempotency key, and
+  provider-neutral payload.
+
+Add ports to `episodic/orchestration/_protocols.py`:
+
+```python
+class CheckpointPort(typ.Protocol):
+    async def reserve_or_get(
+        self,
+        checkpoint: WorkflowCheckpoint,
+    ) -> WorkflowCheckpoint:
+        """Persist a checkpoint or return the existing idempotent record."""
+
+    async def get(
+        self,
+        checkpoint_id: str,
+    ) -> WorkflowCheckpoint | None:
+        """Load a checkpoint by identifier."""
+
+    async def mark_resumed(
+        self,
+        checkpoint_id: str,
+        resume_payload: dict[str, object],
+    ) -> WorkflowCheckpoint:
+        """Record the payload that resumed a checkpoint."""
+```
+
+```python
+class TaskResumePort(typ.Protocol):
+    async def resume(
+        self,
+        command: ResumeWorkflowCommand,
+    ) -> GenerationOrchestrationResult | SuspendedWorkflowResult:
+        """Resume a suspended generation workflow from a checkpoint."""
+```
+
+The exact signatures may evolve during implementation, but the key boundary is
+that callers use orchestration DTOs and ports, not LangGraph or SQLAlchemy
+types.
+
+Stage C implements fast in-memory behaviour. Add an in-memory checkpoint store
+under `episodic/orchestration/` or test helpers so unit tests can exercise
+deduplication, expiry, and resume transitions without a database. Use this to
+settle the DTO invariants and graph behaviour before adding SQLAlchemy.
+
+Stage D implements durable persistence. Add a `workflow_checkpoints` model and
+migration following existing canonical storage conventions. A likely table
+shape is:
+
+- `id`: UUID primary key;
+- `run_id`: UUID or string, indexed;
+- `episode_id`: UUID, indexed when available;
+- `workflow_type`: bounded string;
+- `step_name`: bounded string;
+- `action_id`: bounded string;
+- `idempotency_key`: bounded string with a uniqueness constraint;
+- `status`: bounded enum or string;
+- `state_payload`: JSONB;
+- `external_task_id`: nullable string;
+- `resume_payload`: nullable JSONB;
+- `created_at`, `updated_at`, `expires_at`: timezone-aware timestamps.
+
+Add repository methods through a port-owned adapter. The repository must make
+`reserve_or_get(...)` atomic using a uniqueness constraint on
+`idempotency_key`, so two concurrent retries converge on one record. Use
+py-pglite-backed tests that create a checkpoint, open a fresh unit of work,
+fetch the checkpoint, and resume it.
+
+Stage E extends LangGraph orchestration. Update
+`episodic/orchestration/langgraph.py` so graph construction can receive a
+`CheckpointPort` and optional suspend policy. The implementation should keep
+the existing immediate `plan -> execute -> finish` path working by default, and
+add a new path for suspendable actions. At the suspension point, the node
+should:
+
+1. derive the idempotency key from run/workflow/step/action/retry identity;
+2. save the graph state and task envelope through `CheckpointPort`;
+3. return a `SuspendedWorkflowResult` or state field rather than calling the
+   side-effecting executor again;
+4. log the checkpoint and idempotency key.
+
+Add a resume service or graph helper that accepts `ResumeWorkflowCommand`,
+loads the checkpoint, validates status and idempotency key, reconstructs the
+graph input, injects the resume payload, marks the checkpoint resumed, and
+continues execution. If using `langgraph.types.Command` internally, keep it
+inside the LangGraph module and return only Episodic DTOs to callers.
+
+Stage F updates documentation. In
+`docs/episodic-podcast-generation-system-design.md`, record the concrete
+checkpoint record shape, lifecycle, idempotency-key fields, and resume
+semantics. In `docs/developers-guide.md`, explain how maintainers add a
+suspendable orchestration step without violating ports/adapters boundaries. In
+`docs/users-guide.md`, describe any service-visible behaviour, such as a run
+being reported as suspended or resumable. Add an ADR such as
+`docs/adr/adr-006-langgraph-suspend-resume-checkpointing.md` if the decision is
+not naturally appended to ADR-005.
+
+Stage G validates and completes. Run formatting and gates sequentially. Mark
+`docs/roadmap.md` item `2.4.2` done only after all gates pass. Update this
+ExecPlan's `Progress`, `Surprises & Discoveries`, `Decision Log`, and
+`Outcomes & Retrospective` sections with actual evidence. Commit the feature as
+one or more atomic commits.
+
+## Concrete steps
+
+Work from the repository root:
+
+```plaintext
+/home/leynos/.lody/repos/github---leynos---episodic/worktrees/0582a2ca-e6ad-47bb-9b7b-fee35bdb5bc5
+```
+
+Confirm branch and clean working tree before implementation:
+
+```bash
+git branch --show-current
+git status --short
+```
+
+Expected branch after the planning PR setup:
+
+```plaintext
+2-4-2-add-lang-graph-suspend-and-resume-orchestration
+```
+
+Add the fail-first test files and run the focused tests. Use `tee` for logs:
+
+```bash
+PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 uv run pytest \
+  tests/test_orchestration_checkpointing.py \
+  tests/test_orchestration_resume.py \
+  tests/test_orchestration_properties.py \
+  tests/steps/test_generation_suspend_resume_steps.py \
+  2>&1 | tee /tmp/test-episodic-2-4-2-focused.out
+```
+
+Expected result before implementation:
+
+```plaintext
+FAILED ... checkpointing/resume symbols are not implemented
+```
+
+Implement Stage B through Stage E in small commits, rerunning the focused tests
+after each stage. When focused tests pass, run the full required gates
+sequentially:
+
+```bash
+make check-fmt 2>&1 | tee /tmp/check-fmt-episodic-2-4-2.out
+make typecheck 2>&1 | tee /tmp/typecheck-episodic-2-4-2.out
+make lint 2>&1 | tee /tmp/lint-episodic-2-4-2.out
+make test 2>&1 | tee /tmp/test-episodic-2-4-2.out
+make markdownlint 2>&1 | tee /tmp/markdownlint-episodic-2-4-2.out
+make nixie 2>&1 | tee /tmp/nixie-episodic-2-4-2.out
+```
+
+Expected result after implementation:
+
+```plaintext
+... passed
+```
+
+The exact number of tests may change as the branch evolves; record the final
+counts and log paths in this ExecPlan.
+
+## Validation and acceptance
+
+The feature is accepted when all of the following are true:
+
+- Unit tests prove checkpoint DTO validation, idempotency-key construction,
+  repository save/load/resume transitions, and resume-service error handling.
+- Behavioural pytest-bdd coverage uses Vidai Mock and demonstrates a run that
+  suspends, persists a checkpoint, resumes from a fresh graph/repository
+  instance, and avoids duplicate idempotent dispatch.
+- Hypothesis tests prove key and state-transition invariants over generated
+  workflow IDs, action IDs, step names, retry values, and valid transition
+  sequences.
+- The existing immediate orchestration path from `2.4.1` still works without
+  requiring checkpoint configuration.
+- Durable checkpoint tests prove the SQLAlchemy adapter can save, reload, and
+  mark checkpoints resumed through a fresh unit of work.
+- `docs/episodic-podcast-generation-system-design.md` records the concrete
+  design decision, `docs/developers-guide.md` records internal practice, and
+  `docs/users-guide.md` records user-visible behaviour.
+- `docs/roadmap.md` marks item `2.4.2` as done.
+- `make check-fmt`, `make typecheck`, `make lint`, `make test`,
+  `make markdownlint`, and `make nixie` all pass sequentially.
+
+## Idempotence and recovery
+
+All implementation steps should be re-runnable. Tests may create temporary
+Vidai Mock configuration under pytest-managed `tmp_path` directories and must
+clean up child processes in fixtures. The checkpoint repository must tolerate a
+retry after a partial failure by returning the existing record for the same
+idempotency key.
+
+If a migration or repository change fails, roll forward with a corrective
+migration or patch rather than deleting user data. Do not run destructive git
+or database commands without explicit approval. If a checkpoint is persisted
+but the graph resume fails, keep the checkpoint in a non-resumed state with
+diagnostic metadata so a later retry can resume or mark it failed.
+
+## Artifacts and notes
+
+Useful existing entrypoints:
+
+```plaintext
+episodic/orchestration/langgraph.py
+episodic/orchestration/generation.py
+episodic/orchestration/_dto.py
+episodic/orchestration/_protocols.py
+episodic/canonical/storage/models.py
+episodic/canonical/storage/uow.py
+tests/test_generation_orchestration_langgraph.py
+tests/steps/test_generation_orchestration_steps.py
+tests/features/generation_orchestration.feature
+```
+
+Current design anchors:
+
+```plaintext
+docs/episodic-podcast-generation-system-design.md#langgraph-integration-principles
+docs/episodic-podcast-generation-system-design.md#state-persistence-and-checkpointing
+docs/agentic-systems-with-langgraph-and-celery.md
+docs/langgraph-and-celery-in-hexagonal-architecture.md
+```
+
+## Interfaces and dependencies
+
+Use existing dependencies from `pyproject.toml`: `langgraph`, `sqlalchemy`,
+`alembic`, `pytest`, `pytest-bdd`, `hypothesis`, and Vidai Mock as an external
+test executable. Do not add a runtime dependency unless the dependency
+tolerance is explicitly approved.
+
+The implementation must leave these interfaces available to application code:
+
+```python
+class CheckpointPort(typ.Protocol):
+    async def reserve_or_get(
+        self,
+        checkpoint: WorkflowCheckpoint,
+    ) -> WorkflowCheckpoint:
+        """Persist a checkpoint or return the existing idempotent record."""
+
+    async def get(
+        self,
+        checkpoint_id: str,
+    ) -> WorkflowCheckpoint | None:
+        """Load a checkpoint by identifier."""
+
+    async def mark_resumed(
+        self,
+        checkpoint_id: str,
+        resume_payload: dict[str, object],
+    ) -> WorkflowCheckpoint:
+        """Record the payload that resumed a checkpoint."""
+```
+
+```python
+class TaskResumePort(typ.Protocol):
+    async def resume(
+        self,
+        command: ResumeWorkflowCommand,
+    ) -> GenerationOrchestrationResult | SuspendedWorkflowResult:
+        """Resume a suspended generation workflow from a checkpoint."""
+```
+
+The exact method names may change if the implementation discovers a cleaner
+local convention, but the semantic contract must remain: checkpointing and
+resumption are port-driven, idempotent, durable, and independent of concrete
+LangGraph or SQLAlchemy types.
+
+Revision note 2026-05-07: Created the initial draft ExecPlan for roadmap item
+`2.4.2` from the roadmap, design documents, existing `2.4.1` orchestration
+code, hexagonal architecture guidance, and Vidai Mock testing requirements.
+This is a pre-implementation plan and requires explicit approval before code
+implementation begins.
+
+Revision note 2026-05-08: Added validation evidence for the planning-only
+change and recorded the formatter-target discovery. This does not change the
+implementation sequence, but it gives the next implementer the exact branch
+gate status and a known documentation tooling caveat.

--- a/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md
+++ b/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md
@@ -736,5 +736,13 @@ passed with `make check-fmt`, `make typecheck`, `make lint`,
 reported 461 passed and 3 skipped tests. An earlier `make test` run hit a
 single setup timeout in
 `tests/test_snapshot_sources.py::test_snapshot_resolved_bindings_persists_reference_source_documents[explicit_created_at]`;
- the isolated test rerun passed both parametrisations before the clean full
+the isolated test rerun passed both parametrisations before the clean full
 rerun.
+
+Revision note 2026-05-12: Review follow-up verified that the suspend
+checkpoint path already had no pre-save lookup and already derives reuse from
+the `save_or_reuse()` result, so no TOCTOU change was still needed. The
+remaining missing required checkpoint field helper now normalises missing
+payload keys to the documented `TypeError` contract. Validation passed with
+focused orchestration tests, `make check-fmt`, `make typecheck`, `make lint`,
+and `make test`; the full test suite reported 461 passed and 3 skipped tests.

--- a/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md
+++ b/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md
@@ -414,11 +414,11 @@ class CheckpointPort(typ.Protocol):
     ) -> WorkflowCheckpoint | None:
         """Load a checkpoint by workflow-step idempotency key."""
 
-    async def save(
+    async def save_or_reuse(
         self,
         checkpoint: WorkflowCheckpoint,
     ) -> WorkflowCheckpoint:
-        """Persist a checkpoint or return the existing idempotent record."""
+        """Persist a checkpoint or return the first record for its key."""
 
     async def mark_resumed(
         self,
@@ -648,11 +648,11 @@ class CheckpointPort(typ.Protocol):
     ) -> WorkflowCheckpoint | None:
         """Load a checkpoint by workflow-step idempotency key."""
 
-    async def save(
+    async def save_or_reuse(
         self,
         checkpoint: WorkflowCheckpoint,
     ) -> WorkflowCheckpoint:
-        """Persist a checkpoint or return the existing idempotent record."""
+        """Persist a checkpoint or return the first record for its key."""
 
     async def mark_resumed(
         self,
@@ -702,8 +702,8 @@ idempotency attempts plus SQL not-found checkpoint lookups.
 
 Revision note 2026-05-10: Validation for the code review follow-up passed with
 `make check-fmt`, `make typecheck`, `make lint`, `make markdownlint`,
-`make nixie`, and `make test`. The full test suite reported 456 passed and
-3 skipped tests.
+`make nixie`, and `make test`. The full test suite reported 456 passed and 3
+skipped tests.
 
 Revision note 2026-05-10: Review follow-up verified that SQL checkpoint saves
 already use a nested transaction savepoint for duplicate idempotency keys, so
@@ -711,14 +711,30 @@ no whole-unit-of-work rollback fix was needed. Multi-step suspended checkpoints
 now fail explicitly during `resume_generation_orchestration` instead of
 silently finalizing only the first externally supplied action result.
 
-Revision note 2026-05-10: Validation for the multi-step resume follow-up
-passed with `make check-fmt`, `make typecheck`, `make lint`,
-`make markdownlint`, `make nixie`, and `make test`. The full test suite
-reported 457 passed and 3 skipped tests.
+Revision note 2026-05-10: Validation for the multi-step resume follow-up passed
+with `make check-fmt`, `make typecheck`, `make lint`, `make markdownlint`,
+`make nixie`, and `make test`. The full test suite reported 457 passed and 3
+skipped tests.
 
-Revision note 2026-05-12: Review follow-up converted missing
-`planner_result` checkpoint payloads from `KeyError` to the documented
-`TypeError` path, updated the developer guide wording, and normalized revision
-note spelling. Validation passed with `make check-fmt`, `make typecheck`,
-`make lint`, `make markdownlint`, `make nixie`, and `make test`; the full test
-suite reported 458 passed and 3 skipped tests.
+Revision note 2026-05-12: Review follow-up converted missing `planner_result`
+checkpoint payloads from `KeyError` to the documented `TypeError` path, updated
+the developer guide wording, and normalized revision note spelling. Validation
+passed with `make check-fmt`, `make typecheck`, `make lint`,
+`make markdownlint`, `make nixie`, and `make test`; the full test suite
+reported 458 passed and 3 skipped tests.
+
+Revision note 2026-05-12: Checkpoint persistence was renamed from `save()` to
+`save_or_reuse()` across the port, adapters, call sites, and tests so the
+first-write-wins contract is explicit. Suspend now writes unconditionally
+through `save_or_reuse()` and derives checkpoint reuse from the returned
+checkpoint identifier, keeping duplicate-key arbitration in the store. The
+SQLAlchemy checkpoint store now emits observability events for reads, inserts,
+duplicate-key reuse, and resume marking. Added malformed resume payload and
+unknown `mark_resumed()` tests for in-memory and SQL-backed stores. Validation
+passed with `make check-fmt`, `make typecheck`, `make lint`,
+`make markdownlint`, `make nixie`, and `make test`; the full test suite
+reported 461 passed and 3 skipped tests. An earlier `make test` run hit a
+single setup timeout in
+`tests/test_snapshot_sources.py::test_snapshot_resolved_bindings_persists_reference_source_documents[explicit_created_at]`;
+ the isolated test rerun passed both parametrisations before the clean full
+rerun.

--- a/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md
+++ b/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md
@@ -67,8 +67,8 @@ Success is observable in these behaviours:
   idempotency-key and state-transition invariants.
 - Update `docs/episodic-podcast-generation-system-design.md`,
   `docs/users-guide.md`, and `docs/developers-guide.md` for the implemented
-  behaviour. Add or update an ADR in `docs/adr/` for the durable design
-  decision if the existing ADR does not already cover it.
+  behaviour. Add or update an Architecture Decision Record (ADR) in `docs/adr/`
+  for the durable design decision if the existing ADR does not already cover it.
 - Do not mark `docs/roadmap.md` item `2.4.2` done until the implementation,
   documentation, and validation gates all pass.
 - Run validation commands sequentially, not in parallel:
@@ -189,9 +189,9 @@ Success is observable in these behaviours:
   `docs/adr/adr-007-durable-generation-checkpoints.md`.
 - [x] Stage F: update design, user, developer, and ADR documentation.
 - [x] (2026-05-08 01:27Z) Stage G: final validation passed after marking
-  roadmap item `2.4.2` done: `make check-fmt`, `make typecheck`,
-  `make lint`, `make test`, `make markdownlint`, and `make nixie`. `make test`
-  reported `446 passed, 3 skipped`.
+  roadmap item `2.4.2` done: `make check-fmt`, `make typecheck`, `make lint`,
+  `make test`, `make markdownlint`, and `make nixie`. `make test` reported
+  `446 passed, 3 skipped`.
 - [x] (2026-05-08 01:27Z) Formatting note: `make fmt` still reports the
   repository-wide legacy MD013 formatter issue in unrelated documents after
   leaving Python files unchanged. The explicit required gates pass.
@@ -402,24 +402,29 @@ Add ports to `episodic/orchestration/_protocols.py`:
 
 ```python
 class CheckpointPort(typ.Protocol):
-    async def reserve_or_get(
-        self,
-        checkpoint: WorkflowCheckpoint,
-    ) -> WorkflowCheckpoint:
-        """Persist a checkpoint or return the existing idempotent record."""
-
     async def get(
         self,
         checkpoint_id: str,
     ) -> WorkflowCheckpoint | None:
         """Load a checkpoint by identifier."""
 
+    async def get_by_idempotency_key(
+        self,
+        idempotency_key: str,
+    ) -> WorkflowCheckpoint | None:
+        """Load a checkpoint by workflow-step idempotency key."""
+
+    async def save(
+        self,
+        checkpoint: WorkflowCheckpoint,
+    ) -> WorkflowCheckpoint:
+        """Persist a checkpoint or return the existing idempotent record."""
+
     async def mark_resumed(
         self,
         checkpoint_id: str,
-        resume_payload: dict[str, object],
     ) -> WorkflowCheckpoint:
-        """Record the payload that resumed a checkpoint."""
+        """Mark a checkpoint as resumed."""
 ```
 
 ```python
@@ -631,24 +636,29 @@ The implementation must leave these interfaces available to application code:
 
 ```python
 class CheckpointPort(typ.Protocol):
-    async def reserve_or_get(
-        self,
-        checkpoint: WorkflowCheckpoint,
-    ) -> WorkflowCheckpoint:
-        """Persist a checkpoint or return the existing idempotent record."""
-
     async def get(
         self,
         checkpoint_id: str,
     ) -> WorkflowCheckpoint | None:
         """Load a checkpoint by identifier."""
 
+    async def get_by_idempotency_key(
+        self,
+        idempotency_key: str,
+    ) -> WorkflowCheckpoint | None:
+        """Load a checkpoint by workflow-step idempotency key."""
+
+    async def save(
+        self,
+        checkpoint: WorkflowCheckpoint,
+    ) -> WorkflowCheckpoint:
+        """Persist a checkpoint or return the existing idempotent record."""
+
     async def mark_resumed(
         self,
         checkpoint_id: str,
-        resume_payload: dict[str, object],
     ) -> WorkflowCheckpoint:
-        """Record the payload that resumed a checkpoint."""
+        """Mark a checkpoint as resumed."""
 ```
 
 ```python
@@ -677,9 +687,20 @@ implementation sequence, but it gives the next implementer the exact branch
 gate status and a known documentation tooling caveat.
 
 Revision note 2026-05-10: Follow-up review fixes added richer suspend/resume
-module documentation, documented `resume_generation_orchestration` error
-paths, injected the in-memory checkpoint clock, serialised in-memory
-checkpoint saves with an `asyncio.Lock`, and changed the SQLAlchemy checkpoint
-adapter to insert first and query only after duplicate-key conflicts. Added
-missing unknown-checkpoint, concurrent in-memory save, checkpoint payload
-property, and checkpoint payload snapshot coverage.
+module documentation, documented `resume_generation_orchestration` error paths,
+injected the in-memory checkpoint clock, serialised in-memory checkpoint saves
+with an `asyncio.Lock`, and changed the SQLAlchemy checkpoint adapter to insert
+first and query only after duplicate-key conflicts. Added missing
+unknown-checkpoint, concurrent in-memory save, checkpoint payload property, and
+checkpoint payload snapshot coverage.
+
+Revision note 2026-05-10: Code review follow-up made checkpoint planner payload
+deserialisation symmetric for optional planner usage, added the explicit
+`CheckpointPort.mark_resumed()` status transition after successful resume,
+fixed the SQLAlchemy checkpoint store runtime annotation, and covered negative
+idempotency attempts plus SQL not-found checkpoint lookups.
+
+Revision note 2026-05-10: Validation for the code review follow-up passed with
+`make check-fmt`, `make typecheck`, `make lint`, `make markdownlint`,
+`make nixie`, and `make test`. The full test suite reported 456 passed and
+3 skipped tests.

--- a/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md
+++ b/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md
@@ -391,7 +391,7 @@ Stage B defines the internal contracts. Add DTOs to
   `workflow_type`, `step_name`, `action_id`, `idempotency_key`, `status`,
   `state_payload`, `external_task_id`, `resume_payload`, `created_at`,
   `updated_at`, and `expires_at`;
-- `WorkflowCheckpointStatus` with values such as `pending`, `resumed`,
+- `WorkflowCheckpointStatus` with values such as `suspended`, `resumed`,
   `expired`, and `failed`;
 - `SuspendedWorkflowResult` with the checkpoint identifier, idempotency key,
   waiting reason, and optional task envelope;
@@ -463,7 +463,7 @@ shape is:
 - `created_at`, `updated_at`, `expires_at`: timezone-aware timestamps.
 
 Add repository methods through a port-owned adapter. The repository must make
-`reserve_or_get(...)` atomic using a uniqueness constraint on
+`save_or_reuse(...)` atomic using a uniqueness constraint on
 `idempotency_key`, so two concurrent retries converge on one record. Use
 py-pglite-backed tests that create a checkpoint, open a fresh unit of work,
 fetch the checkpoint, and resume it.
@@ -746,3 +746,15 @@ remaining missing required checkpoint field helper now normalises missing
 payload keys to the documented `TypeError` contract. Validation passed with
 focused orchestration tests, `make check-fmt`, `make typecheck`, `make lint`,
 and `make test`; the full test suite reported 461 passed and 3 skipped tests.
+
+Revision note 2026-05-13: Review follow-up verified and fixed the remaining
+checkpoint persistence issues: the migration now creates a DB-side
+`updated_at` trigger, checkpoint status is backed by the
+`WorkflowCheckpointStatus` enum in the domain and SQLAlchemy model, plan
+payload required-input deserialization now uses the shared `TypeError`
+contract, and redundant future annotations imports were removed from the new
+checkpoint storage files. Stale checkpoint-store API references were updated to
+the final `save_or_reuse(...)` API, and screen-reader descriptions now precede
+the suspend and resume sequence diagrams. The snapshot import comment was
+already resolved in the current code and required no change. Focused checkpoint,
+migration-drift, and malformed-payload tests passed.

--- a/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md
+++ b/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md
@@ -531,7 +531,7 @@ PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 uv run pytest \
   tests/test_orchestration_checkpointing.py \
   tests/test_orchestration_resume.py \
   tests/test_orchestration_properties.py \
-  tests/steps/test_generation_suspend_resume_steps.py \
+  tests/steps/test_generation_orchestration_steps.py \
   2>&1 | tee /tmp/test-episodic-2-4-2-focused.out
 ```
 
@@ -704,3 +704,14 @@ Revision note 2026-05-10: Validation for the code review follow-up passed with
 `make check-fmt`, `make typecheck`, `make lint`, `make markdownlint`,
 `make nixie`, and `make test`. The full test suite reported 456 passed and
 3 skipped tests.
+
+Revision note 2026-05-10: Review follow-up verified that SQL checkpoint saves
+already use a nested transaction savepoint for duplicate idempotency keys, so
+no whole-unit-of-work rollback fix was needed. Multi-step suspended checkpoints
+now fail explicitly during `resume_generation_orchestration` instead of
+silently finalising only the first externally supplied action result.
+
+Revision note 2026-05-10: Validation for the multi-step resume follow-up
+passed with `make check-fmt`, `make typecheck`, `make lint`,
+`make markdownlint`, `make nixie`, and `make test`. The full test suite
+reported 457 passed and 3 skipped tests.

--- a/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md
+++ b/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md
@@ -5,7 +5,7 @@ This ExecPlan (execution plan) is a living document. The sections
 `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
 proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
 ## Purpose / big picture
 
@@ -151,19 +151,55 @@ Success is observable in these behaviours:
 - [x] (2026-05-08 00:04Z) Ran planning-change validation gates:
   `make check-fmt`, `make typecheck`, `make lint`, `make test`,
   `make markdownlint`, and `make nixie` all passed.
-- [ ] Await explicit approval before implementing the feature.
-- [ ] Stage A: add fail-first tests for checkpoint DTOs, idempotency keys,
+- [x] (2026-05-08 00:20Z) Received explicit implementation approval and moved
+  this ExecPlan from draft to in-progress execution.
+- [x] (2026-05-08 00:36Z) Stage A partial: added focused unit tests for graph
+  suspension, idempotency reuse, resume aggregation, and a Hypothesis property
+  test for deterministic step keys. The focused graph and property pytest
+  command passed with `15 passed`.
+- [x] (2026-05-08 01:16Z) Stage A complete: the implementation is covered by
+  unit tests, py-pglite storage tests, a Vidai Mock behavioural test, and a
+  Hypothesis idempotency-key invariant.
+- [x] Stage A: add fail-first tests for checkpoint DTOs, idempotency keys,
   persistence, graph suspension, graph resumption, Vidai Mock behaviour, and
   Hypothesis invariants.
-- [ ] Stage B: implement orchestration DTOs and ports for checkpoint persistence
+- [x] (2026-05-08 00:36Z) Stage B partial: added
+  `WorkflowCheckpoint`, `SuspendedWorkflowResult`, `ResumeWorkflowCommand`,
+  `CheckpointPort`, `TaskResumePort`, and deterministic idempotency-key
+  construction under the orchestration boundary.
+- [x] Stage B: implement orchestration DTOs and ports for checkpoint persistence
   and task resumption.
-- [ ] Stage C: implement the in-memory adapter used by fast unit tests.
-- [ ] Stage D: implement the durable SQLAlchemy checkpoint adapter and wire it
+- [x] (2026-05-08 00:36Z) Stage C: implemented
+  `InMemoryCheckpointStore` for fast suspend/resume unit tests.
+- [x] (2026-05-08 00:47Z) Stage D: added
+  `workflow_checkpoints`, an Alembic migration,
+  `SqlAlchemyWorkflowCheckpointStore`, unit-of-work wiring, and
+  py-pglite-backed tests. The focused graph, property, and storage pytest
+  command passed with `17 passed`.
+- [x] (2026-05-08 00:52Z) Stage E partial: added a Vidai Mock-backed BDD
+  suspend/resume scenario. The focused generation orchestration BDD pytest
+  command passed with `4 passed`.
+- [x] Stage D: implement the durable SQLAlchemy checkpoint adapter and wire it
   through composition roots without leaking adapter types into graph nodes.
-- [ ] Stage E: update LangGraph orchestration to suspend, persist checkpoints,
+- [x] Stage E: update LangGraph orchestration to suspend, persist checkpoints,
   resume from saved state, and deduplicate repeated step invocations.
-- [ ] Stage F: update design, user, developer, and ADR documentation.
-- [ ] Stage G: run all validation gates, mark roadmap item `2.4.2` done, and
+- [x] (2026-05-08 01:16Z) Stage F: updated
+  `docs/episodic-podcast-generation-system-design.md`, `docs/users-guide.md`,
+  `docs/developers-guide.md`, and added
+  `docs/adr/adr-007-durable-generation-checkpoints.md`.
+- [x] Stage F: update design, user, developer, and ADR documentation.
+- [x] (2026-05-08 01:27Z) Stage G: final validation passed after marking
+  roadmap item `2.4.2` done: `make check-fmt`, `make typecheck`,
+  `make lint`, `make test`, `make markdownlint`, and `make nixie`. `make test`
+  reported `446 passed, 3 skipped`.
+- [x] (2026-05-08 01:27Z) Formatting note: `make fmt` still reports the
+  repository-wide legacy MD013 formatter issue in unrelated documents after
+  leaving Python files unchanged. The explicit required gates pass.
+- [x] (2026-05-08 01:16Z) Stage G partial: `make check-fmt`,
+  `make typecheck`, `make lint`, `make test`, `make markdownlint`, and
+  `make nixie` passed before marking the roadmap item done. `make test`
+  reported `446 passed, 3 skipped`.
+- [x] Stage G: run all validation gates, mark roadmap item `2.4.2` done, and
   commit the implementation.
 
 ## Surprises & Discoveries
@@ -206,6 +242,20 @@ Success is observable in these behaviours:
   rely on the explicit gate commands unless the formatter target is repaired in
   a separate change.
 
+- Observation: the minimal graph can support `2.4.2` by adding a checkpointing
+  branch that stops after `plan` and persists the first executable action,
+  while the non-checkpointed path remains unchanged. Evidence:
+  `tests/test_generation_orchestration_langgraph.py` passed both the existing
+  full execution test and the new suspend/resume tests. Impact: no redesign of
+  the existing planner or tool executor ports is needed.
+
+- Observation: repeated suspend invocations still re-run planning in the current
+  graph but reuse the existing checkpoint before dispatching the external
+  execution step. Evidence: the BDD scenario records two planning model calls
+  and one execution model call. Impact: this satisfies step idempotency for the
+  suspendable side-effecting execution step without expanding `2.4.2` into
+  plan-result caching.
+
 ## Decision Log
 
 - Decision: Treat this document as a pre-implementation draft and do not begin
@@ -232,11 +282,30 @@ Success is observable in these behaviours:
   of any one LangGraph persistence implementation. Date/Author: 2026-05-07,
   Codex.
 
+- Decision: Resume accepts a `ResumeWorkflowCommand` carrying the external
+  action result and uses a `TaskResumePort` before rebuilding the final
+  `GenerationOrchestrationResult`. Rationale: this keeps later queue and human
+  approval adapters outside the graph while proving the suspend/resume state
+  transition today. Date/Author: 2026-05-08, Codex.
+
 ## Outcomes & Retrospective
 
-This section is intentionally empty while the plan remains in draft. Update it
-after each implementation milestone with the behaviour achieved, validation
-evidence, gaps, and follow-up work.
+Roadmap item `2.4.2` now has durable suspend-and-resume orchestration for the
+structured generation graph. The graph can persist a checkpoint before the
+side-effecting execution step, return a typed suspended result, reuse the first
+checkpoint for repeated idempotency keys, and resume by accepting an external
+action result through `TaskResumePort`.
+
+The implementation stayed within the planned boundary: no public API exposes
+LangGraph internals, no Celery queue routing or cost-ledger persistence was
+added, and graph nodes depend on orchestration ports rather than SQLAlchemy or
+provider adapters. Documentation now records the user-visible checkpoint
+behaviour, developer practices, and ADR-007.
+
+Final validation passed with `make check-fmt`, `make typecheck`, `make lint`,
+`make test`, `make markdownlint`, and `make nixie`. `make fmt` remains affected
+by a pre-existing repository-wide Markdown line-length formatter issue; no
+unrelated formatter output was retained.
 
 ## Context and orientation
 

--- a/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md
+++ b/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md
@@ -688,14 +688,14 @@ gate status and a known documentation tooling caveat.
 
 Revision note 2026-05-10: Follow-up review fixes added richer suspend/resume
 module documentation, documented `resume_generation_orchestration` error paths,
-injected the in-memory checkpoint clock, serialised in-memory checkpoint saves
+injected the in-memory checkpoint clock, serialized in-memory checkpoint saves
 with an `asyncio.Lock`, and changed the SQLAlchemy checkpoint adapter to insert
 first and query only after duplicate-key conflicts. Added missing
 unknown-checkpoint, concurrent in-memory save, checkpoint payload property, and
 checkpoint payload snapshot coverage.
 
 Revision note 2026-05-10: Code review follow-up made checkpoint planner payload
-deserialisation symmetric for optional planner usage, added the explicit
+deserialization symmetric for optional planner usage, added the explicit
 `CheckpointPort.mark_resumed()` status transition after successful resume,
 fixed the SQLAlchemy checkpoint store runtime annotation, and covered negative
 idempotency attempts plus SQL not-found checkpoint lookups.
@@ -709,9 +709,16 @@ Revision note 2026-05-10: Review follow-up verified that SQL checkpoint saves
 already use a nested transaction savepoint for duplicate idempotency keys, so
 no whole-unit-of-work rollback fix was needed. Multi-step suspended checkpoints
 now fail explicitly during `resume_generation_orchestration` instead of
-silently finalising only the first externally supplied action result.
+silently finalizing only the first externally supplied action result.
 
 Revision note 2026-05-10: Validation for the multi-step resume follow-up
 passed with `make check-fmt`, `make typecheck`, `make lint`,
 `make markdownlint`, `make nixie`, and `make test`. The full test suite
 reported 457 passed and 3 skipped tests.
+
+Revision note 2026-05-12: Review follow-up converted missing
+`planner_result` checkpoint payloads from `KeyError` to the documented
+`TypeError` path, updated the developer guide wording, and normalized revision
+note spelling. Validation passed with `make check-fmt`, `make typecheck`,
+`make lint`, `make markdownlint`, `make nixie`, and `make test`; the full test
+suite reported 458 passed and 3 skipped tests.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -248,7 +248,7 @@ metering. Completion enables reliable, auditable generation workflows.
 - [x] 2.4.1. Implement structured-output planning and tool-calling execution.
   - Define model tiering for cost control.
   - Implement tool-calling patterns for enrichment steps.
-- [ ] 2.4.2. Add LangGraph suspend-and-resume orchestration. Requires 2.1.1.
+- [x] 2.4.2. Add LangGraph suspend-and-resume orchestration. Requires 2.1.1.
   - Implement checkpoint persistence for resumable workflows.
   - Define idempotency keys for each workflow step.
   - See

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -97,6 +97,16 @@ Table: Show-notes model configuration settings.
 Both model names must reference endpoints available through the configured LLM
 provider.
 
+
+##### Resumable orchestration
+
+Generation workflows now persist an internal checkpoint before a suspendable
+execution step runs. If the same workflow step is retried with the same
+idempotency key, Episodic reuses the existing checkpoint instead of dispatching
+the side-effecting execution step twice. Operators do not need to manage these
+checkpoints directly in this release; public generation-run checkpoint APIs are
+planned for a later roadmap item.
+
 ##### Failure behaviour
 
 If either stage returns a response that does not match the expected structured

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -97,7 +97,6 @@ Table: Show-notes model configuration settings.
 Both model names must reference endpoints available through the configured LLM
 provider.
 
-
 ##### Resumable orchestration
 
 Generation workflows now persist an internal checkpoint before a suspendable

--- a/episodic/canonical/domain.py
+++ b/episodic/canonical/domain.py
@@ -73,6 +73,13 @@ class ReferenceBindingTargetKind(enum.StrEnum):
     INGESTION_JOB = "ingestion_job"
 
 
+class WorkflowCheckpointStatus(enum.StrEnum):
+    """Lifecycle states for resumable orchestration checkpoints."""
+
+    SUSPENDED = "suspended"
+    RESUMED = "resumed"
+
+
 @dc.dataclass(frozen=True)
 class SeriesProfile:
     """Series metadata required for canonical ingestion."""

--- a/episodic/canonical/storage/__init__.py
+++ b/episodic/canonical/storage/__init__.py
@@ -27,6 +27,7 @@ from .models import (
     SeriesProfileRecord,
     SourceDocumentRecord,
     TeiHeaderRecord,
+    WorkflowCheckpointRecord,
 )
 from .repositories import (
     SqlAlchemyApprovalEventRepository,
@@ -43,6 +44,7 @@ from .repositories import (
     SqlAlchemyTeiHeaderRepository,
 )
 from .uow import SqlAlchemyUnitOfWork
+from .workflow_checkpoints import SqlAlchemyWorkflowCheckpointStore
 
 __all__ = (
     "ApprovalEventRecord",
@@ -70,6 +72,8 @@ __all__ = (
     "SqlAlchemySourceDocumentRepository",
     "SqlAlchemyTeiHeaderRepository",
     "SqlAlchemyUnitOfWork",
+    "SqlAlchemyWorkflowCheckpointStore",
     "TeiHeaderRecord",
+    "WorkflowCheckpointRecord",
     "detect_schema_drift",
 )

--- a/episodic/canonical/storage/models.py
+++ b/episodic/canonical/storage/models.py
@@ -24,6 +24,7 @@ from episodic.canonical.domain import (
     ReferenceBindingTargetKind,
     ReferenceDocumentKind,
     ReferenceDocumentLifecycleState,
+    WorkflowCheckpointStatus,
 )
 
 if typ.TYPE_CHECKING:
@@ -74,10 +75,37 @@ REFERENCE_BINDING_TARGET_KIND = sa.Enum(
     name="reference_binding_target_kind",
     values_callable=lambda enum_cls: [item.value for item in enum_cls],
 )
+WORKFLOW_CHECKPOINT_STATUS = sa.Enum(
+    WorkflowCheckpointStatus,
+    name="workflow_checkpoint_status",
+    values_callable=lambda enum_cls: [item.value for item in enum_cls],
+)
 
 
 class WorkflowCheckpointRecord(Base):
-    """SQLAlchemy model for resumable orchestration checkpoints."""
+    """SQLAlchemy model for resumable orchestration checkpoints.
+
+    Attributes
+    ----------
+    id : uuid.UUID
+        Primary key for the checkpoint record.
+    workflow_id : str
+        Indexed workflow correlation identifier used to group checkpoints.
+    workflow_type : str
+        Non-null orchestration workflow category.
+    step_name : str
+        Non-null name of the suspended workflow step.
+    idempotency_key : str
+        Unique key that enforces first-write-wins checkpoint persistence.
+    payload : dict[str, object]
+        Non-null JSONB checkpoint payload containing resumable graph state.
+    status : WorkflowCheckpointStatus
+        Non-null enum status with a default of ``suspended``.
+    created_at : datetime.datetime
+        Timestamp when the checkpoint was created.
+    updated_at : datetime.datetime
+        Timestamp when the checkpoint was last updated.
+    """
 
     __tablename__ = "workflow_checkpoints"
 
@@ -101,10 +129,10 @@ class WorkflowCheckpointRecord(Base):
         postgresql.JSONB,
         nullable=False,
     )
-    status: orm.Mapped[str] = orm.mapped_column(
-        sa.String(80),
+    status: orm.Mapped[WorkflowCheckpointStatus] = orm.mapped_column(
+        WORKFLOW_CHECKPOINT_STATUS,
         nullable=False,
-        server_default="suspended",
+        server_default=WorkflowCheckpointStatus.SUSPENDED.value,
     )
     created_at: orm.Mapped[dt.datetime] = orm.mapped_column(
         sa.DateTime(timezone=True),

--- a/episodic/canonical/storage/models.py
+++ b/episodic/canonical/storage/models.py
@@ -76,6 +76,49 @@ REFERENCE_BINDING_TARGET_KIND = sa.Enum(
 )
 
 
+class WorkflowCheckpointRecord(Base):
+    """SQLAlchemy model for resumable orchestration checkpoints."""
+
+    __tablename__ = "workflow_checkpoints"
+
+    id: orm.Mapped[uuid.UUID] = orm.mapped_column(
+        postgresql.UUID(as_uuid=True),
+        primary_key=True,
+    )
+    workflow_id: orm.Mapped[str] = orm.mapped_column(
+        sa.String(160),
+        nullable=False,
+        index=True,
+    )
+    workflow_type: orm.Mapped[str] = orm.mapped_column(sa.String(120), nullable=False)
+    step_name: orm.Mapped[str] = orm.mapped_column(sa.String(120), nullable=False)
+    idempotency_key: orm.Mapped[str] = orm.mapped_column(
+        sa.String(512),
+        nullable=False,
+        unique=True,
+    )
+    payload: orm.Mapped[dict[str, object]] = orm.mapped_column(
+        postgresql.JSONB,
+        nullable=False,
+    )
+    status: orm.Mapped[str] = orm.mapped_column(
+        sa.String(80),
+        nullable=False,
+        server_default="suspended",
+    )
+    created_at: orm.Mapped[dt.datetime] = orm.mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+    )
+    updated_at: orm.Mapped[dt.datetime] = orm.mapped_column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        server_default=sa.func.now(),
+        onupdate=sa.func.now(),
+    )
+
+
 class SeriesProfileRecord(Base):
     """SQLAlchemy model for series profiles.
 

--- a/episodic/canonical/storage/uow.py
+++ b/episodic/canonical/storage/uow.py
@@ -31,6 +31,7 @@ from .repositories import (
     SqlAlchemySourceDocumentRepository,
     SqlAlchemyTeiHeaderRepository,
 )
+from .workflow_checkpoints import SqlAlchemyWorkflowCheckpointStore
 
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
@@ -108,6 +109,7 @@ class SqlAlchemyUnitOfWork(CanonicalUnitOfWork):
             SqlAlchemyReferenceDocumentRevisionRepository(self._session)
         )
         self.reference_bindings = SqlAlchemyReferenceBindingRepository(self._session)
+        self.workflow_checkpoints = SqlAlchemyWorkflowCheckpointStore(self._session)
         return self
 
     async def __aexit__(

--- a/episodic/canonical/storage/workflow_checkpoints.py
+++ b/episodic/canonical/storage/workflow_checkpoints.py
@@ -8,6 +8,8 @@ to make repeated suspend attempts converge on the first persisted checkpoint.
 It does not import graph code, LLM adapters, or Celery concerns.
 """
 
+from __future__ import annotations
+
 import typing as typ
 import uuid
 
@@ -88,4 +90,18 @@ class SqlAlchemyWorkflowCheckpointStore:
             if existing is not None:
                 return existing
             raise
+        return _map_checkpoint(record)
+
+    async def mark_resumed(self, checkpoint_id: str) -> WorkflowCheckpoint:
+        """Mark a checkpoint as resumed and return the updated record."""
+        record = await self._session.get(
+            WorkflowCheckpointRecord,
+            uuid.UUID(checkpoint_id),
+        )
+        if record is None:
+            msg = f"unknown checkpoint: {checkpoint_id}"
+            raise ValueError(msg)
+        record.status = "resumed"
+        await self._session.flush()
+        await self._session.refresh(record)
         return _map_checkpoint(record)

--- a/episodic/canonical/storage/workflow_checkpoints.py
+++ b/episodic/canonical/storage/workflow_checkpoints.py
@@ -8,14 +8,13 @@ to make repeated suspend attempts converge on the first persisted checkpoint.
 It does not import graph code, LLM adapters, or Celery concerns.
 """
 
-from __future__ import annotations
-
 import typing as typ
 import uuid
 
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
+from episodic.canonical.domain import WorkflowCheckpointStatus
 from episodic.orchestration import WorkflowCheckpoint
 from episodic.orchestration._types import _log_event
 
@@ -34,7 +33,7 @@ def _map_checkpoint(record: WorkflowCheckpointRecord) -> WorkflowCheckpoint:
         step_name=record.step_name,
         idempotency_key=record.idempotency_key,
         payload=record.payload,
-        status=record.status,
+        status=str(record.status),
         created_at=record.created_at,
         updated_at=record.updated_at,
     )
@@ -43,7 +42,7 @@ def _map_checkpoint(record: WorkflowCheckpointRecord) -> WorkflowCheckpoint:
 class SqlAlchemyWorkflowCheckpointStore:
     """Durable SQLAlchemy implementation of the orchestration `CheckpointPort`."""
 
-    def __init__(self, session: AsyncSession) -> None:
+    def __init__(self, session: "AsyncSession") -> None:  # noqa: UP037
         self._session = session
 
     async def get(self, checkpoint_id: str) -> WorkflowCheckpoint | None:
@@ -92,7 +91,7 @@ class SqlAlchemyWorkflowCheckpointStore:
             step_name=checkpoint.step_name,
             idempotency_key=checkpoint.idempotency_key,
             payload=checkpoint.payload,
-            status=checkpoint.status,
+            status=WorkflowCheckpointStatus(checkpoint.status),
         )
         try:
             async with self._session.begin_nested():
@@ -125,7 +124,7 @@ class SqlAlchemyWorkflowCheckpointStore:
         if record is None:
             msg = f"unknown checkpoint: {checkpoint_id}"
             raise ValueError(msg)
-        record.status = "resumed"
+        record.status = WorkflowCheckpointStatus.RESUMED
         await self._session.flush()
         _log_event(
             "debug",

--- a/episodic/canonical/storage/workflow_checkpoints.py
+++ b/episodic/canonical/storage/workflow_checkpoints.py
@@ -1,4 +1,12 @@
-"""SQLAlchemy checkpoint adapter for resumable orchestration workflows."""
+"""SQLAlchemy checkpoint adapter for resumable orchestration workflows.
+
+This adapter implements the orchestration-layer `CheckpointPort` at the
+canonical storage boundary. LangGraph nodes hand it typed
+`WorkflowCheckpoint` DTOs; the adapter maps those DTOs to the
+`workflow_checkpoints` table and relies on the table's unique idempotency key
+to make repeated suspend attempts converge on the first persisted checkpoint.
+It does not import graph code, LLM adapters, or Celery concerns.
+"""
 
 import typing as typ
 import uuid
@@ -30,7 +38,7 @@ def _map_checkpoint(record: WorkflowCheckpointRecord) -> WorkflowCheckpoint:
 
 
 class SqlAlchemyWorkflowCheckpointStore:
-    """SQLAlchemy implementation of the orchestration CheckpointPort."""
+    """Durable SQLAlchemy implementation of the orchestration `CheckpointPort`."""
 
     def __init__(self, session: AsyncSession) -> None:
         self._session = session
@@ -62,9 +70,6 @@ class SqlAlchemyWorkflowCheckpointStore:
 
     async def save(self, checkpoint: WorkflowCheckpoint) -> WorkflowCheckpoint:
         """Persist a checkpoint or return the existing record for its key."""
-        existing = await self.get_by_idempotency_key(checkpoint.idempotency_key)
-        if existing is not None:
-            return existing
         record = WorkflowCheckpointRecord(
             id=uuid.UUID(checkpoint.checkpoint_id),
             workflow_id=checkpoint.workflow_id,
@@ -74,11 +79,11 @@ class SqlAlchemyWorkflowCheckpointStore:
             payload=checkpoint.payload,
             status=checkpoint.status,
         )
-        self._session.add(record)
         try:
-            await self._session.flush()
+            async with self._session.begin_nested():
+                self._session.add(record)
+                await self._session.flush()
         except IntegrityError:
-            await self._session.rollback()
             existing = await self.get_by_idempotency_key(checkpoint.idempotency_key)
             if existing is not None:
                 return existing

--- a/episodic/canonical/storage/workflow_checkpoints.py
+++ b/episodic/canonical/storage/workflow_checkpoints.py
@@ -17,6 +17,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
 from episodic.orchestration import WorkflowCheckpoint
+from episodic.orchestration._types import _log_event
 
 from .models import WorkflowCheckpointRecord
 
@@ -51,6 +52,12 @@ class SqlAlchemyWorkflowCheckpointStore:
             WorkflowCheckpointRecord,
             uuid.UUID(checkpoint_id),
         )
+        _log_event(
+            "debug",
+            "sql_checkpoint_store.get",
+            checkpoint_id=checkpoint_id,
+            found=record is not None,
+        )
         if record is None:
             return None
         return _map_checkpoint(record)
@@ -66,11 +73,17 @@ class SqlAlchemyWorkflowCheckpointStore:
             )
         )
         record = result.scalar_one_or_none()
+        _log_event(
+            "debug",
+            "sql_checkpoint_store.get_by_idempotency_key",
+            idempotency_key=idempotency_key,
+            found=record is not None,
+        )
         if record is None:
             return None
         return _map_checkpoint(record)
 
-    async def save(self, checkpoint: WorkflowCheckpoint) -> WorkflowCheckpoint:
+    async def save_or_reuse(self, checkpoint: WorkflowCheckpoint) -> WorkflowCheckpoint:
         """Persist a checkpoint or return the existing record for its key."""
         record = WorkflowCheckpointRecord(
             id=uuid.UUID(checkpoint.checkpoint_id),
@@ -85,7 +98,18 @@ class SqlAlchemyWorkflowCheckpointStore:
             async with self._session.begin_nested():
                 self._session.add(record)
                 await self._session.flush()
+                _log_event(
+                    "debug",
+                    "sql_checkpoint_store.save_or_reuse.persisted",
+                    checkpoint_id=checkpoint.checkpoint_id,
+                    idempotency_key=checkpoint.idempotency_key,
+                )
         except IntegrityError:
+            _log_event(
+                "warning",
+                "sql_checkpoint_store.save_or_reuse.idempotency_conflict",
+                idempotency_key=checkpoint.idempotency_key,
+            )
             existing = await self.get_by_idempotency_key(checkpoint.idempotency_key)
             if existing is not None:
                 return existing
@@ -103,5 +127,10 @@ class SqlAlchemyWorkflowCheckpointStore:
             raise ValueError(msg)
         record.status = "resumed"
         await self._session.flush()
+        _log_event(
+            "debug",
+            "sql_checkpoint_store.mark_resumed",
+            checkpoint_id=checkpoint_id,
+        )
         await self._session.refresh(record)
         return _map_checkpoint(record)

--- a/episodic/canonical/storage/workflow_checkpoints.py
+++ b/episodic/canonical/storage/workflow_checkpoints.py
@@ -1,0 +1,86 @@
+"""SQLAlchemy checkpoint adapter for resumable orchestration workflows."""
+
+import typing as typ
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+
+from episodic.orchestration import WorkflowCheckpoint
+
+from .models import WorkflowCheckpointRecord
+
+if typ.TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+def _map_checkpoint(record: WorkflowCheckpointRecord) -> WorkflowCheckpoint:
+    """Map a SQLAlchemy checkpoint record to the orchestration DTO."""
+    return WorkflowCheckpoint(
+        checkpoint_id=str(record.id),
+        workflow_id=record.workflow_id,
+        workflow_type=record.workflow_type,
+        step_name=record.step_name,
+        idempotency_key=record.idempotency_key,
+        payload=record.payload,
+        status=record.status,
+        created_at=record.created_at,
+        updated_at=record.updated_at,
+    )
+
+
+class SqlAlchemyWorkflowCheckpointStore:
+    """SQLAlchemy implementation of the orchestration CheckpointPort."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get(self, checkpoint_id: str) -> WorkflowCheckpoint | None:
+        """Return a checkpoint by identifier."""
+        record = await self._session.get(
+            WorkflowCheckpointRecord,
+            uuid.UUID(checkpoint_id),
+        )
+        if record is None:
+            return None
+        return _map_checkpoint(record)
+
+    async def get_by_idempotency_key(
+        self,
+        idempotency_key: str,
+    ) -> WorkflowCheckpoint | None:
+        """Return the checkpoint for an idempotency key."""
+        result = await self._session.execute(
+            select(WorkflowCheckpointRecord).where(
+                WorkflowCheckpointRecord.idempotency_key == idempotency_key
+            )
+        )
+        record = result.scalar_one_or_none()
+        if record is None:
+            return None
+        return _map_checkpoint(record)
+
+    async def save(self, checkpoint: WorkflowCheckpoint) -> WorkflowCheckpoint:
+        """Persist a checkpoint or return the existing record for its key."""
+        existing = await self.get_by_idempotency_key(checkpoint.idempotency_key)
+        if existing is not None:
+            return existing
+        record = WorkflowCheckpointRecord(
+            id=uuid.UUID(checkpoint.checkpoint_id),
+            workflow_id=checkpoint.workflow_id,
+            workflow_type=checkpoint.workflow_type,
+            step_name=checkpoint.step_name,
+            idempotency_key=checkpoint.idempotency_key,
+            payload=checkpoint.payload,
+            status=checkpoint.status,
+        )
+        self._session.add(record)
+        try:
+            await self._session.flush()
+        except IntegrityError:
+            await self._session.rollback()
+            existing = await self.get_by_idempotency_key(checkpoint.idempotency_key)
+            if existing is not None:
+                return existing
+            raise
+        return _map_checkpoint(record)

--- a/episodic/orchestration/__init__.py
+++ b/episodic/orchestration/__init__.py
@@ -1,5 +1,6 @@
 """Structured planning and tool execution for generation orchestration."""
 
+from episodic.orchestration.checkpoints import InMemoryCheckpointStore
 from episodic.orchestration.generation import (
     ActionExecutionResult,
     ActionKind,
@@ -12,18 +13,23 @@ from episodic.orchestration.generation import (
     PlannerPort,
     PlannerResult,
     PlanningResponseFormatError,
+    ResumeWorkflowCommand,
     ShowNotesFormatError,
     ShowNotesToolExecutor,
     StructuredGenerationPlanner,
     StructuredPlanningOrchestrator,
+    SuspendedWorkflowResult,
     ToolExecutionError,
     ToolExecutorPort,
     UnsupportedActionError,
+    WorkflowCheckpoint,
     build_generation_result,
+    build_workflow_step_idempotency_key,
 )
 from episodic.orchestration.langgraph import (
     GenerationGraphState,
     build_generation_orchestration_graph,
+    resume_generation_orchestration,
 )
 
 __all__ = [
@@ -34,18 +40,24 @@ __all__ = [
     "GenerationOrchestrationConfig",
     "GenerationOrchestrationRequest",
     "GenerationOrchestrationResult",
+    "InMemoryCheckpointStore",
     "ModelTier",
     "PlannedAction",
     "PlannerPort",
     "PlannerResult",
     "PlanningResponseFormatError",
+    "ResumeWorkflowCommand",
     "ShowNotesFormatError",
     "ShowNotesToolExecutor",
     "StructuredGenerationPlanner",
     "StructuredPlanningOrchestrator",
+    "SuspendedWorkflowResult",
     "ToolExecutionError",
     "ToolExecutorPort",
     "UnsupportedActionError",
+    "WorkflowCheckpoint",
     "build_generation_orchestration_graph",
     "build_generation_result",
+    "build_workflow_step_idempotency_key",
+    "resume_generation_orchestration",
 ]

--- a/episodic/orchestration/__init__.py
+++ b/episodic/orchestration/__init__.py
@@ -23,6 +23,7 @@ from episodic.orchestration.generation import (
     ToolExecutorPort,
     UnsupportedActionError,
     WorkflowCheckpoint,
+    WorkflowStepIdentity,
     build_generation_result,
     build_workflow_step_idempotency_key,
 )
@@ -56,6 +57,7 @@ __all__ = [
     "ToolExecutorPort",
     "UnsupportedActionError",
     "WorkflowCheckpoint",
+    "WorkflowStepIdentity",
     "build_generation_orchestration_graph",
     "build_generation_result",
     "build_workflow_step_idempotency_key",

--- a/episodic/orchestration/_dto.py
+++ b/episodic/orchestration/_dto.py
@@ -471,12 +471,28 @@ class ResumeWorkflowCommand:
             raise TypeError(msg)
 
 
-def build_workflow_step_idempotency_key(  # noqa: PLR0913
+@dc.dataclass(frozen=True, slots=True)
+class WorkflowStepIdentity:
+    """Stable identity fields for one resumable workflow step."""
+
+    workflow_id: str
+    workflow_type: str
+    step_name: str
+    action_id: str
+
+    def __post_init__(self) -> None:
+        """Normalise identity fields eagerly."""
+        for field_name in ("workflow_id", "workflow_type", "step_name", "action_id"):
+            object.__setattr__(
+                self,
+                field_name,
+                _normalize_non_empty_text(getattr(self, field_name), field_name),
+            )
+
+
+def build_workflow_step_idempotency_key(
+    step: WorkflowStepIdentity,
     *,
-    workflow_id: str,
-    workflow_type: str,
-    step_name: str,
-    action_id: str,
     attempt: int = 0,
 ) -> str:
     """Build the deterministic idempotency key for a suspendable workflow step."""
@@ -484,10 +500,10 @@ def build_workflow_step_idempotency_key(  # noqa: PLR0913
         msg = "attempt must be greater than or equal to zero."
         raise ValueError(msg)
     parts = (
-        _normalize_non_empty_text(workflow_id, "workflow_id"),
-        _normalize_non_empty_text(workflow_type, "workflow_type"),
-        _normalize_non_empty_text(step_name, "step_name"),
-        _normalize_non_empty_text(action_id, "action_id"),
+        step.workflow_id,
+        step.workflow_type,
+        step.step_name,
+        step.action_id,
         str(attempt),
     )
     return ":".join(parts)

--- a/episodic/orchestration/_dto.py
+++ b/episodic/orchestration/_dto.py
@@ -1,5 +1,7 @@
 """Typed DTOs, protocols, and validation helpers for generation orchestration."""
 
+from __future__ import annotations
+
 import collections.abc as cabc
 import dataclasses as dc
 import typing as typ
@@ -11,6 +13,8 @@ from episodic.llm import (
 )
 
 if typ.TYPE_CHECKING:
+    import datetime as dt
+
     from episodic.generation import ShowNotesResult
 
 from ._types import (
@@ -396,3 +400,94 @@ class GenerationOrchestrationResult:
                 )
                 raise TypeError(msg)
         object.__setattr__(self, "action_results", action_results)
+
+
+@dc.dataclass(frozen=True, slots=True)
+class WorkflowCheckpoint:
+    """Durable orchestration state saved when a generation workflow pauses."""
+
+    checkpoint_id: str
+    workflow_id: str
+    workflow_type: str
+    step_name: str
+    idempotency_key: str
+    payload: dict[str, object]
+    status: str = "suspended"
+    created_at: dt.datetime | None = None
+    updated_at: dt.datetime | None = None
+
+    def __post_init__(self) -> None:
+        """Validate checkpoint identity fields and freeze the payload mapping."""
+        _normalize_string_fields(
+            self,
+            (
+                "checkpoint_id",
+                "workflow_id",
+                "workflow_type",
+                "step_name",
+                "idempotency_key",
+                "status",
+            ),
+        )
+        if not isinstance(self.payload, dict):
+            msg = "payload must be a mapping object."
+            raise TypeError(msg)
+        object.__setattr__(self, "payload", dict(self.payload))
+
+
+@dc.dataclass(frozen=True, slots=True)
+class SuspendedWorkflowResult:
+    """Typed result returned when a graph pauses before external work resumes it."""
+
+    checkpoint_id: str
+    workflow_id: str
+    step_name: str
+    idempotency_key: str
+
+    def __post_init__(self) -> None:
+        """Reject blank suspend metadata."""
+        _normalize_string_fields(
+            self,
+            ("checkpoint_id", "workflow_id", "step_name", "idempotency_key"),
+        )
+
+
+@dc.dataclass(frozen=True, slots=True)
+class ResumeWorkflowCommand:
+    """Input for resuming a suspended workflow from a durable checkpoint."""
+
+    checkpoint_id: str
+    result: ActionExecutionResult
+
+    def __post_init__(self) -> None:
+        """Validate resume identity and result shape."""
+        object.__setattr__(
+            self,
+            "checkpoint_id",
+            _normalize_non_empty_text(self.checkpoint_id, "checkpoint_id"),
+        )
+        if not isinstance(self.result, ActionExecutionResult):
+            msg = "result must be an ActionExecutionResult."
+            raise TypeError(msg)
+
+
+def build_workflow_step_idempotency_key(  # noqa: PLR0913
+    *,
+    workflow_id: str,
+    workflow_type: str,
+    step_name: str,
+    action_id: str,
+    attempt: int = 0,
+) -> str:
+    """Build the deterministic idempotency key for a suspendable workflow step."""
+    if attempt < 0:
+        msg = "attempt must be greater than or equal to zero."
+        raise ValueError(msg)
+    parts = (
+        _normalize_non_empty_text(workflow_id, "workflow_id"),
+        _normalize_non_empty_text(workflow_type, "workflow_type"),
+        _normalize_non_empty_text(step_name, "step_name"),
+        _normalize_non_empty_text(action_id, "action_id"),
+        str(attempt),
+    )
+    return ":".join(parts)

--- a/episodic/orchestration/_dto.py
+++ b/episodic/orchestration/_dto.py
@@ -1,11 +1,21 @@
-"""Typed DTOs, protocols, and validation helpers for generation orchestration."""
+"""Typed DTOs and validation helpers for generation orchestration.
 
-from __future__ import annotations
+These immutable dataclasses are the application-level contracts shared by the
+planner, tool executors, LangGraph wrapper, checkpoint ports, and API-facing
+service code. The checkpoint DTOs in this module carry only resumable workflow
+state: stable workflow identity, the idempotency key for the paused step, and a
+JSON-shaped payload that the graph can reconstruct during resume. Persistence
+adapters map these DTOs to storage records without leaking database models back
+into orchestration policy.
+"""
 
 import collections.abc as cabc
 import dataclasses as dc
 import typing as typ
 
+from episodic.generation import (
+    ShowNotesResult,  # noqa: TC001 -- Python 3.14 lazy dataclass annotations are inspected by Hypothesis at runtime.
+)
 from episodic.llm import (
     LLMProviderOperation,
     LLMTokenBudget,
@@ -14,8 +24,6 @@ from episodic.llm import (
 
 if typ.TYPE_CHECKING:
     import datetime as dt
-
-    from episodic.generation import ShowNotesResult
 
 from ._types import (
     ActionKind,
@@ -404,7 +412,13 @@ class GenerationOrchestrationResult:
 
 @dc.dataclass(frozen=True, slots=True)
 class WorkflowCheckpoint:
-    """Durable orchestration state saved when a generation workflow pauses."""
+    """Durable orchestration state saved when a generation workflow pauses.
+
+    `CheckpointPort` implementations persist this DTO before the graph crosses
+    an external boundary. `workflow_id`, `workflow_type`, `step_name`, and
+    `idempotency_key` identify the resumable step; `payload` stores the
+    JSON-shaped graph state needed by `resume_generation_orchestration`.
+    """
 
     checkpoint_id: str
     workflow_id: str
@@ -437,7 +451,12 @@ class WorkflowCheckpoint:
 
 @dc.dataclass(frozen=True, slots=True)
 class SuspendedWorkflowResult:
-    """Typed result returned when a graph pauses before external work resumes it."""
+    """Typed result returned when a graph pauses before external work resumes it.
+
+    API handlers and worker dispatchers can use this value to expose the
+    checkpoint identifier and idempotency key without depending on LangGraph
+    state internals or storage adapter records.
+    """
 
     checkpoint_id: str
     workflow_id: str
@@ -454,7 +473,12 @@ class SuspendedWorkflowResult:
 
 @dc.dataclass(frozen=True, slots=True)
 class ResumeWorkflowCommand:
-    """Input for resuming a suspended workflow from a durable checkpoint."""
+    """Input for resuming a suspended workflow from a durable checkpoint.
+
+    The command combines the checkpoint identifier with the externally produced
+    action result. `TaskResumePort` implementations validate or transform that
+    result before the graph aggregates the final orchestration outcome.
+    """
 
     checkpoint_id: str
     result: ActionExecutionResult

--- a/episodic/orchestration/_dto.py
+++ b/episodic/orchestration/_dto.py
@@ -341,7 +341,7 @@ class PlannerResult:
     """Planner output plus normalized provider metadata."""
 
     plan: ExecutionPlan
-    usage: LLMUsage
+    usage: LLMUsage | None
     model: str
     provider_response_id: str
     finish_reason: str | None
@@ -394,7 +394,7 @@ class GenerationOrchestrationResult:
 
     plan: ExecutionPlan
     action_results: tuple[ActionExecutionResult, ...]
-    planner_usage: LLMUsage
+    planner_usage: LLMUsage | None
     total_usage: LLMUsage
 
     def __post_init__(self) -> None:

--- a/episodic/orchestration/_protocols.py
+++ b/episodic/orchestration/_protocols.py
@@ -59,6 +59,9 @@ class CheckpointPort(typ.Protocol):
     async def save(self, checkpoint: WorkflowCheckpoint) -> WorkflowCheckpoint:
         """Persist a checkpoint or return the existing record for its key."""
 
+    async def mark_resumed(self, checkpoint_id: str) -> WorkflowCheckpoint:
+        """Mark a checkpoint as resumed and return the updated record."""
+
 
 class TaskResumePort(typ.Protocol):
     """Application-level port for resuming suspended workflow tasks."""

--- a/episodic/orchestration/_protocols.py
+++ b/episodic/orchestration/_protocols.py
@@ -1,4 +1,13 @@
-"""Protocol definitions for generation orchestration boundaries."""
+"""Protocol definitions for generation orchestration boundaries.
+
+The generation graph is deliberately written against these ports so domain
+policy remains independent from LangGraph, SQLAlchemy, Celery, and LLM
+provider adapters. `PlannerPort` and `ToolExecutorPort` drive the normal
+plan/execute flow. `CheckpointPort` and `TaskResumePort` define the
+suspend/resume seam: graph nodes persist typed checkpoint DTOs before
+side-effecting work and later consume externally supplied action results
+without knowing which queue, worker, or user interface produced them.
+"""
 
 import typing as typ
 

--- a/episodic/orchestration/_protocols.py
+++ b/episodic/orchestration/_protocols.py
@@ -56,8 +56,12 @@ class CheckpointPort(typ.Protocol):
     ) -> WorkflowCheckpoint | None:
         """Return the checkpoint recorded for a suspendable step key."""
 
-    async def save(self, checkpoint: WorkflowCheckpoint) -> WorkflowCheckpoint:
-        """Persist a checkpoint or return the existing record for its key."""
+    async def save_or_reuse(self, checkpoint: WorkflowCheckpoint) -> WorkflowCheckpoint:
+        """Persist the checkpoint if the idempotency key is new.
+
+        Return the existing record unchanged if the key was already written
+        (first-write-wins).
+        """
 
     async def mark_resumed(self, checkpoint_id: str) -> WorkflowCheckpoint:
         """Mark a checkpoint as resumed and return the updated record."""

--- a/episodic/orchestration/_protocols.py
+++ b/episodic/orchestration/_protocols.py
@@ -9,6 +9,8 @@ if typ.TYPE_CHECKING:
         GenerationOrchestrationRequest,
         PlannedAction,
         PlannerResult,
+        ResumeWorkflowCommand,
+        WorkflowCheckpoint,
     )
 
 
@@ -31,6 +33,29 @@ class PlannerPort(typ.Protocol):
         request: GenerationOrchestrationRequest,
     ) -> PlannerResult:
         """Return a typed execution plan for the supplied generation request."""
+
+
+class CheckpointPort(typ.Protocol):
+    """Persistence port for suspended generation workflow checkpoints."""
+
+    async def get(self, checkpoint_id: str) -> WorkflowCheckpoint | None:
+        """Return a checkpoint by identifier, or None when it is unknown."""
+
+    async def get_by_idempotency_key(
+        self,
+        idempotency_key: str,
+    ) -> WorkflowCheckpoint | None:
+        """Return the checkpoint recorded for a suspendable step key."""
+
+    async def save(self, checkpoint: WorkflowCheckpoint) -> WorkflowCheckpoint:
+        """Persist a checkpoint or return the existing record for its key."""
+
+
+class TaskResumePort(typ.Protocol):
+    """Application-level port for resuming suspended workflow tasks."""
+
+    async def resume(self, command: ResumeWorkflowCommand) -> ActionExecutionResult:
+        """Return the externally supplied result for a suspended task."""
 
 
 class _ShowNotesGeneratorPort(typ.Protocol):

--- a/episodic/orchestration/checkpoints.py
+++ b/episodic/orchestration/checkpoints.py
@@ -1,0 +1,49 @@
+"""Checkpoint adapters and helpers for resumable generation orchestration."""
+
+import dataclasses as dc
+import datetime as dt
+
+from episodic.orchestration._dto import WorkflowCheckpoint
+
+
+@dc.dataclass(slots=True)
+class InMemoryCheckpointStore:
+    """In-memory checkpoint adapter for fast orchestration tests."""
+
+    _by_id: dict[str, WorkflowCheckpoint] = dc.field(default_factory=dict)
+    _by_key: dict[str, str] = dc.field(default_factory=dict)
+
+    async def get(self, checkpoint_id: str) -> WorkflowCheckpoint | None:
+        """Return a checkpoint by identifier."""
+        return self._by_id.get(checkpoint_id)
+
+    async def get_by_idempotency_key(
+        self,
+        idempotency_key: str,
+    ) -> WorkflowCheckpoint | None:
+        """Return a checkpoint by its step idempotency key."""
+        checkpoint_id = self._by_key.get(idempotency_key)
+        if checkpoint_id is None:
+            return None
+        return self._by_id[checkpoint_id]
+
+    async def save(self, checkpoint: WorkflowCheckpoint) -> WorkflowCheckpoint:
+        """Persist a checkpoint, preserving the first record for a key."""
+        existing = await self.get_by_idempotency_key(checkpoint.idempotency_key)
+        if existing is not None:
+            return existing
+        now = dt.datetime.now(dt.UTC)
+        stored = WorkflowCheckpoint(
+            checkpoint_id=checkpoint.checkpoint_id,
+            workflow_id=checkpoint.workflow_id,
+            workflow_type=checkpoint.workflow_type,
+            step_name=checkpoint.step_name,
+            idempotency_key=checkpoint.idempotency_key,
+            payload=checkpoint.payload,
+            status=checkpoint.status,
+            created_at=checkpoint.created_at or now,
+            updated_at=checkpoint.updated_at or now,
+        )
+        self._by_id[stored.checkpoint_id] = stored
+        self._by_key[stored.idempotency_key] = stored.checkpoint_id
+        return stored

--- a/episodic/orchestration/checkpoints.py
+++ b/episodic/orchestration/checkpoints.py
@@ -46,14 +46,14 @@ class InMemoryCheckpointStore:
             return None
         return self._by_id[checkpoint_id]
 
-    async def save(self, checkpoint: WorkflowCheckpoint) -> WorkflowCheckpoint:
+    async def save_or_reuse(self, checkpoint: WorkflowCheckpoint) -> WorkflowCheckpoint:
         """Persist a checkpoint, preserving the first record for a key."""
         async with self._lock:
             existing = await self.get_by_idempotency_key(checkpoint.idempotency_key)
             if existing is not None:
                 _log_event(
                     "debug",
-                    "checkpoint_store.in_memory.save.reuse",
+                    "checkpoint_store.in_memory.save_or_reuse.reuse",
                     checkpoint_id=existing.checkpoint_id,
                     idempotency_key=existing.idempotency_key,
                 )
@@ -74,7 +74,7 @@ class InMemoryCheckpointStore:
             self._by_key[stored.idempotency_key] = stored.checkpoint_id
             _log_event(
                 "debug",
-                "checkpoint_store.in_memory.save.created",
+                "checkpoint_store.in_memory.save_or_reuse.created",
                 checkpoint_id=stored.checkpoint_id,
                 idempotency_key=stored.idempotency_key,
             )

--- a/episodic/orchestration/checkpoints.py
+++ b/episodic/orchestration/checkpoints.py
@@ -79,3 +79,30 @@ class InMemoryCheckpointStore:
                 idempotency_key=stored.idempotency_key,
             )
             return stored
+
+    async def mark_resumed(self, checkpoint_id: str) -> WorkflowCheckpoint:
+        """Mark a stored checkpoint as resumed and return the updated record."""
+        async with self._lock:
+            existing = self._by_id.get(checkpoint_id)
+            if existing is None:
+                msg = f"unknown checkpoint: {checkpoint_id}"
+                raise ValueError(msg)
+            resumed = WorkflowCheckpoint(
+                checkpoint_id=existing.checkpoint_id,
+                workflow_id=existing.workflow_id,
+                workflow_type=existing.workflow_type,
+                step_name=existing.step_name,
+                idempotency_key=existing.idempotency_key,
+                payload=existing.payload,
+                status="resumed",
+                created_at=existing.created_at,
+                updated_at=self.time_provider(),
+            )
+            self._by_id[checkpoint_id] = resumed
+            _log_event(
+                "debug",
+                "checkpoint_store.in_memory.mark_resumed",
+                checkpoint_id=resumed.checkpoint_id,
+                idempotency_key=resumed.idempotency_key,
+            )
+            return resumed

--- a/episodic/orchestration/checkpoints.py
+++ b/episodic/orchestration/checkpoints.py
@@ -1,17 +1,36 @@
-"""Checkpoint adapters and helpers for resumable generation orchestration."""
+"""Checkpoint adapters for resumable generation orchestration.
 
+The orchestration graph depends on the `CheckpointPort` protocol rather than a
+database implementation. This module supplies the lightweight in-memory adapter
+used by unit and behavioural tests to exercise the same suspend/resume contract
+without SQLAlchemy. It preserves first-write-wins idempotency for workflow-step
+keys and injects its clock so tests can make timestamp behaviour deterministic.
+
+`InMemoryCheckpointStore` is intentionally process-local and unbounded. It is
+not suitable for production services without eviction, persistence, and
+cross-process coordination; production code should use the canonical storage
+adapter instead.
+"""
+
+import asyncio
 import dataclasses as dc
 import datetime as dt
+import typing as typ
 
 from episodic.orchestration._dto import WorkflowCheckpoint
+from episodic.orchestration._types import _log_event
+
+TimeProvider = typ.Callable[[], dt.datetime]
 
 
 @dc.dataclass(slots=True)
 class InMemoryCheckpointStore:
-    """In-memory checkpoint adapter for fast orchestration tests."""
+    """In-memory `CheckpointPort` adapter with atomic first-write semantics."""
 
+    time_provider: TimeProvider = lambda: dt.datetime.now(dt.UTC)
     _by_id: dict[str, WorkflowCheckpoint] = dc.field(default_factory=dict)
     _by_key: dict[str, str] = dc.field(default_factory=dict)
+    _lock: asyncio.Lock = dc.field(default_factory=asyncio.Lock)
 
     async def get(self, checkpoint_id: str) -> WorkflowCheckpoint | None:
         """Return a checkpoint by identifier."""
@@ -29,21 +48,34 @@ class InMemoryCheckpointStore:
 
     async def save(self, checkpoint: WorkflowCheckpoint) -> WorkflowCheckpoint:
         """Persist a checkpoint, preserving the first record for a key."""
-        existing = await self.get_by_idempotency_key(checkpoint.idempotency_key)
-        if existing is not None:
-            return existing
-        now = dt.datetime.now(dt.UTC)
-        stored = WorkflowCheckpoint(
-            checkpoint_id=checkpoint.checkpoint_id,
-            workflow_id=checkpoint.workflow_id,
-            workflow_type=checkpoint.workflow_type,
-            step_name=checkpoint.step_name,
-            idempotency_key=checkpoint.idempotency_key,
-            payload=checkpoint.payload,
-            status=checkpoint.status,
-            created_at=checkpoint.created_at or now,
-            updated_at=checkpoint.updated_at or now,
-        )
-        self._by_id[stored.checkpoint_id] = stored
-        self._by_key[stored.idempotency_key] = stored.checkpoint_id
-        return stored
+        async with self._lock:
+            existing = await self.get_by_idempotency_key(checkpoint.idempotency_key)
+            if existing is not None:
+                _log_event(
+                    "debug",
+                    "checkpoint_store.in_memory.save.reuse",
+                    checkpoint_id=existing.checkpoint_id,
+                    idempotency_key=existing.idempotency_key,
+                )
+                return existing
+            now = self.time_provider()
+            stored = WorkflowCheckpoint(
+                checkpoint_id=checkpoint.checkpoint_id,
+                workflow_id=checkpoint.workflow_id,
+                workflow_type=checkpoint.workflow_type,
+                step_name=checkpoint.step_name,
+                idempotency_key=checkpoint.idempotency_key,
+                payload=checkpoint.payload,
+                status=checkpoint.status,
+                created_at=checkpoint.created_at or now,
+                updated_at=checkpoint.updated_at or now,
+            )
+            self._by_id[stored.checkpoint_id] = stored
+            self._by_key[stored.idempotency_key] = stored.checkpoint_id
+            _log_event(
+                "debug",
+                "checkpoint_store.in_memory.save.created",
+                checkpoint_id=stored.checkpoint_id,
+                idempotency_key=stored.idempotency_key,
+            )
+            return stored

--- a/episodic/orchestration/generation.py
+++ b/episodic/orchestration/generation.py
@@ -21,6 +21,7 @@ from ._dto import (
     ResumeWorkflowCommand,
     SuspendedWorkflowResult,
     WorkflowCheckpoint,
+    WorkflowStepIdentity,
     _coerce_action_kind,
     _coerce_action_kinds,
     _coerce_model_tier,
@@ -65,6 +66,7 @@ __all__ = [
     "ToolExecutorPort",
     "UnsupportedActionError",
     "WorkflowCheckpoint",
+    "WorkflowStepIdentity",
     "build_generation_result",
     "build_workflow_step_idempotency_key",
 ]

--- a/episodic/orchestration/generation.py
+++ b/episodic/orchestration/generation.py
@@ -18,6 +18,9 @@ from ._dto import (
     GenerationOrchestrationResult,
     PlannedAction,
     PlannerResult,
+    ResumeWorkflowCommand,
+    SuspendedWorkflowResult,
+    WorkflowCheckpoint,
     _coerce_action_kind,
     _coerce_action_kinds,
     _coerce_model_tier,
@@ -25,6 +28,7 @@ from ._dto import (
     _require_object,
     _require_optional_string_list,
     _require_plan_step_list,
+    build_workflow_step_idempotency_key,
 )
 from ._protocols import PlannerPort, ToolExecutorPort
 from ._show_notes_executor import ShowNotesToolExecutor
@@ -51,14 +55,18 @@ __all__ = [
     "PlannerPort",
     "PlannerResult",
     "PlanningResponseFormatError",
+    "ResumeWorkflowCommand",
     "ShowNotesFormatError",
     "ShowNotesToolExecutor",
     "StructuredGenerationPlanner",
     "StructuredPlanningOrchestrator",
+    "SuspendedWorkflowResult",
     "ToolExecutionError",
     "ToolExecutorPort",
     "UnsupportedActionError",
+    "WorkflowCheckpoint",
     "build_generation_result",
+    "build_workflow_step_idempotency_key",
 ]
 
 

--- a/episodic/orchestration/langgraph.py
+++ b/episodic/orchestration/langgraph.py
@@ -456,6 +456,12 @@ async def resume_generation_orchestration(
 ) -> dto.GenerationOrchestrationResult:
     """Resume a suspended generation workflow and return the final result.
 
+    `resume_generation_orchestration` currently assumes one suspended action
+    per checkpoint: `resume_port.resume(command)` returns one action result, and
+    `build_generation_result(planner_result, (action_result,))` finalises that
+    single result. Any future model that allows one checkpoint to cover
+    multiple `planner_result.plan.steps` entries must update this code path.
+
     Raises
     ------
         ValueError: If the command references an unknown checkpoint.
@@ -478,6 +484,12 @@ async def resume_generation_orchestration(
         raise ValueError(msg)
     payload = checkpoint.payload
     planner_result = _planner_result_from_payload(payload["planner_result"])
+    if len(planner_result.plan.steps) != 1:
+        msg = (
+            "resume_generation_orchestration currently supports exactly one "
+            "planned step per suspended checkpoint."
+        )
+        raise ValueError(msg)
     action_result = await resume_port.resume(command)
     result = build_generation_result(planner_result, (action_result,))
     resumed_checkpoint = await checkpoint_port.mark_resumed(checkpoint.checkpoint_id)

--- a/episodic/orchestration/langgraph.py
+++ b/episodic/orchestration/langgraph.py
@@ -52,39 +52,63 @@ def _usage_to_payload(usage: LLMUsage | None) -> dict[str, int] | None:
     }
 
 
-def _as_object_payload(payload: object, field_name: str) -> dict[str, object]:
+def _as_object_payload(payload: object, context: str) -> dict[str, object]:
     """Return payload as a string-keyed object."""
     if not isinstance(payload, dict):
-        msg = f"checkpoint {field_name} payload must be an object."
+        msg = f"checkpoint {context} payload must be an object."
         raise TypeError(msg)
     return typ.cast("dict[str, object]", payload)
 
 
-def _required_int(payload: dict[str, object], field_name: str) -> int:
+def _require_field[FieldT](
+    payload: dict[str, object],
+    field_name: str,
+    expected_type: type[FieldT],
+    *,
+    context: str,
+) -> FieldT:
+    """Return a required typed checkpoint payload field."""
+    try:
+        value = payload[field_name]
+    except KeyError as exc:
+        msg = f"checkpoint {context} missing required field: {field_name}"
+        raise KeyError(msg) from exc
+    if not isinstance(value, expected_type):
+        msg = (
+            f"checkpoint {context} field {field_name} must be a "
+            f"{expected_type.__name__}."
+        )
+        raise TypeError(msg)
+    return value
+
+
+def _required_int(
+    payload: dict[str, object],
+    field_name: str,
+    *,
+    context: str,
+) -> int:
     """Return an integer field from a checkpoint payload."""
-    value = payload[field_name]
-    if not isinstance(value, int):
-        msg = f"checkpoint {field_name} must be an integer."
-        raise TypeError(msg)
-    return value
+    return _require_field(payload, field_name, int, context=context)
 
 
-def _required_string(payload: dict[str, object], field_name: str) -> str:
+def _required_string(
+    payload: dict[str, object],
+    field_name: str,
+    *,
+    context: str,
+) -> str:
     """Return a string field from a checkpoint payload."""
-    value = payload[field_name]
-    if not isinstance(value, str):
-        msg = f"checkpoint {field_name} must be a string."
-        raise TypeError(msg)
-    return value
+    return _require_field(payload, field_name, str, context=context)
 
 
 def _usage_from_payload(payload: object) -> LLMUsage:
     """Return LLMUsage from a checkpoint payload."""
     usage_payload = _as_object_payload(payload, "usage")
     return LLMUsage(
-        input_tokens=_required_int(usage_payload, "input_tokens"),
-        output_tokens=_required_int(usage_payload, "output_tokens"),
-        total_tokens=_required_int(usage_payload, "total_tokens"),
+        input_tokens=_required_int(usage_payload, "input_tokens", context="usage"),
+        output_tokens=_required_int(usage_payload, "output_tokens", context="usage"),
+        total_tokens=_required_int(usage_payload, "total_tokens", context="usage"),
     )
 
 
@@ -115,21 +139,31 @@ def _plan_from_payload(payload: object) -> dto.ExecutionPlan:
         msg = "checkpoint plan steps must be a list."
         raise TypeError(msg)
     return dto.ExecutionPlan(
-        plan_version=_required_string(plan_payload, "plan_version"),
+        plan_version=_required_string(
+            plan_payload,
+            "plan_version",
+            context="plan",
+        ),
         selected_planning_model=_required_string(
             plan_payload,
             "selected_planning_model",
+            context="plan",
         ),
         selected_execution_model=_required_string(
             plan_payload,
             "selected_execution_model",
+            context="plan",
         ),
         steps=tuple(
             dto.PlannedAction(
-                action_id=_required_string(step, "action_id"),
-                action_kind=dto.ActionKind(_required_string(step, "action_kind")),
-                rationale=_required_string(step, "rationale"),
-                model_tier=dto.ModelTier(_required_string(step, "model_tier")),
+                action_id=_required_string(step, "action_id", context="plan step"),
+                action_kind=dto.ActionKind(
+                    _required_string(step, "action_kind", context="plan step")
+                ),
+                rationale=_required_string(step, "rationale", context="plan step"),
+                model_tier=dto.ModelTier(
+                    _required_string(step, "model_tier", context="plan step")
+                ),
                 required_inputs=tuple(
                     str(item)
                     for item in typ.cast(
@@ -159,13 +193,25 @@ def _planner_result_from_payload(payload: object) -> dto.PlannerResult:
     planner_payload = _as_object_payload(payload, "planner_result")
     return dto.PlannerResult(
         plan=_plan_from_payload(planner_payload["plan"]),
-        usage=_usage_from_payload(planner_payload["usage"]),
-        model=_required_string(planner_payload, "model"),
-        provider_response_id=_required_string(planner_payload, "provider_response_id"),
+        usage=(
+            None
+            if planner_payload.get("usage") is None
+            else _usage_from_payload(planner_payload["usage"])
+        ),
+        model=_required_string(planner_payload, "model", context="planner_result"),
+        provider_response_id=_required_string(
+            planner_payload,
+            "provider_response_id",
+            context="planner_result",
+        ),
         finish_reason=(
             None
             if planner_payload.get("finish_reason") is None
-            else _required_string(planner_payload, "finish_reason")
+            else _required_string(
+                planner_payload,
+                "finish_reason",
+                context="planner_result",
+            )
         ),
     )
 
@@ -186,11 +232,17 @@ def _action_result_from_payload(payload: object) -> dto.ActionExecutionResult:
     """Return an ActionExecutionResult from a checkpoint payload."""
     action_payload = _as_object_payload(payload, "action_result")
     return dto.ActionExecutionResult(
-        action_id=_required_string(action_payload, "action_id"),
-        action_kind=dto.ActionKind(_required_string(action_payload, "action_kind")),
-        model_tier=dto.ModelTier(_required_string(action_payload, "model_tier")),
-        model=_required_string(action_payload, "model"),
-        summary=_required_string(action_payload, "summary"),
+        action_id=_required_string(
+            action_payload, "action_id", context="action_result"
+        ),
+        action_kind=dto.ActionKind(
+            _required_string(action_payload, "action_kind", context="action_result")
+        ),
+        model_tier=dto.ModelTier(
+            _required_string(action_payload, "model_tier", context="action_result")
+        ),
+        model=_required_string(action_payload, "model", context="action_result"),
+        summary=_required_string(action_payload, "summary", context="action_result"),
         usage=(
             None
             if action_payload.get("usage") is None
@@ -294,6 +346,37 @@ async def _execute_node(
     return result
 
 
+def _build_execute_step_identity(
+    *,
+    request: dto.GenerationOrchestrationRequest,
+    action: dto.PlannedAction,
+    workflow_type: str,
+) -> dto.WorkflowStepIdentity:
+    """Return the idempotency identity for the execute workflow step."""
+    return dto.WorkflowStepIdentity(
+        workflow_id=request.correlation_id,
+        workflow_type=workflow_type,
+        step_name="execute",
+        action_id=action.action_id,
+    )
+
+
+def _build_checkpoint_payload(
+    *,
+    request: dto.GenerationOrchestrationRequest,
+    planner_result: dto.PlannerResult,
+) -> dict[str, object]:
+    """Return the persisted suspend payload for generation resume."""
+    return {
+        "request": {
+            "correlation_id": request.correlation_id,
+            "script_tei_xml": request.script_tei_xml,
+            "template_structure": request.template_structure,
+        },
+        "planner_result": _planner_result_to_payload(planner_result),
+    }
+
+
 async def _suspend_execute_node(
     state: GenerationGraphState,
     *,
@@ -314,23 +397,22 @@ async def _suspend_execute_node(
         raise ValueError(msg)
 
     action = planner_result.plan.steps[0]
-    workflow_id = request.correlation_id
+    identity = _build_execute_step_identity(
+        request=request,
+        action=action,
+        workflow_type=workflow_type,
+    )
     idempotency_key = dto.build_workflow_step_idempotency_key(
-        dto.WorkflowStepIdentity(
-            workflow_id=workflow_id,
-            workflow_type=workflow_type,
-            step_name="execute",
-            action_id=action.action_id,
-        )
+        identity,
     )
     _log_event(
         "debug",
         "generation_graph.suspend_execute_node.start",
         correlation_id=request.correlation_id,
-        workflow_id=workflow_id,
-        workflow_type=workflow_type,
-        step_name="execute",
-        action_id=action.action_id,
+        workflow_id=identity.workflow_id,
+        workflow_type=identity.workflow_type,
+        step_name=identity.step_name,
+        action_id=identity.action_id,
         idempotency_key=idempotency_key,
     )
     existing = await checkpoint_port.get_by_idempotency_key(idempotency_key)
@@ -339,18 +421,14 @@ async def _suspend_execute_node(
         existing = await checkpoint_port.save(
             dto.WorkflowCheckpoint(
                 checkpoint_id=str(uuid.uuid4()),
-                workflow_id=workflow_id,
-                workflow_type=workflow_type,
-                step_name="execute",
+                workflow_id=identity.workflow_id,
+                workflow_type=identity.workflow_type,
+                step_name=identity.step_name,
                 idempotency_key=idempotency_key,
-                payload={
-                    "request": {
-                        "correlation_id": request.correlation_id,
-                        "script_tei_xml": request.script_tei_xml,
-                        "template_structure": request.template_structure,
-                    },
-                    "planner_result": _planner_result_to_payload(planner_result),
-                },
+                payload=_build_checkpoint_payload(
+                    request=request,
+                    planner_result=planner_result,
+                ),
             )
         )
     _log_event(
@@ -402,11 +480,13 @@ async def resume_generation_orchestration(
     planner_result = _planner_result_from_payload(payload["planner_result"])
     action_result = await resume_port.resume(command)
     result = build_generation_result(planner_result, (action_result,))
+    resumed_checkpoint = await checkpoint_port.mark_resumed(checkpoint.checkpoint_id)
     _log_event(
         "debug",
         "generation_graph.resume.finish",
-        checkpoint_id=checkpoint.checkpoint_id,
-        idempotency_key=checkpoint.idempotency_key,
+        checkpoint_id=resumed_checkpoint.checkpoint_id,
+        idempotency_key=resumed_checkpoint.idempotency_key,
+        status=resumed_checkpoint.status,
     )
     return result
 
@@ -477,9 +557,9 @@ def build_generation_orchestration_graph(
         """Async entry point for the execute graph node."""
         return await _execute_node(state, tool_executor=tool_executor)
 
-    graph.add_node("plan", _run_plan_node)
     if checkpoint_port is None:
-        graph.add_node("execute", _run_execute_node)
+        execute_node = _run_execute_node
+        execute_target = "finish"
     else:
 
         async def _run_suspend_execute_node(
@@ -491,13 +571,14 @@ def build_generation_orchestration_graph(
                 checkpoint_port=checkpoint_port,
             )
 
-        graph.add_node("execute", _run_suspend_execute_node)
+        execute_node = _run_suspend_execute_node
+        execute_target = END
+
+    graph.add_node("plan", _run_plan_node)
+    graph.add_node("execute", execute_node)
     graph.add_node("finish", _finish_node)
     graph.add_edge(START, "plan")
     graph.add_edge("plan", "execute")
-    if checkpoint_port is None:
-        graph.add_edge("execute", "finish")
-    else:
-        graph.add_edge("execute", END)
+    graph.add_edge("execute", execute_target)
     graph.add_edge("finish", END)
     return graph.compile()

--- a/episodic/orchestration/langgraph.py
+++ b/episodic/orchestration/langgraph.py
@@ -308,10 +308,12 @@ async def _suspend_execute_node(
     action = planner_result.plan.steps[0]
     workflow_id = request.correlation_id
     idempotency_key = dto.build_workflow_step_idempotency_key(
-        workflow_id=workflow_id,
-        workflow_type=workflow_type,
-        step_name="execute",
-        action_id=action.action_id,
+        dto.WorkflowStepIdentity(
+            workflow_id=workflow_id,
+            workflow_type=workflow_type,
+            step_name="execute",
+            action_id=action.action_id,
+        )
     )
     existing = await checkpoint_port.get_by_idempotency_key(idempotency_key)
     if existing is None:

--- a/episodic/orchestration/langgraph.py
+++ b/episodic/orchestration/langgraph.py
@@ -1,4 +1,12 @@
-"""LangGraph wrapper for structured generation orchestration."""
+"""LangGraph wrapper for structured generation orchestration.
+
+This module owns the in-process graph topology for structured content
+generation. The default graph plans, executes, and aggregates results. When a
+`CheckpointPort` is supplied, the graph switches to a suspend path that
+persists the planned state before the side-effecting execution step and returns
+a `SuspendedWorkflowResult`; `resume_generation_orchestration` later rebuilds
+the saved planner state and folds in an externally supplied action result.
+"""
 
 import dataclasses as dc
 import importlib
@@ -292,7 +300,7 @@ async def _suspend_execute_node(
     checkpoint_port: protocols.CheckpointPort,
     workflow_type: str = "generation_orchestration",
 ) -> dict[str, dto.SuspendedWorkflowResult]:
-    """Persist a checkpoint before executing the first action."""
+    """Persist or reuse a checkpoint before executing the first action."""
     request = state.request
     if request is None:
         msg = "missing required state value: request"
@@ -315,7 +323,18 @@ async def _suspend_execute_node(
             action_id=action.action_id,
         )
     )
+    _log_event(
+        "debug",
+        "generation_graph.suspend_execute_node.start",
+        correlation_id=request.correlation_id,
+        workflow_id=workflow_id,
+        workflow_type=workflow_type,
+        step_name="execute",
+        action_id=action.action_id,
+        idempotency_key=idempotency_key,
+    )
     existing = await checkpoint_port.get_by_idempotency_key(idempotency_key)
+    reused_checkpoint = existing is not None
     if existing is None:
         existing = await checkpoint_port.save(
             dto.WorkflowCheckpoint(
@@ -334,6 +353,14 @@ async def _suspend_execute_node(
                 },
             )
         )
+    _log_event(
+        "debug",
+        "generation_graph.suspend_execute_node.finish",
+        correlation_id=request.correlation_id,
+        checkpoint_id=existing.checkpoint_id,
+        idempotency_key=existing.idempotency_key,
+        reused_checkpoint=reused_checkpoint,
+    )
     suspended_result = dto.SuspendedWorkflowResult(
         checkpoint_id=existing.checkpoint_id,
         workflow_id=existing.workflow_id,
@@ -349,15 +376,39 @@ async def resume_generation_orchestration(
     resume_port: protocols.TaskResumePort,
     command: dto.ResumeWorkflowCommand,
 ) -> dto.GenerationOrchestrationResult:
-    """Resume a suspended generation workflow and return the final result."""
+    """Resume a suspended generation workflow and return the final result.
+
+    Raises
+    ------
+        ValueError: If the command references an unknown checkpoint.
+        TypeError: If the stored checkpoint payload cannot be deserialised into
+            the expected planner-result shape.
+    """
+    _log_event(
+        "debug",
+        "generation_graph.resume.start",
+        checkpoint_id=command.checkpoint_id,
+    )
     checkpoint = await checkpoint_port.get(command.checkpoint_id)
     if checkpoint is None:
+        _log_event(
+            "error",
+            "generation_graph.resume.unknown_checkpoint",
+            checkpoint_id=command.checkpoint_id,
+        )
         msg = f"unknown checkpoint: {command.checkpoint_id}"
         raise ValueError(msg)
     payload = checkpoint.payload
     planner_result = _planner_result_from_payload(payload["planner_result"])
     action_result = await resume_port.resume(command)
-    return build_generation_result(planner_result, (action_result,))
+    result = build_generation_result(planner_result, (action_result,))
+    _log_event(
+        "debug",
+        "generation_graph.resume.finish",
+        checkpoint_id=checkpoint.checkpoint_id,
+        idempotency_key=checkpoint.idempotency_key,
+    )
+    return result
 
 
 def _finish_node(

--- a/episodic/orchestration/langgraph.py
+++ b/episodic/orchestration/langgraph.py
@@ -385,13 +385,14 @@ def _build_checkpoint_payload(
     }
 
 
-async def _suspend_execute_node(
+def _validate_suspend_preconditions(
     state: GenerationGraphState,
-    *,
-    checkpoint_port: protocols.CheckpointPort,
-    workflow_type: str = "generation_orchestration",
-) -> dict[str, dto.SuspendedWorkflowResult]:
-    """Persist or reuse a checkpoint before executing the first action."""
+) -> tuple[
+    dto.GenerationOrchestrationRequest,
+    dto.PlannerResult,
+    dto.PlannedAction,
+]:
+    """Validate and extract required state fields for a suspend checkpoint."""
     request = state.request
     if request is None:
         msg = "missing required state value: request"
@@ -408,8 +409,17 @@ async def _suspend_execute_node(
                 "one planned step per suspended checkpoint."
             )
         raise ValueError(msg)
+    return request, planner_result, planner_result.plan.steps[0]
 
-    action = planner_result.plan.steps[0]
+
+async def _suspend_execute_node(
+    state: GenerationGraphState,
+    *,
+    checkpoint_port: protocols.CheckpointPort,
+    workflow_type: str = "generation_orchestration",
+) -> dict[str, dto.SuspendedWorkflowResult]:
+    """Persist or reuse a checkpoint before executing the first action."""
+    request, planner_result, action = _validate_suspend_preconditions(state)
     identity = _build_execute_step_identity(
         request=request,
         action=action,

--- a/episodic/orchestration/langgraph.py
+++ b/episodic/orchestration/langgraph.py
@@ -191,8 +191,13 @@ def _planner_result_to_payload(result: dto.PlannerResult) -> dict[str, object]:
 def _planner_result_from_payload(payload: object) -> dto.PlannerResult:
     """Return a PlannerResult from a checkpoint payload."""
     planner_payload = _as_object_payload(payload, "planner_result")
+    try:
+        plan_payload = planner_payload["plan"]
+    except KeyError as exc:
+        msg = "checkpoint planner_result missing required field: plan"
+        raise TypeError(msg) from exc
     return dto.PlannerResult(
-        plan=_plan_from_payload(planner_payload["plan"]),
+        plan=_plan_from_payload(plan_payload),
         usage=(
             None
             if planner_payload.get("usage") is None
@@ -415,22 +420,21 @@ async def _suspend_execute_node(
         action_id=identity.action_id,
         idempotency_key=idempotency_key,
     )
-    existing = await checkpoint_port.get_by_idempotency_key(idempotency_key)
-    reused_checkpoint = existing is not None
-    if existing is None:
-        existing = await checkpoint_port.save(
-            dto.WorkflowCheckpoint(
-                checkpoint_id=str(uuid.uuid4()),
-                workflow_id=identity.workflow_id,
-                workflow_type=identity.workflow_type,
-                step_name=identity.step_name,
-                idempotency_key=idempotency_key,
-                payload=_build_checkpoint_payload(
-                    request=request,
-                    planner_result=planner_result,
-                ),
-            )
+    fresh_id = str(uuid.uuid4())
+    existing = await checkpoint_port.save_or_reuse(
+        dto.WorkflowCheckpoint(
+            checkpoint_id=fresh_id,
+            workflow_id=identity.workflow_id,
+            workflow_type=identity.workflow_type,
+            step_name=identity.step_name,
+            idempotency_key=idempotency_key,
+            payload=_build_checkpoint_payload(
+                request=request,
+                planner_result=planner_result,
+            ),
         )
+    )
+    reused_checkpoint = existing.checkpoint_id != fresh_id
     _log_event(
         "debug",
         "generation_graph.suspend_execute_node.finish",

--- a/episodic/orchestration/langgraph.py
+++ b/episodic/orchestration/langgraph.py
@@ -9,6 +9,7 @@ the saved planner state and folds in an externally supplied action result.
 """
 
 import dataclasses as dc
+import enum
 import importlib
 import time
 import typing as typ
@@ -102,6 +103,25 @@ def _required_string(
     return _require_field(payload, field_name, str, context=context)
 
 
+def _required_enum[EnumT: enum.Enum](
+    payload: dict[str, object],
+    field_name: str,
+    enum_type: type[EnumT],
+    *,
+    context: str,
+) -> EnumT:
+    """Return an enum field from a checkpoint payload."""
+    value = _required_string(payload, field_name, context=context)
+    try:
+        return enum_type(value)
+    except ValueError as exc:
+        msg = (
+            f"checkpoint {context} field {field_name} must be a valid "
+            f"{enum_type.__name__}."
+        )
+        raise TypeError(msg) from exc
+
+
 def _usage_from_payload(payload: object) -> LLMUsage:
     """Return LLMUsage from a checkpoint payload."""
     usage_payload = _as_object_payload(payload, "usage")
@@ -157,12 +177,18 @@ def _plan_from_payload(payload: object) -> dto.ExecutionPlan:
         steps=tuple(
             dto.PlannedAction(
                 action_id=_required_string(step, "action_id", context="plan step"),
-                action_kind=dto.ActionKind(
-                    _required_string(step, "action_kind", context="plan step")
+                action_kind=_required_enum(
+                    step,
+                    "action_kind",
+                    dto.ActionKind,
+                    context="plan step",
                 ),
                 rationale=_required_string(step, "rationale", context="plan step"),
-                model_tier=dto.ModelTier(
-                    _required_string(step, "model_tier", context="plan step")
+                model_tier=_required_enum(
+                    step,
+                    "model_tier",
+                    dto.ModelTier,
+                    context="plan step",
                 ),
                 required_inputs=tuple(
                     str(item)
@@ -245,11 +271,17 @@ def _action_result_from_payload(payload: object) -> dto.ActionExecutionResult:
         action_id=_required_string(
             action_payload, "action_id", context="action_result"
         ),
-        action_kind=dto.ActionKind(
-            _required_string(action_payload, "action_kind", context="action_result")
+        action_kind=_required_enum(
+            action_payload,
+            "action_kind",
+            dto.ActionKind,
+            context="action_result",
         ),
-        model_tier=dto.ModelTier(
-            _required_string(action_payload, "model_tier", context="action_result")
+        model_tier=_required_enum(
+            action_payload,
+            "model_tier",
+            dto.ModelTier,
+            context="action_result",
         ),
         model=_required_string(action_payload, "model", context="action_result"),
         summary=_required_string(action_payload, "summary", context="action_result"),

--- a/episodic/orchestration/langgraph.py
+++ b/episodic/orchestration/langgraph.py
@@ -483,7 +483,12 @@ async def resume_generation_orchestration(
         msg = f"unknown checkpoint: {command.checkpoint_id}"
         raise ValueError(msg)
     payload = checkpoint.payload
-    planner_result = _planner_result_from_payload(payload["planner_result"])
+    try:
+        planner_result_payload = payload["planner_result"]
+    except KeyError as exc:
+        msg = "checkpoint payload missing required field: planner_result"
+        raise TypeError(msg) from exc
+    planner_result = _planner_result_from_payload(planner_result_payload)
     if len(planner_result.plan.steps) != 1:
         msg = (
             "resume_generation_orchestration currently supports exactly one "

--- a/episodic/orchestration/langgraph.py
+++ b/episodic/orchestration/langgraph.py
@@ -168,7 +168,12 @@ def _plan_from_payload(payload: object) -> dto.ExecutionPlan:
                     str(item)
                     for item in typ.cast(
                         "list[object]",
-                        step["required_inputs"],
+                        _require_field(
+                            step,
+                            "required_inputs",
+                            list,
+                            context="plan step",
+                        ),
                     )
                 ),
             )

--- a/episodic/orchestration/langgraph.py
+++ b/episodic/orchestration/langgraph.py
@@ -4,9 +4,11 @@ import dataclasses as dc
 import importlib
 import time
 import typing as typ
+import uuid
 
 from langgraph.graph import END, START, StateGraph
 
+from episodic.llm import LLMUsage
 from episodic.orchestration._types import _log_event
 from episodic.orchestration._usage import build_generation_result
 
@@ -28,6 +30,165 @@ class GenerationGraphState:
     planner_result: dto.PlannerResult | None = None
     action_results: tuple[dto.ActionExecutionResult, ...] = ()
     orchestration_result: dto.GenerationOrchestrationResult | None = None
+    suspended_result: dto.SuspendedWorkflowResult | None = None
+
+
+def _usage_to_payload(usage: LLMUsage | None) -> dict[str, int] | None:
+    """Return a JSON-compatible LLMUsage payload."""
+    if usage is None:
+        return None
+    return {
+        "input_tokens": usage.input_tokens,
+        "output_tokens": usage.output_tokens,
+        "total_tokens": usage.total_tokens,
+    }
+
+
+def _as_object_payload(payload: object, field_name: str) -> dict[str, object]:
+    """Return payload as a string-keyed object."""
+    if not isinstance(payload, dict):
+        msg = f"checkpoint {field_name} payload must be an object."
+        raise TypeError(msg)
+    return typ.cast("dict[str, object]", payload)
+
+
+def _required_int(payload: dict[str, object], field_name: str) -> int:
+    """Return an integer field from a checkpoint payload."""
+    value = payload[field_name]
+    if not isinstance(value, int):
+        msg = f"checkpoint {field_name} must be an integer."
+        raise TypeError(msg)
+    return value
+
+
+def _required_string(payload: dict[str, object], field_name: str) -> str:
+    """Return a string field from a checkpoint payload."""
+    value = payload[field_name]
+    if not isinstance(value, str):
+        msg = f"checkpoint {field_name} must be a string."
+        raise TypeError(msg)
+    return value
+
+
+def _usage_from_payload(payload: object) -> LLMUsage:
+    """Return LLMUsage from a checkpoint payload."""
+    usage_payload = _as_object_payload(payload, "usage")
+    return LLMUsage(
+        input_tokens=_required_int(usage_payload, "input_tokens"),
+        output_tokens=_required_int(usage_payload, "output_tokens"),
+        total_tokens=_required_int(usage_payload, "total_tokens"),
+    )
+
+
+def _plan_to_payload(plan: dto.ExecutionPlan) -> dict[str, object]:
+    """Return a JSON-compatible execution-plan checkpoint payload."""
+    return {
+        "plan_version": plan.plan_version,
+        "selected_planning_model": plan.selected_planning_model,
+        "selected_execution_model": plan.selected_execution_model,
+        "steps": [
+            {
+                "action_id": action.action_id,
+                "action_kind": str(action.action_kind),
+                "rationale": action.rationale,
+                "model_tier": str(action.model_tier),
+                "required_inputs": list(action.required_inputs),
+            }
+            for action in plan.steps
+        ],
+    }
+
+
+def _plan_from_payload(payload: object) -> dto.ExecutionPlan:
+    """Return an ExecutionPlan from a checkpoint payload."""
+    plan_payload = _as_object_payload(payload, "plan")
+    steps = plan_payload.get("steps")
+    if not isinstance(steps, list):
+        msg = "checkpoint plan steps must be a list."
+        raise TypeError(msg)
+    return dto.ExecutionPlan(
+        plan_version=_required_string(plan_payload, "plan_version"),
+        selected_planning_model=_required_string(
+            plan_payload,
+            "selected_planning_model",
+        ),
+        selected_execution_model=_required_string(
+            plan_payload,
+            "selected_execution_model",
+        ),
+        steps=tuple(
+            dto.PlannedAction(
+                action_id=_required_string(step, "action_id"),
+                action_kind=dto.ActionKind(_required_string(step, "action_kind")),
+                rationale=_required_string(step, "rationale"),
+                model_tier=dto.ModelTier(_required_string(step, "model_tier")),
+                required_inputs=tuple(
+                    str(item)
+                    for item in typ.cast(
+                        "list[object]",
+                        step["required_inputs"],
+                    )
+                ),
+            )
+            for step in typ.cast("list[dict[str, object]]", steps)
+        ),
+    )
+
+
+def _planner_result_to_payload(result: dto.PlannerResult) -> dict[str, object]:
+    """Return a JSON-compatible planner-result checkpoint payload."""
+    return {
+        "plan": _plan_to_payload(result.plan),
+        "usage": _usage_to_payload(result.usage),
+        "model": result.model,
+        "provider_response_id": result.provider_response_id,
+        "finish_reason": result.finish_reason,
+    }
+
+
+def _planner_result_from_payload(payload: object) -> dto.PlannerResult:
+    """Return a PlannerResult from a checkpoint payload."""
+    planner_payload = _as_object_payload(payload, "planner_result")
+    return dto.PlannerResult(
+        plan=_plan_from_payload(planner_payload["plan"]),
+        usage=_usage_from_payload(planner_payload["usage"]),
+        model=_required_string(planner_payload, "model"),
+        provider_response_id=_required_string(planner_payload, "provider_response_id"),
+        finish_reason=(
+            None
+            if planner_payload.get("finish_reason") is None
+            else _required_string(planner_payload, "finish_reason")
+        ),
+    )
+
+
+def _action_result_to_payload(result: dto.ActionExecutionResult) -> dict[str, object]:
+    """Return a JSON-compatible action-result checkpoint payload."""
+    return {
+        "action_id": result.action_id,
+        "action_kind": str(result.action_kind),
+        "model_tier": str(result.model_tier),
+        "model": result.model,
+        "summary": result.summary,
+        "usage": _usage_to_payload(result.usage),
+    }
+
+
+def _action_result_from_payload(payload: object) -> dto.ActionExecutionResult:
+    """Return an ActionExecutionResult from a checkpoint payload."""
+    action_payload = _as_object_payload(payload, "action_result")
+    return dto.ActionExecutionResult(
+        action_id=_required_string(action_payload, "action_id"),
+        action_kind=dto.ActionKind(_required_string(action_payload, "action_kind")),
+        model_tier=dto.ModelTier(_required_string(action_payload, "model_tier")),
+        model=_required_string(action_payload, "model"),
+        summary=_required_string(action_payload, "summary"),
+        usage=(
+            None
+            if action_payload.get("usage") is None
+            else _usage_from_payload(action_payload["usage"])
+        ),
+    )
 
 
 async def _plan_node(
@@ -125,6 +286,78 @@ async def _execute_node(
     return result
 
 
+async def _suspend_execute_node(
+    state: GenerationGraphState,
+    *,
+    checkpoint_port: protocols.CheckpointPort,
+    workflow_type: str = "generation_orchestration",
+) -> dict[str, dto.SuspendedWorkflowResult]:
+    """Persist a checkpoint before executing the first action."""
+    request = state.request
+    if request is None:
+        msg = "missing required state value: request"
+        raise ValueError(msg)
+    planner_result = state.planner_result
+    if planner_result is None:
+        msg = "missing required state value: planner_result"
+        raise ValueError(msg)
+    if not planner_result.plan.steps:
+        msg = "cannot suspend a workflow with no planned steps"
+        raise ValueError(msg)
+
+    action = planner_result.plan.steps[0]
+    workflow_id = request.correlation_id
+    idempotency_key = dto.build_workflow_step_idempotency_key(
+        workflow_id=workflow_id,
+        workflow_type=workflow_type,
+        step_name="execute",
+        action_id=action.action_id,
+    )
+    existing = await checkpoint_port.get_by_idempotency_key(idempotency_key)
+    if existing is None:
+        existing = await checkpoint_port.save(
+            dto.WorkflowCheckpoint(
+                checkpoint_id=str(uuid.uuid4()),
+                workflow_id=workflow_id,
+                workflow_type=workflow_type,
+                step_name="execute",
+                idempotency_key=idempotency_key,
+                payload={
+                    "request": {
+                        "correlation_id": request.correlation_id,
+                        "script_tei_xml": request.script_tei_xml,
+                        "template_structure": request.template_structure,
+                    },
+                    "planner_result": _planner_result_to_payload(planner_result),
+                },
+            )
+        )
+    suspended_result = dto.SuspendedWorkflowResult(
+        checkpoint_id=existing.checkpoint_id,
+        workflow_id=existing.workflow_id,
+        step_name=existing.step_name,
+        idempotency_key=existing.idempotency_key,
+    )
+    return {"suspended_result": suspended_result}
+
+
+async def resume_generation_orchestration(
+    *,
+    checkpoint_port: protocols.CheckpointPort,
+    resume_port: protocols.TaskResumePort,
+    command: dto.ResumeWorkflowCommand,
+) -> dto.GenerationOrchestrationResult:
+    """Resume a suspended generation workflow and return the final result."""
+    checkpoint = await checkpoint_port.get(command.checkpoint_id)
+    if checkpoint is None:
+        msg = f"unknown checkpoint: {command.checkpoint_id}"
+        raise ValueError(msg)
+    payload = checkpoint.payload
+    planner_result = _planner_result_from_payload(payload["planner_result"])
+    action_result = await resume_port.resume(command)
+    return build_generation_result(planner_result, (action_result,))
+
+
 def _finish_node(
     state: GenerationGraphState,
 ) -> dict[str, dto.GenerationOrchestrationResult]:
@@ -169,6 +402,7 @@ def build_generation_orchestration_graph(
     *,
     planner: protocols.PlannerPort,
     tool_executor: protocols.ToolExecutorPort,
+    checkpoint_port: protocols.CheckpointPort | None = None,
 ) -> CompiledStateGraph[
     GenerationGraphState,
     None,
@@ -191,10 +425,26 @@ def build_generation_orchestration_graph(
         return await _execute_node(state, tool_executor=tool_executor)
 
     graph.add_node("plan", _run_plan_node)
-    graph.add_node("execute", _run_execute_node)
+    if checkpoint_port is None:
+        graph.add_node("execute", _run_execute_node)
+    else:
+
+        async def _run_suspend_execute_node(
+            state: GenerationGraphState,
+        ) -> dict[str, dto.SuspendedWorkflowResult]:
+            """Async entry point for the suspend-before-execute graph node."""
+            return await _suspend_execute_node(
+                state,
+                checkpoint_port=checkpoint_port,
+            )
+
+        graph.add_node("execute", _run_suspend_execute_node)
     graph.add_node("finish", _finish_node)
     graph.add_edge(START, "plan")
     graph.add_edge("plan", "execute")
-    graph.add_edge("execute", "finish")
+    if checkpoint_port is None:
+        graph.add_edge("execute", "finish")
+    else:
+        graph.add_edge("execute", END)
     graph.add_edge("finish", END)
     return graph.compile()

--- a/episodic/orchestration/langgraph.py
+++ b/episodic/orchestration/langgraph.py
@@ -72,7 +72,7 @@ def _require_field[FieldT](
         value = payload[field_name]
     except KeyError as exc:
         msg = f"checkpoint {context} missing required field: {field_name}"
-        raise KeyError(msg) from exc
+        raise TypeError(msg) from exc
     if not isinstance(value, expected_type):
         msg = (
             f"checkpoint {context} field {field_name} must be a "

--- a/episodic/orchestration/langgraph.py
+++ b/episodic/orchestration/langgraph.py
@@ -380,8 +380,6 @@ def _build_checkpoint_payload(
     return {
         "request": {
             "correlation_id": request.correlation_id,
-            "script_tei_xml": request.script_tei_xml,
-            "template_structure": request.template_structure,
         },
         "planner_result": _planner_result_to_payload(planner_result),
     }
@@ -402,8 +400,13 @@ async def _suspend_execute_node(
     if planner_result is None:
         msg = "missing required state value: planner_result"
         raise ValueError(msg)
-    if not planner_result.plan.steps:
+    if len(planner_result.plan.steps) != 1:
         msg = "cannot suspend a workflow with no planned steps"
+        if planner_result.plan.steps:
+            msg = (
+                "suspend_generation_orchestration currently supports exactly "
+                "one planned step per suspended checkpoint."
+            )
         raise ValueError(msg)
 
     action = planner_result.plan.steps[0]

--- a/tests/__snapshots__/test_generation_orchestration_snapshots.ambr
+++ b/tests/__snapshots__/test_generation_orchestration_snapshots.ambr
@@ -31,6 +31,48 @@
   }
   '''
 # ---
+# name: test_checkpoint_payload_snapshot
+  dict({
+    'action_result': dict({
+      'action_id': 'a1',
+      'action_kind': 'generate_show_notes',
+      'model': 'gpt-4o-mini',
+      'model_tier': 'execution',
+      'summary': 'test',
+      'usage': dict({
+        'input_tokens': 10,
+        'output_tokens': 20,
+        'total_tokens': 30,
+      }),
+    }),
+    'planner_result': dict({
+      'finish_reason': 'stop',
+      'model': 'gpt-4.1',
+      'plan': dict({
+        'plan_version': '1',
+        'selected_execution_model': 'gpt-4o-mini',
+        'selected_planning_model': 'gpt-4.1',
+        'steps': list([
+          dict({
+            'action_id': 'a1',
+            'action_kind': 'generate_show_notes',
+            'model_tier': 'execution',
+            'rationale': 'test',
+            'required_inputs': list([
+              'script_tei_xml',
+            ]),
+          }),
+        ]),
+      }),
+      'provider_response_id': 'planner-1',
+      'usage': dict({
+        'input_tokens': 1,
+        'output_tokens': 2,
+        'total_tokens': 3,
+      }),
+    }),
+  })
+# ---
 # name: test_execution_plan_serialisation_snapshot
   dict({
     'plan_version': '1',

--- a/tests/canonical_storage/test_workflow_checkpoints.py
+++ b/tests/canonical_storage/test_workflow_checkpoints.py
@@ -1,7 +1,5 @@
 """SQLAlchemy checkpoint adapter tests."""
 
-from __future__ import annotations
-
 import typing as typ
 import uuid
 

--- a/tests/canonical_storage/test_workflow_checkpoints.py
+++ b/tests/canonical_storage/test_workflow_checkpoints.py
@@ -50,6 +50,34 @@ async def test_checkpoint_store_persists_across_unit_of_work(
 
 
 @pytest.mark.asyncio
+async def test_checkpoint_store_get_returns_none_for_missing_checkpoint(
+    session_factory: object,
+) -> None:
+    """`get` should return None when the checkpoint does not exist."""
+    factory = typ.cast("async_sessionmaker[AsyncSession]", session_factory)
+
+    async with SqlAlchemyUnitOfWork(factory) as uow:
+        result = await uow.workflow_checkpoints.get(str(uuid.uuid4()))
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_store_get_by_idempotency_key_returns_none_for_missing_key(
+    session_factory: object,
+) -> None:
+    """`get_by_idempotency_key` should return None for unknown keys."""
+    factory = typ.cast("async_sessionmaker[AsyncSession]", session_factory)
+
+    async with SqlAlchemyUnitOfWork(factory) as uow:
+        result = await uow.workflow_checkpoints.get_by_idempotency_key(
+            "non-existent-idempotency-key"
+        )
+
+    assert result is None
+
+
+@pytest.mark.asyncio
 async def test_checkpoint_store_reuses_idempotency_key(
     session_factory: object,
 ) -> None:
@@ -64,3 +92,24 @@ async def test_checkpoint_store_reuses_idempotency_key(
         await uow.commit()
 
     assert second.checkpoint_id == first.checkpoint_id
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_store_marks_checkpoint_resumed(
+    session_factory: object,
+) -> None:
+    """`mark_resumed` should persist the resumed checkpoint status."""
+    factory = typ.cast("async_sessionmaker[AsyncSession]", session_factory)
+    checkpoint = _checkpoint()
+
+    async with SqlAlchemyUnitOfWork(factory) as uow:
+        stored = await uow.workflow_checkpoints.save(checkpoint)
+        resumed = await uow.workflow_checkpoints.mark_resumed(stored.checkpoint_id)
+        await uow.commit()
+
+    async with SqlAlchemyUnitOfWork(factory) as uow:
+        fetched = await uow.workflow_checkpoints.get(stored.checkpoint_id)
+
+    assert resumed.status == "resumed"
+    assert fetched is not None
+    assert fetched.status == "resumed"

--- a/tests/canonical_storage/test_workflow_checkpoints.py
+++ b/tests/canonical_storage/test_workflow_checkpoints.py
@@ -1,0 +1,66 @@
+"""SQLAlchemy checkpoint adapter tests."""
+
+from __future__ import annotations
+
+import typing as typ
+import uuid
+
+import pytest
+
+from episodic.canonical.storage import SqlAlchemyUnitOfWork
+from episodic.orchestration import WorkflowCheckpoint
+
+if typ.TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+
+def _checkpoint(*, checkpoint_id: str | None = None) -> WorkflowCheckpoint:
+    """Return a deterministic checkpoint fixture."""
+    return WorkflowCheckpoint(
+        checkpoint_id=checkpoint_id or str(uuid.uuid4()),
+        workflow_id="corr-storage",
+        workflow_type="generation_orchestration",
+        step_name="execute",
+        idempotency_key="corr-storage:generation_orchestration:execute:action-1:0",
+        payload={
+            "request": {"correlation_id": "corr-storage"},
+            "planner_result": {"plan": {"steps": []}},
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_store_persists_across_unit_of_work(
+    session_factory: object,
+) -> None:
+    """Checkpoint records should survive fresh unit-of-work instances."""
+    factory = typ.cast("async_sessionmaker[AsyncSession]", session_factory)
+    checkpoint = _checkpoint()
+
+    async with SqlAlchemyUnitOfWork(factory) as uow:
+        stored = await uow.workflow_checkpoints.save(checkpoint)
+        await uow.commit()
+
+    async with SqlAlchemyUnitOfWork(factory) as uow:
+        fetched = await uow.workflow_checkpoints.get(stored.checkpoint_id)
+
+    assert fetched is not None
+    assert fetched.idempotency_key == checkpoint.idempotency_key
+    assert fetched.payload["request"] == {"correlation_id": "corr-storage"}
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_store_reuses_idempotency_key(
+    session_factory: object,
+) -> None:
+    """Saving the same step key twice should return the first checkpoint."""
+    factory = typ.cast("async_sessionmaker[AsyncSession]", session_factory)
+    checkpoint = _checkpoint()
+    duplicate = _checkpoint(checkpoint_id=str(uuid.uuid4()))
+
+    async with SqlAlchemyUnitOfWork(factory) as uow:
+        first = await uow.workflow_checkpoints.save(checkpoint)
+        second = await uow.workflow_checkpoints.save(duplicate)
+        await uow.commit()
+
+    assert second.checkpoint_id == first.checkpoint_id

--- a/tests/canonical_storage/test_workflow_checkpoints.py
+++ b/tests/canonical_storage/test_workflow_checkpoints.py
@@ -38,7 +38,7 @@ async def test_checkpoint_store_persists_across_unit_of_work(
     checkpoint = _checkpoint()
 
     async with SqlAlchemyUnitOfWork(factory) as uow:
-        stored = await uow.workflow_checkpoints.save(checkpoint)
+        stored = await uow.workflow_checkpoints.save_or_reuse(checkpoint)
         await uow.commit()
 
     async with SqlAlchemyUnitOfWork(factory) as uow:
@@ -87,8 +87,8 @@ async def test_checkpoint_store_reuses_idempotency_key(
     duplicate = _checkpoint(checkpoint_id=str(uuid.uuid4()))
 
     async with SqlAlchemyUnitOfWork(factory) as uow:
-        first = await uow.workflow_checkpoints.save(checkpoint)
-        second = await uow.workflow_checkpoints.save(duplicate)
+        first = await uow.workflow_checkpoints.save_or_reuse(checkpoint)
+        second = await uow.workflow_checkpoints.save_or_reuse(duplicate)
         await uow.commit()
 
     assert second.checkpoint_id == first.checkpoint_id
@@ -103,7 +103,7 @@ async def test_checkpoint_store_marks_checkpoint_resumed(
     checkpoint = _checkpoint()
 
     async with SqlAlchemyUnitOfWork(factory) as uow:
-        stored = await uow.workflow_checkpoints.save(checkpoint)
+        stored = await uow.workflow_checkpoints.save_or_reuse(checkpoint)
         resumed = await uow.workflow_checkpoints.mark_resumed(stored.checkpoint_id)
         await uow.commit()
 
@@ -113,3 +113,15 @@ async def test_checkpoint_store_marks_checkpoint_resumed(
     assert resumed.status == "resumed"
     assert fetched is not None
     assert fetched.status == "resumed"
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_store_mark_resumed_raises_for_unknown_checkpoint_id(
+    session_factory: object,
+) -> None:
+    """`mark_resumed` on an unknown id must raise ValueError."""
+    factory = typ.cast("async_sessionmaker[AsyncSession]", session_factory)
+
+    async with SqlAlchemyUnitOfWork(factory) as uow:
+        with pytest.raises(ValueError, match="unknown checkpoint"):
+            await uow.workflow_checkpoints.mark_resumed(str(uuid.uuid4()))

--- a/tests/features/generation_orchestration.feature
+++ b/tests/features/generation_orchestration.feature
@@ -5,3 +5,11 @@ Feature: Structured generation orchestration
     When the orchestration service plans and executes the request
     Then the orchestration result includes a structured plan and show-notes output
     And the orchestration requests use planning and execution models in order
+
+  Scenario: LangGraph suspends and resumes a structured generation run
+    Given a Vidai Mock orchestration server is running
+    And a generation orchestration request is prepared
+    When the LangGraph orchestration service suspends before execution and resumes the request
+    Then the orchestration result includes a structured plan and show-notes output
+    And the orchestration checkpoint is reused for the repeated workflow step
+    And the orchestration requests use planning and execution models in order

--- a/tests/steps/test_generation_orchestration_steps.py
+++ b/tests/steps/test_generation_orchestration_steps.py
@@ -21,11 +21,16 @@ from episodic.llm.openai_adapter import (
 )
 from episodic.orchestration import (
     ActionKind,
+    GenerationGraphState,
     GenerationOrchestrationConfig,
     GenerationOrchestrationRequest,
+    InMemoryCheckpointStore,
+    ResumeWorkflowCommand,
     ShowNotesToolExecutor,
     StructuredGenerationPlanner,
     StructuredPlanningOrchestrator,
+    build_generation_orchestration_graph,
+    resume_generation_orchestration,
 )
 
 if typ.TYPE_CHECKING:
@@ -33,7 +38,11 @@ if typ.TYPE_CHECKING:
     import collections.abc as cabc
 
     from episodic.llm.ports import LLMPort, LLMRequest, LLMResponse
-    from episodic.orchestration import GenerationOrchestrationResult
+    from episodic.orchestration import (
+        ActionExecutionResult,
+        GenerationOrchestrationResult,
+        SuspendedWorkflowResult,
+    )
 
 
 @dc.dataclass(slots=True)
@@ -45,6 +54,8 @@ class OrchestrationBDDContext:
     request: GenerationOrchestrationRequest | None = None
     result: GenerationOrchestrationResult | None = None
     requests: list[LLMRequest] = dc.field(default_factory=list)
+    suspended_result: SuspendedWorkflowResult | None = None
+    repeated_suspended_result: SuspendedWorkflowResult | None = None
 
 
 @dc.dataclass(slots=True)
@@ -58,6 +69,18 @@ class _RecordingLLMPort:
         """Record and forward the request."""
         self.requests.append(request)
         return await self.wrapped.generate(request)
+
+
+@dc.dataclass(slots=True)
+class _BDDResumePort:
+    """Return the action result supplied by the behavioural resume command."""
+
+    async def resume(
+        self,
+        command: ResumeWorkflowCommand,
+    ) -> ActionExecutionResult:
+        """Return the externally supplied action result."""
+        return command.result
 
 
 def _run_async_step(
@@ -88,6 +111,14 @@ def orchestration_context() -> cabc.Iterator[OrchestrationBDDContext]:
 )
 def test_generation_orchestration_behaviour() -> None:
     """Run the structured generation orchestration scenario."""
+
+
+@scenario(
+    "../features/generation_orchestration.feature",
+    "LangGraph suspends and resumes a structured generation run",
+)
+def test_generation_orchestration_suspend_resume_behaviour() -> None:
+    """Run the resumable generation orchestration scenario."""
 
 
 def _find_free_port() -> int:
@@ -339,6 +370,70 @@ def run_orchestration(
     _run_async_step(_function_scoped_runner, _orchestrate)
 
 
+@when(
+    "the LangGraph orchestration service suspends before execution and resumes "
+    "the request"
+)
+def run_suspend_resume_orchestration(
+    _function_scoped_runner: asyncio.Runner,
+    orchestration_context: OrchestrationBDDContext,
+) -> None:
+    """Call the checkpointing LangGraph flow with a live LLM adapter."""
+
+    async def _orchestrate() -> None:  # noqa: PLR0914
+        request = orchestration_context.request
+        if request is None:
+            msg = "generation request was not prepared"
+            raise AssertionError(msg)
+
+        async with OpenAICompatibleLLMAdapter(
+            config=OpenAICompatibleLLMConfig(
+                base_url=orchestration_context.base_url,
+                api_key="test-key",
+            ),
+        ) as adapter:
+            recording_port = _RecordingLLMPort(wrapped=adapter)
+            config = GenerationOrchestrationConfig(
+                planning_model="gpt-4.1",
+                execution_model="gpt-4o-mini",
+            )
+            planner = StructuredGenerationPlanner(llm=recording_port, config=config)
+            tool_executor = ShowNotesToolExecutor(llm=recording_port, config=config)
+            checkpoint_store = InMemoryCheckpointStore()
+            graph = build_generation_orchestration_graph(
+                planner=planner,
+                tool_executor=tool_executor,
+                checkpoint_port=checkpoint_store,
+            )
+
+            first_state = await graph.ainvoke(GenerationGraphState(request=request))
+            second_state = await graph.ainvoke(GenerationGraphState(request=request))
+            suspended_result = first_state["suspended_result"]
+            checkpoint = await checkpoint_store.get(suspended_result.checkpoint_id)
+            if checkpoint is None:
+                msg = "checkpoint was not persisted"
+                raise AssertionError(msg)
+
+            planner_result = first_state["planner_result"]
+            action = planner_result.plan.steps[0]
+            action_result = await tool_executor.execute(action, request)
+            orchestration_context.result = await resume_generation_orchestration(
+                checkpoint_port=checkpoint_store,
+                resume_port=_BDDResumePort(),
+                command=ResumeWorkflowCommand(
+                    checkpoint_id=suspended_result.checkpoint_id,
+                    result=action_result,
+                ),
+            )
+            orchestration_context.suspended_result = suspended_result
+            orchestration_context.repeated_suspended_result = second_state[
+                "suspended_result"
+            ]
+            orchestration_context.requests = recording_port.requests
+
+    _run_async_step(_function_scoped_runner, _orchestrate)
+
+
 @then("the orchestration result includes a structured plan and show-notes output")
 def assert_result(orchestration_context: OrchestrationBDDContext) -> None:
     """Verify the orchestration result exposes the plan and action output."""
@@ -355,6 +450,20 @@ def assert_result(orchestration_context: OrchestrationBDDContext) -> None:
 def assert_requests(orchestration_context: OrchestrationBDDContext) -> None:
     """Verify the planner call happens before the execution-stage tool call."""
     requests = orchestration_context.requests
-    assert [request.model for request in requests] == ["gpt-4.1", "gpt-4o-mini"]
+    expected_models = ["gpt-4.1", "gpt-4o-mini"]
+    if orchestration_context.suspended_result is not None:
+        expected_models = ["gpt-4.1", "gpt-4.1", "gpt-4o-mini"]
+    assert [request.model for request in requests] == expected_models
     assert "enabled_action_kinds" in requests[0].prompt
-    assert "script_tei_xml" in requests[1].prompt
+    assert "script_tei_xml" in requests[-1].prompt
+
+
+@then("the orchestration checkpoint is reused for the repeated workflow step")
+def assert_checkpoint_reused(orchestration_context: OrchestrationBDDContext) -> None:
+    """Verify repeated suspend calls return the original checkpoint."""
+    first = orchestration_context.suspended_result
+    second = orchestration_context.repeated_suspended_result
+    assert first is not None
+    assert second is not None
+    assert second.checkpoint_id == first.checkpoint_id
+    assert second.idempotency_key == first.idempotency_key

--- a/tests/test_generation_orchestration_langgraph.py
+++ b/tests/test_generation_orchestration_langgraph.py
@@ -202,6 +202,7 @@ class TestGenerationOrchestrationGraph:
         checkpoint = await checkpoint_store.get(suspended_result.checkpoint_id)
         assert checkpoint is not None
         assert checkpoint.idempotency_key == suspended_result.idempotency_key
+        assert checkpoint.payload["request"] == {"correlation_id": "corr-graph"}
         assert tool_executor.calls == []
 
     @pytest.mark.asyncio
@@ -264,21 +265,8 @@ class TestGenerationOrchestrationGraph:
             tool_executor=_FakeToolExecutor(_action_result()),
             checkpoint_port=checkpoint_store,
         )
-        state = await graph.ainvoke(GenerationGraphState(request=_request()))
-        command = ResumeWorkflowCommand(
-            checkpoint_id=state["suspended_result"].checkpoint_id,
-            result=_action_result(),
-        )
-        resume_port = _FakeResumePort()
-
         with pytest.raises(ValueError, match="exactly one planned step"):
-            await resume_generation_orchestration(
-                checkpoint_port=checkpoint_store,
-                resume_port=resume_port,
-                command=command,
-            )
-
-        assert resume_port.calls == []
+            await graph.ainvoke(GenerationGraphState(request=_request()))
 
     @pytest.mark.asyncio
     async def test_resume_generation_orchestration_raises_on_missing_checkpoint(

--- a/tests/test_generation_orchestration_langgraph.py
+++ b/tests/test_generation_orchestration_langgraph.py
@@ -224,6 +224,9 @@ class TestGenerationOrchestrationGraph:
         assert result.total_usage.total_tokens == 38
         assert result.action_results == (_action_result(),)
         assert resume_port.calls == [command]
+        checkpoint = await checkpoint_store.get(command.checkpoint_id)
+        assert checkpoint is not None
+        assert checkpoint.status == "resumed"
 
     @pytest.mark.asyncio
     async def test_resume_generation_orchestration_raises_on_missing_checkpoint(

--- a/tests/test_generation_orchestration_langgraph.py
+++ b/tests/test_generation_orchestration_langgraph.py
@@ -298,6 +298,34 @@ class TestGenerationOrchestrationGraph:
             )
 
     @pytest.mark.asyncio
+    async def test_resume_generation_orchestration_raises_on_missing_plan_payload(
+        self,
+    ) -> None:
+        """Resume should map malformed checkpoint payloads to TypeError."""
+        checkpoint_store = InMemoryCheckpointStore()
+        checkpoint = await checkpoint_store.save(
+            WorkflowCheckpoint(
+                checkpoint_id=str(uuid.uuid4()),
+                workflow_id="corr-graph",
+                workflow_type="generation_orchestration",
+                step_name="execute",
+                idempotency_key="corr-graph:generation_orchestration:execute:a1:0",
+                payload={},
+            )
+        )
+        command = ResumeWorkflowCommand(
+            checkpoint_id=checkpoint.checkpoint_id,
+            result=_action_result(),
+        )
+
+        with pytest.raises(TypeError, match="planner_result"):
+            await resume_generation_orchestration(
+                checkpoint_port=checkpoint_store,
+                resume_port=_FakeResumePort(),
+                command=command,
+            )
+
+    @pytest.mark.asyncio
     async def test_in_memory_checkpoint_store_reuses_concurrent_step_key(
         self,
     ) -> None:

--- a/tests/test_generation_orchestration_langgraph.py
+++ b/tests/test_generation_orchestration_langgraph.py
@@ -119,6 +119,31 @@ def _planner_result() -> PlannerResult:
     )
 
 
+def _multi_step_planner_result() -> PlannerResult:
+    """Return a planner result that exposes unsupported multi-step resume."""
+    result = _planner_result()
+    first_step = result.plan.steps[0]
+    second_step = PlannedAction(
+        action_id="action-2",
+        action_kind=ActionKind.GENERATE_SHOW_NOTES,
+        rationale="Need a second pass.",
+        model_tier=ModelTier.EXECUTION,
+        required_inputs=("script_tei_xml",),
+    )
+    return PlannerResult(
+        plan=ExecutionPlan(
+            plan_version=result.plan.plan_version,
+            selected_planning_model=result.plan.selected_planning_model,
+            selected_execution_model=result.plan.selected_execution_model,
+            steps=(first_step, second_step),
+        ),
+        usage=result.usage,
+        model=result.model,
+        provider_response_id=result.provider_response_id,
+        finish_reason=result.finish_reason,
+    )
+
+
 def _action_result() -> ActionExecutionResult:
     return ActionExecutionResult(
         action_id="action-1",
@@ -227,6 +252,33 @@ class TestGenerationOrchestrationGraph:
         checkpoint = await checkpoint_store.get(command.checkpoint_id)
         assert checkpoint is not None
         assert checkpoint.status == "resumed"
+
+    @pytest.mark.asyncio
+    async def test_resume_generation_orchestration_rejects_multi_step_checkpoint(
+        self,
+    ) -> None:
+        """Resume should not silently drop later planned actions."""
+        checkpoint_store = InMemoryCheckpointStore()
+        graph = build_generation_orchestration_graph(
+            planner=_FakePlanner(_multi_step_planner_result()),
+            tool_executor=_FakeToolExecutor(_action_result()),
+            checkpoint_port=checkpoint_store,
+        )
+        state = await graph.ainvoke(GenerationGraphState(request=_request()))
+        command = ResumeWorkflowCommand(
+            checkpoint_id=state["suspended_result"].checkpoint_id,
+            result=_action_result(),
+        )
+        resume_port = _FakeResumePort()
+
+        with pytest.raises(ValueError, match="exactly one planned step"):
+            await resume_generation_orchestration(
+                checkpoint_port=checkpoint_store,
+                resume_port=resume_port,
+                command=command,
+            )
+
+        assert resume_port.calls == []
 
     @pytest.mark.asyncio
     async def test_resume_generation_orchestration_raises_on_missing_checkpoint(

--- a/tests/test_generation_orchestration_langgraph.py
+++ b/tests/test_generation_orchestration_langgraph.py
@@ -303,7 +303,7 @@ class TestGenerationOrchestrationGraph:
     ) -> None:
         """Resume should map malformed checkpoint payloads to TypeError."""
         checkpoint_store = InMemoryCheckpointStore()
-        checkpoint = await checkpoint_store.save(
+        checkpoint = await checkpoint_store.save_or_reuse(
             WorkflowCheckpoint(
                 checkpoint_id=str(uuid.uuid4()),
                 workflow_id="corr-graph",
@@ -323,6 +323,32 @@ class TestGenerationOrchestrationGraph:
                 checkpoint_port=checkpoint_store,
                 resume_port=_FakeResumePort(),
                 command=command,
+            )
+
+    @pytest.mark.asyncio
+    async def test_resume_generation_orchestration_raises_on_invalid_payload(
+        self,
+    ) -> None:
+        """resume_generation_orchestration raises TypeError for a malformed payload."""
+        store = InMemoryCheckpointStore()
+        bad_checkpoint = WorkflowCheckpoint(
+            checkpoint_id=str(uuid.uuid4()),
+            workflow_id="wf-1",
+            workflow_type="generation_orchestration",
+            step_name="execute",
+            idempotency_key="wf-1:generation_orchestration:execute:a1:0",
+            payload={"planner_result": {"bad": "shape"}},
+        )
+        await store.save_or_reuse(bad_checkpoint)
+
+        with pytest.raises(TypeError):
+            await resume_generation_orchestration(
+                checkpoint_port=store,
+                resume_port=_FakeResumePort(),
+                command=ResumeWorkflowCommand(
+                    checkpoint_id=bad_checkpoint.checkpoint_id,
+                    result=_action_result(),
+                ),
             )
 
     @pytest.mark.asyncio
@@ -350,11 +376,21 @@ class TestGenerationOrchestrationGraph:
         )
 
         stored_first, stored_second = await asyncio.gather(
-            checkpoint_store.save(first),
-            checkpoint_store.save(duplicate),
+            checkpoint_store.save_or_reuse(first),
+            checkpoint_store.save_or_reuse(duplicate),
         )
 
         assert stored_second.checkpoint_id == stored_first.checkpoint_id
+
+    @pytest.mark.asyncio
+    async def test_in_memory_checkpoint_store_mark_resumed_raises_for_unknown_id(
+        self,
+    ) -> None:
+        """`InMemoryCheckpointStore.mark_resumed` rejects an unknown id."""
+        store = InMemoryCheckpointStore()
+
+        with pytest.raises(ValueError, match="unknown checkpoint"):
+            await store.mark_resumed(str(uuid.uuid4()))
 
 
 class TestLangGraphNodeValidation:

--- a/tests/test_generation_orchestration_langgraph.py
+++ b/tests/test_generation_orchestration_langgraph.py
@@ -10,9 +10,11 @@ from episodic.orchestration import (
     ActionKind,
     ExecutionPlan,
     GenerationOrchestrationRequest,
+    InMemoryCheckpointStore,
     ModelTier,
     PlannedAction,
     PlannerResult,
+    ResumeWorkflowCommand,
 )
 from episodic.orchestration.langgraph import (
     GenerationGraphState,
@@ -20,6 +22,7 @@ from episodic.orchestration.langgraph import (
     _finish_node,
     _plan_node,
     build_generation_orchestration_graph,
+    resume_generation_orchestration,
 )
 
 
@@ -46,6 +49,9 @@ class _FakeToolExecutor:
     """Return one canned execution result."""
 
     result: ActionExecutionResult
+    calls: list[tuple[PlannedAction, GenerationOrchestrationRequest]] = dc.field(
+        default_factory=list
+    )
 
     async def execute(
         self,
@@ -61,7 +67,23 @@ class _FakeToolExecutor:
             "expected correlation_id to be 'corr-graph', got: "
             f"{context.correlation_id!r}"
         )
+        self.calls.append((action, context))
         return self.result
+
+
+@dc.dataclass(slots=True)
+class _FakeResumePort:
+    """Return the externally supplied action result for resume tests."""
+
+    calls: list[ResumeWorkflowCommand] = dc.field(default_factory=list)
+
+    async def resume(
+        self,
+        command: ResumeWorkflowCommand,
+    ) -> ActionExecutionResult:
+        """Record and return the command result."""
+        self.calls.append(command)
+        return command.result
 
 
 def _request() -> GenerationOrchestrationRequest:
@@ -132,6 +154,73 @@ class TestGenerationOrchestrationGraph:
             "expected first action result model to be 'gpt-4o-mini', got: "
             f"{orchestration_result.action_results[0].model!r}"
         )
+
+    @pytest.mark.asyncio
+    async def test_generation_graph_suspends_before_tool_execution(self) -> None:
+        """Checkpointing graph should persist a suspend result before execution."""
+        checkpoint_store = InMemoryCheckpointStore()
+        tool_executor = _FakeToolExecutor(_action_result())
+        graph = build_generation_orchestration_graph(
+            planner=_FakePlanner(_planner_result()),
+            tool_executor=tool_executor,
+            checkpoint_port=checkpoint_store,
+        )
+
+        state = await graph.ainvoke(GenerationGraphState(request=_request()))
+
+        suspended_result = state["suspended_result"]
+        assert suspended_result.workflow_id == "corr-graph"
+        assert suspended_result.step_name == "execute"
+        checkpoint = await checkpoint_store.get(suspended_result.checkpoint_id)
+        assert checkpoint is not None
+        assert checkpoint.idempotency_key == suspended_result.idempotency_key
+        assert tool_executor.calls == []
+
+    @pytest.mark.asyncio
+    async def test_generation_graph_reuses_checkpoint_for_same_step_key(self) -> None:
+        """Repeated suspend calls must return the first checkpoint for a step."""
+        checkpoint_store = InMemoryCheckpointStore()
+        graph = build_generation_orchestration_graph(
+            planner=_FakePlanner(_planner_result()),
+            tool_executor=_FakeToolExecutor(_action_result()),
+            checkpoint_port=checkpoint_store,
+        )
+
+        first_state = await graph.ainvoke(GenerationGraphState(request=_request()))
+        second_state = await graph.ainvoke(GenerationGraphState(request=_request()))
+
+        assert (
+            second_state["suspended_result"].checkpoint_id
+            == first_state["suspended_result"].checkpoint_id
+        )
+
+    @pytest.mark.asyncio
+    async def test_resume_generation_orchestration_finishes_from_checkpoint(
+        self,
+    ) -> None:
+        """Resume should rebuild checkpointed plan state and aggregate a result."""
+        checkpoint_store = InMemoryCheckpointStore()
+        graph = build_generation_orchestration_graph(
+            planner=_FakePlanner(_planner_result()),
+            tool_executor=_FakeToolExecutor(_action_result()),
+            checkpoint_port=checkpoint_store,
+        )
+        state = await graph.ainvoke(GenerationGraphState(request=_request()))
+        command = ResumeWorkflowCommand(
+            checkpoint_id=state["suspended_result"].checkpoint_id,
+            result=_action_result(),
+        )
+        resume_port = _FakeResumePort()
+
+        result = await resume_generation_orchestration(
+            checkpoint_port=checkpoint_store,
+            resume_port=resume_port,
+            command=command,
+        )
+
+        assert result.total_usage.total_tokens == 38
+        assert result.action_results == (_action_result(),)
+        assert resume_port.calls == [command]
 
 
 class TestLangGraphNodeValidation:

--- a/tests/test_generation_orchestration_langgraph.py
+++ b/tests/test_generation_orchestration_langgraph.py
@@ -1,6 +1,8 @@
 """Unit tests for the structured generation LangGraph seam."""
 
+import asyncio
 import dataclasses as dc
+import uuid
 
 import pytest
 
@@ -15,6 +17,7 @@ from episodic.orchestration import (
     PlannedAction,
     PlannerResult,
     ResumeWorkflowCommand,
+    WorkflowCheckpoint,
 )
 from episodic.orchestration.langgraph import (
     GenerationGraphState,
@@ -221,6 +224,54 @@ class TestGenerationOrchestrationGraph:
         assert result.total_usage.total_tokens == 38
         assert result.action_results == (_action_result(),)
         assert resume_port.calls == [command]
+
+    @pytest.mark.asyncio
+    async def test_resume_generation_orchestration_raises_on_missing_checkpoint(
+        self,
+    ) -> None:
+        """Resume should fail loudly when the checkpoint identifier is unknown."""
+        command = ResumeWorkflowCommand(
+            checkpoint_id=str(uuid.uuid4()),
+            result=_action_result(),
+        )
+
+        with pytest.raises(ValueError, match="unknown checkpoint"):
+            await resume_generation_orchestration(
+                checkpoint_port=InMemoryCheckpointStore(),
+                resume_port=_FakeResumePort(),
+                command=command,
+            )
+
+    @pytest.mark.asyncio
+    async def test_in_memory_checkpoint_store_reuses_concurrent_step_key(
+        self,
+    ) -> None:
+        """Concurrent saves with one step key should return one checkpoint."""
+        checkpoint_store = InMemoryCheckpointStore()
+        key = "corr-graph:generation_orchestration:execute:action-1:0"
+        first = WorkflowCheckpoint(
+            checkpoint_id=str(uuid.uuid4()),
+            workflow_id="corr-graph",
+            workflow_type="generation_orchestration",
+            step_name="execute",
+            idempotency_key=key,
+            payload={"planner_result": {}},
+        )
+        duplicate = WorkflowCheckpoint(
+            checkpoint_id=str(uuid.uuid4()),
+            workflow_id="corr-graph",
+            workflow_type="generation_orchestration",
+            step_name="execute",
+            idempotency_key=key,
+            payload={"planner_result": {}},
+        )
+
+        stored_first, stored_second = await asyncio.gather(
+            checkpoint_store.save(first),
+            checkpoint_store.save(duplicate),
+        )
+
+        assert stored_second.checkpoint_id == stored_first.checkpoint_id
 
 
 class TestLangGraphNodeValidation:

--- a/tests/test_generation_orchestration_snapshots.py
+++ b/tests/test_generation_orchestration_snapshots.py
@@ -14,7 +14,12 @@ from episodic.orchestration import (
     GenerationOrchestrationResult,
     ModelTier,
     PlannedAction,
+    PlannerResult,
     StructuredGenerationPlanner,
+)
+from episodic.orchestration.langgraph import (
+    _action_result_to_payload,
+    _planner_result_to_payload,
 )
 
 
@@ -92,3 +97,39 @@ def test_generation_orchestration_result_snapshot(
     )
     serialised = dataclasses.asdict(result)
     assert serialised == snapshot
+
+
+def test_checkpoint_payload_snapshot(snapshot: SnapshotAssertion) -> None:
+    planned = PlannedAction(
+        action_id="a1",
+        action_kind=ActionKind.GENERATE_SHOW_NOTES,
+        rationale="test",
+        model_tier=ModelTier.EXECUTION,
+        required_inputs=("script_tei_xml",),
+    )
+    plan = ExecutionPlan(
+        plan_version="1",
+        selected_planning_model="gpt-4.1",
+        selected_execution_model="gpt-4o-mini",
+        steps=(planned,),
+    )
+    planner_result = PlannerResult(
+        plan=plan,
+        usage=LLMUsage(input_tokens=1, output_tokens=2, total_tokens=3),
+        model="gpt-4.1",
+        provider_response_id="planner-1",
+        finish_reason="stop",
+    )
+    action_result = ActionExecutionResult(
+        action_id="a1",
+        action_kind=ActionKind.GENERATE_SHOW_NOTES,
+        model_tier=ModelTier.EXECUTION,
+        model="gpt-4o-mini",
+        summary="test",
+        usage=LLMUsage(input_tokens=10, output_tokens=20, total_tokens=30),
+    )
+
+    assert {
+        "planner_result": _planner_result_to_payload(planner_result),
+        "action_result": _action_result_to_payload(action_result),
+    } == snapshot

--- a/tests/test_orchestration_planner.py
+++ b/tests/test_orchestration_planner.py
@@ -48,6 +48,7 @@ async def test_planner_returns_typed_plan_and_uses_planning_model() -> None:
             required_inputs=("script_tei_xml", "template_structure"),
         ),
     )
+    assert result.usage is not None
     assert result.usage.total_tokens == 52
 
     request = llm.requests[0]

--- a/tests/test_orchestration_properties.py
+++ b/tests/test_orchestration_properties.py
@@ -170,7 +170,7 @@ _execution_plan_strategy = st.builds(
 _planner_result_strategy = st.builds(
     PlannerResult,
     plan=_execution_plan_strategy,
-    usage=_usage_strategy,
+    usage=st.one_of(st.none(), _usage_strategy),
     model=_prop_text,
     provider_response_id=_prop_text,
     finish_reason=st.one_of(st.none(), _prop_text),
@@ -185,6 +185,19 @@ _action_result_strategy = st.builds(
     summary=_prop_text,
     usage=st.one_of(st.none(), _usage_strategy),
 )
+
+
+def test_step_idempotency_key_negative_attempt_raises_value_error() -> None:
+    """Negative attempts should be rejected before building a step key."""
+    step = WorkflowStepIdentity(
+        workflow_id="workflow-id",
+        workflow_type="workflow-type",
+        step_name="step-name",
+        action_id="action-id",
+    )
+
+    with pytest.raises(ValueError, match="attempt must be greater than or equal"):
+        build_workflow_step_idempotency_key(step, attempt=-1)
 
 
 @given(

--- a/tests/test_orchestration_properties.py
+++ b/tests/test_orchestration_properties.py
@@ -28,6 +28,7 @@ from episodic.orchestration import (
     StructuredGenerationPlanner,
     UnsupportedActionError,
     build_generation_orchestration_graph,
+    build_workflow_step_idempotency_key,
 )
 from tests._orchestration_fakes import (
     _config,
@@ -91,6 +92,56 @@ _token_inputs_strategy: st.SearchStrategy[_PropTokenInputs] = st.builds(
     action_input=st.integers(min_value=0, max_value=10_000),
     action_output=st.integers(min_value=0, max_value=10_000),
 )
+
+
+@given(
+    workflow_id=st.text(
+        min_size=1,
+        max_size=32,
+        alphabet=string.ascii_letters + string.digits + "-",
+    ),
+    workflow_type=st.text(
+        min_size=1,
+        max_size=32,
+        alphabet=string.ascii_letters + string.digits + "_",
+    ),
+    step_name=st.text(
+        min_size=1,
+        max_size=32,
+        alphabet=string.ascii_letters + string.digits + "_",
+    ),
+    action_id=st.text(
+        min_size=1,
+        max_size=32,
+        alphabet=string.ascii_letters + string.digits + "-",
+    ),
+    attempt=st.integers(min_value=0, max_value=100),
+)
+@settings(max_examples=50)
+def test_step_idempotency_keys_are_deterministic(
+    workflow_id: str,
+    workflow_type: str,
+    step_name: str,
+    action_id: str,
+    attempt: int,
+) -> None:
+    """Property test: identical workflow step inputs produce identical keys."""
+    first = build_workflow_step_idempotency_key(
+        workflow_id=workflow_id,
+        workflow_type=workflow_type,
+        step_name=step_name,
+        action_id=action_id,
+        attempt=attempt,
+    )
+    second = build_workflow_step_idempotency_key(
+        workflow_id=workflow_id,
+        workflow_type=workflow_type,
+        step_name=step_name,
+        action_id=action_id,
+        attempt=attempt,
+    )
+    assert second == first
+    assert first.endswith(f":{attempt}")
 
 
 @given(st.lists(st.sampled_from(_ACTION_KIND_SAMPLES), min_size=1, max_size=48))

--- a/tests/test_orchestration_properties.py
+++ b/tests/test_orchestration_properties.py
@@ -31,6 +31,14 @@ from episodic.orchestration import (
     build_generation_orchestration_graph,
     build_workflow_step_idempotency_key,
 )
+from episodic.orchestration.langgraph import (
+    _action_result_from_payload,
+    _action_result_to_payload,
+    _plan_from_payload,
+    _plan_to_payload,
+    _planner_result_from_payload,
+    _planner_result_to_payload,
+)
 from tests._orchestration_fakes import (
     _config,
     _FakeLLMPort,
@@ -129,6 +137,55 @@ _step_key_inputs_strategy: st.SearchStrategy[_PropStepKeyInputs] = st.builds(
     ),
 )
 
+_prop_text = st.text(
+    min_size=1,
+    max_size=32,
+    alphabet=string.ascii_letters + string.digits + "-_ .",
+).filter(lambda value: bool(value.strip()))
+
+_usage_strategy = st.builds(
+    LLMUsage,
+    input_tokens=st.integers(min_value=0, max_value=10_000),
+    output_tokens=st.integers(min_value=0, max_value=10_000),
+    total_tokens=st.integers(min_value=0, max_value=20_000),
+)
+
+_planned_action_strategy = st.builds(
+    PlannedAction,
+    action_id=_prop_text,
+    action_kind=st.just(ActionKind.GENERATE_SHOW_NOTES),
+    rationale=_prop_text,
+    model_tier=st.just(ModelTier.EXECUTION),
+    required_inputs=st.lists(_prop_text, max_size=4).map(tuple),
+)
+
+_execution_plan_strategy = st.builds(
+    ExecutionPlan,
+    plan_version=_prop_text,
+    selected_planning_model=_prop_text,
+    selected_execution_model=_prop_text,
+    steps=st.lists(_planned_action_strategy, min_size=1, max_size=4).map(tuple),
+)
+
+_planner_result_strategy = st.builds(
+    PlannerResult,
+    plan=_execution_plan_strategy,
+    usage=_usage_strategy,
+    model=_prop_text,
+    provider_response_id=_prop_text,
+    finish_reason=st.one_of(st.none(), _prop_text),
+)
+
+_action_result_strategy = st.builds(
+    ActionExecutionResult,
+    action_id=_prop_text,
+    action_kind=st.just(ActionKind.GENERATE_SHOW_NOTES),
+    model_tier=st.just(ModelTier.EXECUTION),
+    model=_prop_text,
+    summary=_prop_text,
+    usage=st.one_of(st.none(), _usage_strategy),
+)
+
 
 @given(
     inputs=_step_key_inputs_strategy,
@@ -156,6 +213,33 @@ def test_step_idempotency_keys_are_deterministic(
     )
     assert second == first
     assert first.endswith(f":{attempt}")
+
+
+@given(plan=_execution_plan_strategy)
+@settings(max_examples=50)
+def test_execution_plan_checkpoint_payload_round_trips(
+    plan: ExecutionPlan,
+) -> None:
+    """Property test: checkpoint plan payloads preserve execution plans."""
+    assert _plan_from_payload(_plan_to_payload(plan)) == plan
+
+
+@given(result=_planner_result_strategy)
+@settings(max_examples=50)
+def test_planner_result_checkpoint_payload_round_trips(
+    result: PlannerResult,
+) -> None:
+    """Property test: checkpoint planner payloads preserve planner results."""
+    assert _planner_result_from_payload(_planner_result_to_payload(result)) == result
+
+
+@given(result=_action_result_strategy)
+@settings(max_examples=50)
+def test_action_result_checkpoint_payload_round_trips(
+    result: ActionExecutionResult,
+) -> None:
+    """Property test: checkpoint action payloads preserve action results."""
+    assert _action_result_from_payload(_action_result_to_payload(result)) == result
 
 
 @given(st.lists(st.sampled_from(_ACTION_KIND_SAMPLES), min_size=1, max_size=48))

--- a/tests/test_orchestration_properties.py
+++ b/tests/test_orchestration_properties.py
@@ -27,6 +27,7 @@ from episodic.orchestration import (
     ShowNotesToolExecutor,
     StructuredGenerationPlanner,
     UnsupportedActionError,
+    WorkflowStepIdentity,
     build_generation_orchestration_graph,
     build_workflow_step_idempotency_key,
 )
@@ -93,51 +94,34 @@ _token_inputs_strategy: st.SearchStrategy[_PropTokenInputs] = st.builds(
     action_output=st.integers(min_value=0, max_value=10_000),
 )
 
-
-@given(
-    workflow_id=st.text(
-        min_size=1,
-        max_size=32,
-        alphabet=string.ascii_letters + string.digits + "-",
-    ),
-    workflow_type=st.text(
-        min_size=1,
-        max_size=32,
-        alphabet=string.ascii_letters + string.digits + "_",
-    ),
-    step_name=st.text(
-        min_size=1,
-        max_size=32,
-        alphabet=string.ascii_letters + string.digits + "_",
-    ),
-    action_id=st.text(
-        min_size=1,
-        max_size=32,
-        alphabet=string.ascii_letters + string.digits + "-",
-    ),
-    attempt=st.integers(min_value=0, max_value=100),
+_non_empty_text = st.text(
+    min_size=1,
+    max_size=32,
+    alphabet=string.ascii_letters + string.digits + "-_",
 )
+
+step_identity_strategy = st.builds(
+    WorkflowStepIdentity,
+    workflow_id=_non_empty_text,
+    workflow_type=_non_empty_text,
+    step_name=_non_empty_text,
+    action_id=_non_empty_text,
+)
+
+
+@given(step=step_identity_strategy, attempt=st.integers(min_value=0))
 @settings(max_examples=50)
 def test_step_idempotency_keys_are_deterministic(
-    workflow_id: str,
-    workflow_type: str,
-    step_name: str,
-    action_id: str,
+    step: WorkflowStepIdentity,
     attempt: int,
 ) -> None:
     """Property test: identical workflow step inputs produce identical keys."""
     first = build_workflow_step_idempotency_key(
-        workflow_id=workflow_id,
-        workflow_type=workflow_type,
-        step_name=step_name,
-        action_id=action_id,
+        step,
         attempt=attempt,
     )
     second = build_workflow_step_idempotency_key(
-        workflow_id=workflow_id,
-        workflow_type=workflow_type,
-        step_name=step_name,
-        action_id=action_id,
+        step,
         attempt=attempt,
     )
     assert second == first

--- a/tests/test_orchestration_properties.py
+++ b/tests/test_orchestration_properties.py
@@ -94,28 +94,58 @@ _token_inputs_strategy: st.SearchStrategy[_PropTokenInputs] = st.builds(
     action_output=st.integers(min_value=0, max_value=10_000),
 )
 
-_non_empty_text = st.text(
-    min_size=1,
-    max_size=32,
-    alphabet=string.ascii_letters + string.digits + "-_",
+
+@dc.dataclass(frozen=True, slots=True)
+class _PropStepKeyInputs:
+    """Bundled workflow step identity inputs for idempotency key tests."""
+
+    workflow_id: str
+    workflow_type: str
+    step_name: str
+    action_id: str
+
+
+_step_key_inputs_strategy: st.SearchStrategy[_PropStepKeyInputs] = st.builds(
+    _PropStepKeyInputs,
+    workflow_id=st.text(
+        min_size=1,
+        max_size=32,
+        alphabet=string.ascii_letters + string.digits + "-",
+    ),
+    workflow_type=st.text(
+        min_size=1,
+        max_size=32,
+        alphabet=string.ascii_letters + string.digits + "_",
+    ),
+    step_name=st.text(
+        min_size=1,
+        max_size=32,
+        alphabet=string.ascii_letters + string.digits + "_",
+    ),
+    action_id=st.text(
+        min_size=1,
+        max_size=32,
+        alphabet=string.ascii_letters + string.digits + "-",
+    ),
 )
 
-step_identity_strategy = st.builds(
-    WorkflowStepIdentity,
-    workflow_id=_non_empty_text,
-    workflow_type=_non_empty_text,
-    step_name=_non_empty_text,
-    action_id=_non_empty_text,
+
+@given(
+    inputs=_step_key_inputs_strategy,
+    attempt=st.integers(min_value=0, max_value=100),
 )
-
-
-@given(step=step_identity_strategy, attempt=st.integers(min_value=0))
 @settings(max_examples=50)
 def test_step_idempotency_keys_are_deterministic(
-    step: WorkflowStepIdentity,
+    inputs: _PropStepKeyInputs,
     attempt: int,
 ) -> None:
     """Property test: identical workflow step inputs produce identical keys."""
+    step = WorkflowStepIdentity(
+        workflow_id=inputs.workflow_id,
+        workflow_type=inputs.workflow_type,
+        step_name=inputs.step_name,
+        action_id=inputs.action_id,
+    )
     first = build_workflow_step_idempotency_key(
         step,
         attempt=attempt,


### PR DESCRIPTION
## Summary

This branch implements roadmap task (2.4.2) by adding durable suspend-and-resume orchestration for structured generation runs. It persists workflow checkpoints before the side-effecting execution step, reuses the first checkpoint for repeated idempotency keys, and resumes from a checkpoint through `TaskResumePort` with an externally supplied action result.

Roadmap task: (2.4.2)
Execplan: [docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md](https://github.com/leynos/episodic/blob/2-4-2-add-lang-graph-suspend-and-resume-orchestration/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md)

## Review walkthrough

- Start with [episodic/orchestration/langgraph.py](https://github.com/leynos/episodic/blob/2-4-2-add-lang-graph-suspend-and-resume-orchestration/episodic/orchestration/langgraph.py) for the checkpointing graph path, suspend result, and resume aggregation.
- Review [episodic/orchestration/_dto.py](https://github.com/leynos/episodic/blob/2-4-2-add-lang-graph-suspend-and-resume-orchestration/episodic/orchestration/_dto.py) and [episodic/orchestration/_protocols.py](https://github.com/leynos/episodic/blob/2-4-2-add-lang-graph-suspend-and-resume-orchestration/episodic/orchestration/_protocols.py) for the provider-neutral checkpoint DTOs, ports, and idempotency key contract.
- Review [episodic/canonical/storage/workflow_checkpoints.py](https://github.com/leynos/episodic/blob/2-4-2-add-lang-graph-suspend-and-resume-orchestration/episodic/canonical/storage/workflow_checkpoints.py) and [alembic/versions/20260508_000008_add_workflow_checkpoints.py](https://github.com/leynos/episodic/blob/2-4-2-add-lang-graph-suspend-and-resume-orchestration/alembic/versions/20260508_000008_add_workflow_checkpoints.py) for durable persistence.
- Finish with [tests/test_generation_orchestration_langgraph.py](https://github.com/leynos/episodic/blob/2-4-2-add-lang-graph-suspend-and-resume-orchestration/tests/test_generation_orchestration_langgraph.py), [tests/canonical_storage/test_workflow_checkpoints.py](https://github.com/leynos/episodic/blob/2-4-2-add-lang-graph-suspend-and-resume-orchestration/tests/canonical_storage/test_workflow_checkpoints.py), and [tests/features/generation_orchestration.feature](https://github.com/leynos/episodic/blob/2-4-2-add-lang-graph-suspend-and-resume-orchestration/tests/features/generation_orchestration.feature) for unit, storage, property, and Vidai Mock behavioural coverage.

## Validation

- `make check-fmt`: passed
- `make typecheck`: passed
- `make lint`: passed
- `make test`: passed, `446 passed, 3 skipped`
- `make markdownlint`: passed, `0 error(s)`
- `make nixie`: passed

## Notes

`make fmt` was also run after documentation edits. It left Python files unchanged but still reports the repository-wide legacy Markdown MD013 formatter issue in unrelated documents. The explicit required gates above pass on the final branch state.

## Summary by Sourcery

Add durable suspend-and-resume support to the LangGraph-based generation orchestration, including checkpoint persistence, idempotent workflow step keys, and resume handling, with tests, storage adapters, migration, and documentation updates.

New Features:
- Introduce resumable generation workflows that suspend before the first execution step, persist a checkpoint, and later resume to produce a final orchestration result.
- Expose orchestration DTOs and ports for workflow checkpoints, suspended workflow results, resume commands, and workflow step identities.
- Provide an in-memory checkpoint store and a SQLAlchemy-backed checkpoint store for orchestration checkpoints.

Enhancements:
- Extend the LangGraph generation graph to optionally use checkpointing, returning a suspended workflow result instead of executing the tool when a checkpoint port is configured.
- Add deterministic idempotency key construction for workflow steps and integrate it into checkpoint persistence and reuse logic.
- Export new orchestration types and helpers through the public orchestration module for broader reuse.
- Update developer, user, design, roadmap, and ADR documentation to describe durable generation checkpoints, idempotency behaviour, and testing locations.

Build:
- Add an Alembic migration and SQLAlchemy model for the workflow_checkpoints table used to store orchestration checkpoints.

Deployment:
- Wire the workflow checkpoint store into the SQLAlchemy unit of work and canonical storage exports so it is available to application composition roots.

Tests:
- Add unit tests for LangGraph suspension, checkpoint reuse, and resume aggregation using in-memory checkpoints and fake ports.
- Add SQLAlchemy-backed tests to verify workflow checkpoints persist across units of work and enforce idempotency on repeated saves.
- Introduce a property-based test to ensure workflow step idempotency keys are deterministic for identical inputs.
- Extend BDD scenarios with a Vidai Mock-based suspend-and-resume generation orchestration flow that asserts checkpoint reuse and model call ordering.