### PR TITLE
Add orchestration property tests (#72)

### DIFF
--- a/docs/adr/adr-005-structured-planning-and-tool-execution.md
+++ b/docs/adr/adr-005-structured-planning-and-tool-execution.md
@@ -43,6 +43,11 @@ The accepted design is:
 - Provide a small in-process LangGraph wrapper that sequences
   `plan -> execute -> finish`, leaving checkpointing, suspend-and-resume, and
   queue dispatch to later roadmap items.
+- Allow the graph builder to accept a synchronous
+  `finish_callback: Callable[[GenerationOrchestrationResult], None]` hook for
+  observability and test event recording. The hook receives the aggregated
+  domain result, fires only on the direct `plan -> execute -> finish` path, and
+  is not part of the checkpoint suspend path.
 
 ## Rationale
 
@@ -89,6 +94,10 @@ pattern before chapter markers, guest biographies, or sponsorship copy exist.
 
 - LangGraph remains an implementation detail for orchestration control flow.
   The durable integration boundaries are still the application ports and DTOs.
+- The finish callback is an observation hook rather than a control-flow
+  extension point. Callback exceptions are logged without replacing the
+  computed graph result, and callers that share mutable callback state across
+  concurrent graph invocations must provide their own synchronization.
 
 ## Deferred work
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -847,6 +847,15 @@ provide their own synchronization.
 invoke the LangGraph graph directly. Treat it as the framework state carrier
 for graph nodes rather than as a domain DTO exposed through hooks.
 
+`resume_generation_orchestration(...)` is the public API for completing a
+checkpointed run. Pass the same `CheckpointPort` used by the suspend path, a
+`TaskResumePort` that returns the externally completed action result, and a
+`ResumeWorkflowCommand` naming the checkpoint. The helper reloads the persisted
+planner result, combines it with the resumed action result, marks the
+checkpoint resumed, and returns the final `GenerationOrchestrationResult`. It
+raises `ValueError` for unknown checkpoints and `TypeError` for malformed
+stored planner-result payloads.
+
 ### Maintainer rules
 
 - Keep the planner strict: parse model output into typed DTOs immediately and

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -839,9 +839,9 @@ observability and test event recording. The hook fires only on the direct
 `plan -> execute -> finish` path, after finish-node aggregation has produced
 the domain result and before the graph returns. It is not invoked on the
 checkpoint suspend path. Callback exceptions are logged without replacing the
-already computed graph result. The graph does not serialise concurrent
+already computed graph result. The graph does not serialize concurrent
 invocations of a shared callback; callbacks that mutate shared state must
-provide their own synchronisation.
+provide their own synchronization.
 
 `GenerationGraphState` is part of the public orchestration API for callers that
 invoke the LangGraph graph directly. Treat it as the framework state carrier

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -838,8 +838,8 @@ Roadmap item `2.4.1` introduces a dedicated orchestration package in
 test event recording. The hook fires only on the direct
 `plan -> execute -> finish` path, after finish-node aggregation has produced an
 `orchestration_result` and before the graph returns. It is not invoked on the
-checkpoint suspend path. Callback exceptions are logged and propagated to the
-callback error log without replacing the already computed graph result.
+checkpoint suspend path. Callback exceptions are logged without replacing the
+already computed graph result.
 
 ### Maintainer rules
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -834,12 +834,18 @@ Roadmap item `2.4.1` introduces a dedicated orchestration package in
   adapter for durable checkpoint persistence.
 
 `build_generation_orchestration_graph(...)` accepts an optional
-`finish_callback: Callable[[GenerationGraphState], None]` for observability and
-test event recording. The hook fires only on the direct
-`plan -> execute -> finish` path, after finish-node aggregation has produced an
-`orchestration_result` and before the graph returns. It is not invoked on the
+`finish_callback: Callable[[GenerationOrchestrationResult], None]` for
+observability and test event recording. The hook fires only on the direct
+`plan -> execute -> finish` path, after finish-node aggregation has produced
+the domain result and before the graph returns. It is not invoked on the
 checkpoint suspend path. Callback exceptions are logged without replacing the
-already computed graph result.
+already computed graph result. The graph does not serialise concurrent
+invocations of a shared callback; callbacks that mutate shared state must
+provide their own synchronisation.
+
+`GenerationGraphState` is part of the public orchestration API for callers that
+invoke the LangGraph graph directly. Treat it as the framework state carrier
+for graph nodes rather than as a domain DTO exposed through hooks.
 
 ### Maintainer rules
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -839,7 +839,7 @@ test event recording. The hook fires only on the direct
 `plan -> execute -> finish` path, after finish-node aggregation has produced an
 `orchestration_result` and before the graph returns. It is not invoked on the
 checkpoint suspend path. Callback exceptions are logged and propagated to the
-caller, so callbacks must not raise during normal operation.
+callback error log without replacing the already computed graph result.
 
 ### Maintainer rules
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -833,6 +833,14 @@ Roadmap item `2.4.1` introduces a dedicated orchestration package in
 - `episodic/canonical/storage/workflow_checkpoints.py` contains the SQLAlchemy
   adapter for durable checkpoint persistence.
 
+`build_generation_orchestration_graph(...)` accepts an optional
+`finish_callback: Callable[[GenerationGraphState], None]` for observability and
+test event recording. The hook fires only on the direct
+`plan -> execute -> finish` path, after finish-node aggregation has produced an
+`orchestration_result` and before the graph returns. It is not invoked on the
+checkpoint suspend path. Callback exceptions are logged and propagated to the
+caller, so callbacks must not raise during normal operation.
+
 ### Maintainer rules
 
 - Keep the planner strict: parse model output into typed DTOs immediately and
@@ -867,6 +875,12 @@ Roadmap item `2.4.1` introduces a dedicated orchestration package in
   show-notes execution, guest-bio execution, and properties lives in the
   focused `tests/test_orchestration_*.py`, `tests/test_show_notes_executor.py`,
   and `tests/test_guest_bios_executor.py` modules.
+- Issue `#72` property coverage lives in
+  `tests/test_orchestration_properties.py` and the focused sibling modules for
+  config/model-tier boundaries, planner format errors, and LangGraph
+  invariants.
+- `tests/test_generation_orchestration_snapshots.py` pins planner format-error
+  messages and orchestration artefacts with Syrupy snapshots.
 - LangGraph seam coverage lives in
   `tests/test_generation_orchestration_langgraph.py`.
 - Behavioural coverage lives in
@@ -876,6 +890,9 @@ Roadmap item `2.4.1` introduces a dedicated orchestration package in
   responses from one OpenAI-compatible endpoint: the first for structured
   planning, and the second for the show-notes tool call. Keep that fixture
   model-driven so prompt wording can evolve without breaking the scenario.
+- Durable checkpoint coverage lives in
+  `tests/canonical_storage/test_workflow_checkpoints.py` and uses py-pglite via
+  the migrated SQLAlchemy fixtures.
 
 ## LLM adapter boundary
 

--- a/docs/execplans/2-4-1-structured-output-planning-and-tool-calling-execution.md
+++ b/docs/execplans/2-4-1-structured-output-planning-and-tool-calling-execution.md
@@ -47,6 +47,8 @@ Success is observable in eight ways:
 6. Unit tests (`pytest`) prove structured-response parsing, tier selection,
    execution routing, tool error handling, and boundary enforcement at the
    application-service layer.
+   Issue `#72` adds property-based coverage for orchestration DTOs, planner
+   format errors, model-tier boundaries, and LangGraph invariants.
 7. Behavioural tests (`pytest-bdd`) using Vidai Mock prove that one orchestrated
    generation request produces a deterministic planning call plus downstream
    execution activity through the defined tool-calling path.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -248,6 +248,8 @@ metering. Completion enables reliable, auditable generation workflows.
 - [x] 2.4.1. Implement structured-output planning and tool-calling execution.
   - Define model tiering for cost control.
   - Implement tool-calling patterns for enrichment steps.
+  - Added issue `#72` property-based coverage for orchestration DTOs, planner
+    format errors, model-tier boundaries, and LangGraph invariants.
 - [x] 2.4.2. Add LangGraph suspend-and-resume orchestration. Requires 2.1.1.
   - Implement checkpoint persistence for resumable workflows.
   - Define idempotency keys for each workflow step.

--- a/episodic/orchestration/__init__.py
+++ b/episodic/orchestration/__init__.py
@@ -1,5 +1,7 @@
 """Structured planning and tool execution for generation orchestration."""
 
+from episodic.orchestration._checkpoint_resume import resume_generation_orchestration
+from episodic.orchestration._graph_state import GenerationGraphState
 from episodic.orchestration.checkpoints import InMemoryCheckpointStore
 from episodic.orchestration.generation import (
     ActionExecutionResult,
@@ -30,11 +32,7 @@ from episodic.orchestration.generation import (
     build_generation_result,
     build_workflow_step_idempotency_key,
 )
-from episodic.orchestration.langgraph import (
-    GenerationGraphState,
-    build_generation_orchestration_graph,
-    resume_generation_orchestration,
-)
+from episodic.orchestration.langgraph import build_generation_orchestration_graph
 
 __all__ = [
     "ActionExecutionResult",

--- a/episodic/orchestration/_checkpoint_payload.py
+++ b/episodic/orchestration/_checkpoint_payload.py
@@ -1,0 +1,266 @@
+"""Checkpoint payload serialisation helpers for generation orchestration."""
+
+import enum
+import typing as typ
+
+from episodic.llm import LLMUsage
+
+if typ.TYPE_CHECKING:
+    import importlib
+
+    from episodic.orchestration import _dto as dto
+else:
+    import importlib
+
+    dto = importlib.import_module("episodic.orchestration._dto")
+
+
+def _usage_to_payload(usage: LLMUsage | None) -> dict[str, int] | None:
+    """Return a JSON-compatible LLMUsage payload."""
+    if usage is None:
+        return None
+    return {
+        "input_tokens": usage.input_tokens,
+        "output_tokens": usage.output_tokens,
+        "total_tokens": usage.total_tokens,
+    }
+
+
+def _as_object_payload(payload: object, context: str) -> dict[str, object]:
+    """Return payload as a string-keyed object."""
+    if not isinstance(payload, dict):
+        msg = f"checkpoint {context} payload must be an object."
+        raise TypeError(msg)
+    return typ.cast("dict[str, object]", payload)
+
+
+def _require_field[FieldT](
+    payload: dict[str, object],
+    field_name: str,
+    expected_type: type[FieldT],
+    *,
+    context: str,
+) -> FieldT:
+    """Return a required typed checkpoint payload field."""
+    try:
+        value = payload[field_name]
+    except KeyError as exc:
+        msg = f"checkpoint {context} missing required field: {field_name}"
+        raise TypeError(msg) from exc
+    if not isinstance(value, expected_type):
+        msg = (
+            f"checkpoint {context} field {field_name} must be a "
+            f"{expected_type.__name__}."
+        )
+        raise TypeError(msg)
+    return value
+
+
+def _required_int(
+    payload: dict[str, object],
+    field_name: str,
+    *,
+    context: str,
+) -> int:
+    """Return an integer field from a checkpoint payload."""
+    return _require_field(payload, field_name, int, context=context)
+
+
+def _required_string(
+    payload: dict[str, object],
+    field_name: str,
+    *,
+    context: str,
+) -> str:
+    """Return a string field from a checkpoint payload."""
+    return _require_field(payload, field_name, str, context=context)
+
+
+def _required_enum[EnumT: enum.Enum](
+    payload: dict[str, object],
+    field_name: str,
+    enum_type: type[EnumT],
+    *,
+    context: str,
+) -> EnumT:
+    """Return an enum field from a checkpoint payload."""
+    value = _required_string(payload, field_name, context=context)
+    try:
+        return enum_type(value)
+    except ValueError as exc:
+        msg = (
+            f"checkpoint {context} field {field_name} must be a valid "
+            f"{enum_type.__name__}."
+        )
+        raise TypeError(msg) from exc
+
+
+def _usage_from_payload(payload: object) -> LLMUsage:
+    """Return LLMUsage from a checkpoint payload."""
+    usage_payload = _as_object_payload(payload, "usage")
+    return LLMUsage(
+        input_tokens=_required_int(usage_payload, "input_tokens", context="usage"),
+        output_tokens=_required_int(usage_payload, "output_tokens", context="usage"),
+        total_tokens=_required_int(usage_payload, "total_tokens", context="usage"),
+    )
+
+
+def _plan_to_payload(plan: dto.ExecutionPlan) -> dict[str, object]:
+    """Return a JSON-compatible execution-plan checkpoint payload."""
+    return {
+        "plan_version": plan.plan_version,
+        "selected_planning_model": plan.selected_planning_model,
+        "selected_execution_model": plan.selected_execution_model,
+        "steps": [
+            {
+                "action_id": action.action_id,
+                "action_kind": str(action.action_kind),
+                "rationale": action.rationale,
+                "model_tier": str(action.model_tier),
+                "required_inputs": list(action.required_inputs),
+            }
+            for action in plan.steps
+        ],
+    }
+
+
+def _plan_from_payload(payload: object) -> dto.ExecutionPlan:
+    """Return an ExecutionPlan from a checkpoint payload."""
+    plan_payload = _as_object_payload(payload, "plan")
+    steps = plan_payload.get("steps")
+    if not isinstance(steps, list):
+        msg = "checkpoint plan steps must be a list."
+        raise TypeError(msg)
+    return dto.ExecutionPlan(
+        plan_version=_required_string(
+            plan_payload,
+            "plan_version",
+            context="plan",
+        ),
+        selected_planning_model=_required_string(
+            plan_payload,
+            "selected_planning_model",
+            context="plan",
+        ),
+        selected_execution_model=_required_string(
+            plan_payload,
+            "selected_execution_model",
+            context="plan",
+        ),
+        steps=tuple(
+            dto.PlannedAction(
+                action_id=_required_string(step, "action_id", context="plan step"),
+                action_kind=_required_enum(
+                    step,
+                    "action_kind",
+                    dto.ActionKind,
+                    context="plan step",
+                ),
+                rationale=_required_string(step, "rationale", context="plan step"),
+                model_tier=_required_enum(
+                    step,
+                    "model_tier",
+                    dto.ModelTier,
+                    context="plan step",
+                ),
+                required_inputs=tuple(
+                    str(item)
+                    for item in typ.cast(
+                        "list[object]",
+                        _require_field(
+                            step,
+                            "required_inputs",
+                            list,
+                            context="plan step",
+                        ),
+                    )
+                ),
+            )
+            for step in typ.cast("list[dict[str, object]]", steps)
+        ),
+    )
+
+
+def _planner_result_to_payload(result: dto.PlannerResult) -> dict[str, object]:
+    """Return a JSON-compatible planner-result checkpoint payload."""
+    return {
+        "plan": _plan_to_payload(result.plan),
+        "usage": _usage_to_payload(result.usage),
+        "model": result.model,
+        "provider_response_id": result.provider_response_id,
+        "finish_reason": result.finish_reason,
+    }
+
+
+def _planner_result_from_payload(payload: object) -> dto.PlannerResult:
+    """Return a PlannerResult from a checkpoint payload."""
+    planner_payload = _as_object_payload(payload, "planner_result")
+    try:
+        plan_payload = planner_payload["plan"]
+    except KeyError as exc:
+        msg = "checkpoint planner_result missing required field: plan"
+        raise TypeError(msg) from exc
+    return dto.PlannerResult(
+        plan=_plan_from_payload(plan_payload),
+        usage=(
+            None
+            if planner_payload.get("usage") is None
+            else _usage_from_payload(planner_payload["usage"])
+        ),
+        model=_required_string(planner_payload, "model", context="planner_result"),
+        provider_response_id=_required_string(
+            planner_payload,
+            "provider_response_id",
+            context="planner_result",
+        ),
+        finish_reason=(
+            None
+            if planner_payload.get("finish_reason") is None
+            else _required_string(
+                planner_payload,
+                "finish_reason",
+                context="planner_result",
+            )
+        ),
+    )
+
+
+def _action_result_to_payload(result: dto.ActionExecutionResult) -> dict[str, object]:
+    """Return a JSON-compatible action-result checkpoint payload."""
+    return {
+        "action_id": result.action_id,
+        "action_kind": str(result.action_kind),
+        "model_tier": str(result.model_tier),
+        "model": result.model,
+        "summary": result.summary,
+        "usage": _usage_to_payload(result.usage),
+    }
+
+
+def _action_result_from_payload(payload: object) -> dto.ActionExecutionResult:
+    """Return an ActionExecutionResult from a checkpoint payload."""
+    action_payload = _as_object_payload(payload, "action_result")
+    return dto.ActionExecutionResult(
+        action_id=_required_string(
+            action_payload, "action_id", context="action_result"
+        ),
+        action_kind=_required_enum(
+            action_payload,
+            "action_kind",
+            dto.ActionKind,
+            context="action_result",
+        ),
+        model_tier=_required_enum(
+            action_payload,
+            "model_tier",
+            dto.ModelTier,
+            context="action_result",
+        ),
+        model=_required_string(action_payload, "model", context="action_result"),
+        summary=_required_string(action_payload, "summary", context="action_result"),
+        usage=(
+            None
+            if action_payload.get("usage") is None
+            else _usage_from_payload(action_payload["usage"])
+        ),
+    )

--- a/episodic/orchestration/_checkpoint_payload.py
+++ b/episodic/orchestration/_checkpoint_payload.py
@@ -95,6 +95,20 @@ def _required_enum[EnumT: enum.Enum](
         raise TypeError(msg) from exc
 
 
+def _required_string_list(
+    payload: dict[str, object],
+    field_name: str,
+    *,
+    context: str,
+) -> tuple[str, ...]:
+    """Return a list-of-strings field from a checkpoint payload."""
+    items = _require_field(payload, field_name, list, context=context)
+    if not all(isinstance(item, str) for item in items):
+        msg = f"checkpoint {context} field {field_name} must be a list of strings."
+        raise TypeError(msg)
+    return tuple(items)
+
+
 def _usage_from_payload(payload: object) -> LLMUsage:
     """Return LLMUsage from a checkpoint payload."""
     usage_payload = _as_object_payload(payload, "usage")
@@ -124,6 +138,32 @@ def _plan_to_payload(plan: dto.ExecutionPlan) -> dict[str, object]:
     }
 
 
+def _planned_action_from_payload(payload: object) -> dto.PlannedAction:
+    """Return one PlannedAction from a checkpoint plan-step payload."""
+    step = _as_object_payload(payload, "plan step")
+    return dto.PlannedAction(
+        action_id=_required_string(step, "action_id", context="plan step"),
+        action_kind=_required_enum(
+            step,
+            "action_kind",
+            dto.ActionKind,
+            context="plan step",
+        ),
+        rationale=_required_string(step, "rationale", context="plan step"),
+        model_tier=_required_enum(
+            step,
+            "model_tier",
+            dto.ModelTier,
+            context="plan step",
+        ),
+        required_inputs=_required_string_list(
+            step,
+            "required_inputs",
+            context="plan step",
+        ),
+    )
+
+
 def _plan_from_payload(payload: object) -> dto.ExecutionPlan:
     """Return an ExecutionPlan from a checkpoint payload."""
     plan_payload = _as_object_payload(payload, "plan")
@@ -147,37 +187,7 @@ def _plan_from_payload(payload: object) -> dto.ExecutionPlan:
             "selected_execution_model",
             context="plan",
         ),
-        steps=tuple(
-            dto.PlannedAction(
-                action_id=_required_string(step, "action_id", context="plan step"),
-                action_kind=_required_enum(
-                    step,
-                    "action_kind",
-                    dto.ActionKind,
-                    context="plan step",
-                ),
-                rationale=_required_string(step, "rationale", context="plan step"),
-                model_tier=_required_enum(
-                    step,
-                    "model_tier",
-                    dto.ModelTier,
-                    context="plan step",
-                ),
-                required_inputs=tuple(
-                    str(item)
-                    for item in typ.cast(
-                        "list[object]",
-                        _require_field(
-                            step,
-                            "required_inputs",
-                            list,
-                            context="plan step",
-                        ),
-                    )
-                ),
-            )
-            for step in typ.cast("list[dict[str, object]]", steps)
-        ),
+        steps=tuple(_planned_action_from_payload(step) for step in steps),
     )
 
 

--- a/episodic/orchestration/_checkpoint_payload.py
+++ b/episodic/orchestration/_checkpoint_payload.py
@@ -1,4 +1,17 @@
-"""Checkpoint payload serialisation helpers for generation orchestration."""
+"""Checkpoint payload serialization helpers for generation orchestration.
+
+This module owns the JSON-compatible payload shape persisted through
+`CheckpointPort` when `langgraph.py` takes the suspend-before-execute path.
+`_checkpoint_resume.py` uses these helpers to store `PlannerResult` values in a
+workflow checkpoint and to rebuild them when
+`resume_generation_orchestration(...)` receives an external task result.
+
+The conversion helpers keep checkpoint payload validation close to the DTOs
+they reconstruct. `_planner_result_to_payload(...)` and
+`_planner_result_from_payload(...)` are the main suspend/resume boundary; the
+plan, action-result, and usage helpers support property tests and snapshot
+coverage for that persisted contract.
+"""
 
 import enum
 import typing as typ

--- a/episodic/orchestration/_checkpoint_resume.py
+++ b/episodic/orchestration/_checkpoint_resume.py
@@ -1,0 +1,197 @@
+"""Checkpoint suspend and resume logic for generation orchestration."""
+
+import typing as typ
+import uuid
+
+from episodic.orchestration._checkpoint_payload import (
+    _planner_result_from_payload,
+    _planner_result_to_payload,
+)
+from episodic.orchestration._types import _log_event
+from episodic.orchestration._usage import build_generation_result
+
+if typ.TYPE_CHECKING:
+    import importlib
+
+    from episodic.orchestration import _dto as dto
+    from episodic.orchestration import _protocols as protocols
+    from episodic.orchestration._graph_state import GenerationGraphState
+else:
+    import importlib
+
+    dto = importlib.import_module("episodic.orchestration._dto")
+    protocols = importlib.import_module("episodic.orchestration._protocols")
+
+
+def _build_execute_step_identity(
+    *,
+    request: dto.GenerationOrchestrationRequest,
+    action: dto.PlannedAction,
+    workflow_type: str,
+) -> dto.WorkflowStepIdentity:
+    """Return the idempotency identity for the execute workflow step."""
+    return dto.WorkflowStepIdentity(
+        workflow_id=request.correlation_id,
+        workflow_type=workflow_type,
+        step_name="execute",
+        action_id=action.action_id,
+    )
+
+
+def _build_checkpoint_payload(
+    *,
+    request: dto.GenerationOrchestrationRequest,
+    planner_result: dto.PlannerResult,
+) -> dict[str, object]:
+    """Return the persisted suspend payload for generation resume."""
+    return {
+        "request": {
+            "correlation_id": request.correlation_id,
+        },
+        "planner_result": _planner_result_to_payload(planner_result),
+    }
+
+
+def _validate_suspend_preconditions(
+    state: GenerationGraphState,
+) -> tuple[
+    dto.GenerationOrchestrationRequest,
+    dto.PlannerResult,
+    dto.PlannedAction,
+]:
+    """Validate and extract required state fields for a suspend checkpoint."""
+    request = state.request
+    if request is None:
+        msg = "missing required state value: request"
+        raise ValueError(msg)
+    planner_result = state.planner_result
+    if planner_result is None:
+        msg = "missing required state value: planner_result"
+        raise ValueError(msg)
+    if len(planner_result.plan.steps) != 1:
+        msg = "cannot suspend a workflow with no planned steps"
+        if planner_result.plan.steps:
+            msg = (
+                "suspend_generation_orchestration currently supports exactly "
+                "one planned step per suspended checkpoint."
+            )
+        raise ValueError(msg)
+    return request, planner_result, planner_result.plan.steps[0]
+
+
+async def _suspend_execute_node(
+    state: GenerationGraphState,
+    *,
+    checkpoint_port: protocols.CheckpointPort,
+    workflow_type: str = "generation_orchestration",
+) -> dict[str, dto.SuspendedWorkflowResult]:
+    """Persist or reuse a checkpoint before executing the first action."""
+    request, planner_result, action = _validate_suspend_preconditions(state)
+    identity = _build_execute_step_identity(
+        request=request,
+        action=action,
+        workflow_type=workflow_type,
+    )
+    idempotency_key = dto.build_workflow_step_idempotency_key(
+        identity,
+    )
+    _log_event(
+        "debug",
+        "generation_graph.suspend_execute_node.start",
+        correlation_id=request.correlation_id,
+        workflow_id=identity.workflow_id,
+        workflow_type=identity.workflow_type,
+        step_name=identity.step_name,
+        action_id=identity.action_id,
+        idempotency_key=idempotency_key,
+    )
+    fresh_id = str(uuid.uuid4())
+    existing = await checkpoint_port.save_or_reuse(
+        dto.WorkflowCheckpoint(
+            checkpoint_id=fresh_id,
+            workflow_id=identity.workflow_id,
+            workflow_type=identity.workflow_type,
+            step_name=identity.step_name,
+            idempotency_key=idempotency_key,
+            payload=_build_checkpoint_payload(
+                request=request,
+                planner_result=planner_result,
+            ),
+        )
+    )
+    reused_checkpoint = existing.checkpoint_id != fresh_id
+    _log_event(
+        "debug",
+        "generation_graph.suspend_execute_node.finish",
+        correlation_id=request.correlation_id,
+        checkpoint_id=existing.checkpoint_id,
+        idempotency_key=existing.idempotency_key,
+        reused_checkpoint=reused_checkpoint,
+    )
+    suspended_result = dto.SuspendedWorkflowResult(
+        checkpoint_id=existing.checkpoint_id,
+        workflow_id=existing.workflow_id,
+        step_name=existing.step_name,
+        idempotency_key=existing.idempotency_key,
+    )
+    return {"suspended_result": suspended_result}
+
+
+async def resume_generation_orchestration(
+    *,
+    checkpoint_port: protocols.CheckpointPort,
+    resume_port: protocols.TaskResumePort,
+    command: dto.ResumeWorkflowCommand,
+) -> dto.GenerationOrchestrationResult:
+    """Resume a suspended generation workflow and return the final result.
+
+    `resume_generation_orchestration` currently assumes one suspended action
+    per checkpoint: `resume_port.resume(command)` returns one action result, and
+    `build_generation_result(planner_result, (action_result,))` finalises that
+    single result. Any future model that allows one checkpoint to cover
+    multiple `planner_result.plan.steps` entries must update this code path.
+
+    Raises
+    ------
+        ValueError: If the command references an unknown checkpoint.
+        TypeError: If the stored checkpoint payload cannot be deserialised into
+            the expected planner-result shape.
+    """
+    _log_event(
+        "debug",
+        "generation_graph.resume.start",
+        checkpoint_id=command.checkpoint_id,
+    )
+    checkpoint = await checkpoint_port.get(command.checkpoint_id)
+    if checkpoint is None:
+        _log_event(
+            "error",
+            "generation_graph.resume.unknown_checkpoint",
+            checkpoint_id=command.checkpoint_id,
+        )
+        msg = f"unknown checkpoint: {command.checkpoint_id}"
+        raise ValueError(msg)
+    payload = checkpoint.payload
+    try:
+        planner_result_payload = payload["planner_result"]
+    except KeyError as exc:
+        msg = "checkpoint payload missing required field: planner_result"
+        raise TypeError(msg) from exc
+    planner_result = _planner_result_from_payload(planner_result_payload)
+    if len(planner_result.plan.steps) != 1:
+        msg = (
+            "resume_generation_orchestration currently supports exactly one "
+            "planned step per suspended checkpoint."
+        )
+        raise ValueError(msg)
+    action_result = await resume_port.resume(command)
+    result = build_generation_result(planner_result, (action_result,))
+    resumed_checkpoint = await checkpoint_port.mark_resumed(checkpoint.checkpoint_id)
+    _log_event(
+        "debug",
+        "generation_graph.resume.finish",
+        checkpoint_id=resumed_checkpoint.checkpoint_id,
+        idempotency_key=resumed_checkpoint.idempotency_key,
+        status=resumed_checkpoint.status,
+    )
+    return result

--- a/episodic/orchestration/_checkpoint_resume.py
+++ b/episodic/orchestration/_checkpoint_resume.py
@@ -1,4 +1,16 @@
-"""Checkpoint suspend and resume logic for generation orchestration."""
+"""Checkpoint suspend and resume logic for generation orchestration.
+
+This module contains the checkpoint side of the LangGraph orchestration path.
+`langgraph.py` calls `_suspend_execute_node(...)` when a `CheckpointPort` is
+provided, so the graph persists the planned execution step and returns a
+`SuspendedWorkflowResult` instead of running tools inline.
+
+`resume_generation_orchestration(...)` is the public API for completing that
+paused workflow. It reloads the checkpoint payload, rebuilds the planner result
+with `_checkpoint_payload` helpers, obtains the external action result from a
+`TaskResumePort`, aggregates the final `GenerationOrchestrationResult`, and
+marks the checkpoint resumed.
+"""
 
 import typing as typ
 import uuid

--- a/episodic/orchestration/_dto.py
+++ b/episodic/orchestration/_dto.py
@@ -3,14 +3,12 @@
 import collections.abc as cabc
 import dataclasses as dc
 import typing as typ
+import uuid  # noqa: TC003 - runtime annotation inspection needs this name.
 
 from episodic.llm import (
     LLMProviderOperation,
     LLMTokenBudget,
 )
-
-if typ.TYPE_CHECKING:
-    import uuid
 
 from ._types import (
     ActionKind,

--- a/episodic/orchestration/_graph_state.py
+++ b/episodic/orchestration/_graph_state.py
@@ -12,7 +12,68 @@ else:
 
 @dc.dataclass(slots=True)
 class GenerationGraphState:
-    """Typed graph state for initialize-plan-execute-finish orchestration."""
+    """State carried by the structured generation LangGraph workflow.
+
+    ``GenerationGraphState`` stores the values exchanged by the generation
+    graph as it moves through initialize, plan, execute, and finish phases.
+    Nodes should read the fields they require, return partial dictionaries for
+    the fields they produce, and leave unrelated state untouched so LangGraph
+    can merge each node result into the next state.
+
+    Parameters
+    ----------
+    request : dto.GenerationOrchestrationRequest | None, optional
+        Original generation request. It provides the user input and
+        correlation identifier required by the plan, execute, suspend, and
+        finish nodes. It is ``None`` only before graph invocation or in
+        deliberately invalid node-validation tests.
+    planner_result : dto.PlannerResult | None, optional
+        Structured plan emitted by the plan node. The execute, suspend, and
+        finish paths require this value before selecting actions or aggregating
+        results.
+    action_results : tuple[dto.ActionExecutionResult, ...], optional
+        Ordered tool execution results emitted by the direct execute path. The
+        finish node aggregates these results with ``planner_result``.
+    orchestration_result : dto.GenerationOrchestrationResult | None, optional
+        Final domain result emitted by the finish node on the direct
+        plan -> execute -> finish path.
+    suspended_result : dto.SuspendedWorkflowResult | None, optional
+        Checkpoint metadata emitted by the suspend path when execution stops
+        before side-effecting tool work.
+
+    Attributes
+    ----------
+    request : dto.GenerationOrchestrationRequest | None
+        The request currently attached to the graph state.
+    planner_result : dto.PlannerResult | None
+        The planner output currently attached to the graph state.
+    action_results : tuple[dto.ActionExecutionResult, ...]
+        The accumulated action execution outputs in traversal order.
+    orchestration_result : dto.GenerationOrchestrationResult | None
+        The completed orchestration result, when the finish node has run.
+    suspended_result : dto.SuspendedWorkflowResult | None
+        The checkpoint suspend result, when the checkpoint path has run.
+
+    Raises
+    ------
+    None
+        The dataclass does not enforce invariants at construction time. Graph
+        nodes validate required fields when they run.
+
+    Notes
+    -----
+    Graph-node authors should treat missing values as normal for earlier
+    traversal phases. A node that produces a planner result should return
+    ``{"planner_result": result}``; a node that produces action results should
+    return ``{"action_results": results}``; and a finish node should return
+    ``{"orchestration_result": result}``.
+
+    Examples
+    --------
+    >>> state = GenerationGraphState(request=request)
+    >>> state.request is request
+    True
+    """
 
     request: dto.GenerationOrchestrationRequest | None = None
     planner_result: dto.PlannerResult | None = None

--- a/episodic/orchestration/_graph_state.py
+++ b/episodic/orchestration/_graph_state.py
@@ -1,0 +1,21 @@
+"""LangGraph state container for generation orchestration."""
+
+import dataclasses as dc
+import importlib
+import typing as typ
+
+if typ.TYPE_CHECKING:
+    from episodic.orchestration import _dto as dto
+else:
+    dto = importlib.import_module("episodic.orchestration._dto")
+
+
+@dc.dataclass(slots=True)
+class GenerationGraphState:
+    """Typed graph state for initialize-plan-execute-finish orchestration."""
+
+    request: dto.GenerationOrchestrationRequest | None = None
+    planner_result: dto.PlannerResult | None = None
+    action_results: tuple[dto.ActionExecutionResult, ...] = ()
+    orchestration_result: dto.GenerationOrchestrationResult | None = None
+    suspended_result: dto.SuspendedWorkflowResult | None = None

--- a/episodic/orchestration/langgraph.py
+++ b/episodic/orchestration/langgraph.py
@@ -22,6 +22,8 @@ from episodic.orchestration._types import _log_event
 from episodic.orchestration._usage import build_generation_result
 
 if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+
     from langgraph.graph.state import CompiledStateGraph
 
     from episodic.orchestration import _dto as dto
@@ -607,6 +609,7 @@ def build_generation_orchestration_graph(
     planner: protocols.PlannerPort,
     tool_executor: protocols.ToolExecutorPort,
     checkpoint_port: protocols.CheckpointPort | None = None,
+    finish_callback: cabc.Callable[[GenerationGraphState], None] | None = None,
 ) -> CompiledStateGraph[
     GenerationGraphState,
     None,
@@ -628,6 +631,15 @@ def build_generation_orchestration_graph(
         """Async entry point for the execute graph node."""
         return await _execute_node(state, tool_executor=tool_executor)
 
+    def _run_finish_node(
+        state: GenerationGraphState,
+    ) -> dict[str, dto.GenerationOrchestrationResult]:
+        """Entry point for the finish graph node."""
+        result = _finish_node(state)
+        if finish_callback is not None:
+            finish_callback(state)
+        return result
+
     if checkpoint_port is None:
         execute_node = _run_execute_node
         execute_target = "finish"
@@ -647,7 +659,7 @@ def build_generation_orchestration_graph(
 
     graph.add_node("plan", _run_plan_node)
     graph.add_node("execute", execute_node)
-    graph.add_node("finish", _finish_node)
+    graph.add_node("finish", _run_finish_node)
     graph.add_edge(START, "plan")
     graph.add_edge("plan", "execute")
     graph.add_edge("execute", execute_target)

--- a/episodic/orchestration/langgraph.py
+++ b/episodic/orchestration/langgraph.py
@@ -609,7 +609,8 @@ def build_generation_orchestration_graph(
     planner: protocols.PlannerPort,
     tool_executor: protocols.ToolExecutorPort,
     checkpoint_port: protocols.CheckpointPort | None = None,
-    finish_callback: cabc.Callable[[GenerationGraphState], None] | None = None,
+    finish_callback: cabc.Callable[[dto.GenerationOrchestrationResult], None]
+    | None = None,
 ) -> CompiledStateGraph[
     GenerationGraphState,
     None,
@@ -631,10 +632,12 @@ def build_generation_orchestration_graph(
             writes a checkpoint after planning and returns a suspended result
             instead of running the direct finish path.
         finish_callback: Optional callable invoked as
-            `finish_callback(state)` after finish-node aggregation and before
+            `finish_callback(result)` after finish-node aggregation and before
             returning from the direct-execute path. It receives the
-            `GenerationGraphState` that entered the finish node; callback
-            exceptions are logged without replacing the computed graph result.
+            `GenerationOrchestrationResult` produced by the finish node.
+            Invoked only on the direct plan -> execute -> finish path, not
+            the checkpoint suspend path. Callback exceptions are logged
+            without replacing the computed graph result.
     """
     graph = StateGraph(GenerationGraphState)
 
@@ -656,12 +659,8 @@ def build_generation_orchestration_graph(
         """Entry point for the finish graph node."""
         result = _finish_node(state)
         if finish_callback is not None:
-            callback_state = dc.replace(
-                state,
-                orchestration_result=result["orchestration_result"],
-            )
             try:
-                finish_callback(callback_state)
+                finish_callback(result["orchestration_result"])
                 _log_event(
                     "debug",
                     "generation_graph.finish_node.callback.finish",

--- a/episodic/orchestration/langgraph.py
+++ b/episodic/orchestration/langgraph.py
@@ -634,7 +634,7 @@ def build_generation_orchestration_graph(
             `finish_callback(state)` after finish-node aggregation and before
             returning from the direct-execute path. It receives the
             `GenerationGraphState` that entered the finish node; callback
-            exceptions are logged and propagated to the caller.
+            exceptions are logged without replacing the computed graph result.
     """
     graph = StateGraph(GenerationGraphState)
 
@@ -671,7 +671,7 @@ def build_generation_orchestration_graph(
                         else None
                     ),
                 )
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
                 _log_event(
                     "error",
                     "generation_graph.finish_node.callback.error",
@@ -682,7 +682,6 @@ def build_generation_orchestration_graph(
                     ),
                     error=str(exc),
                 )
-                raise
         return result
 
     if checkpoint_port is None:

--- a/episodic/orchestration/langgraph.py
+++ b/episodic/orchestration/langgraph.py
@@ -604,6 +604,66 @@ def _finish_node(
     return result
 
 
+def _invoke_finish_callback(
+    finish_callback: cabc.Callable[[dto.GenerationOrchestrationResult], None],
+    state: GenerationGraphState,
+    result: dict[str, dto.GenerationOrchestrationResult],
+) -> None:
+    """Invoke *finish_callback* with the post-aggregation result.
+
+    Logs a debug event on success and an error event on failure. Exceptions are
+    swallowed so callback failures do not replace the already-computed graph
+    result.
+    """
+    correlation_id = state.request.correlation_id if state.request is not None else None
+    try:
+        finish_callback(result["orchestration_result"])
+        _log_event(
+            "debug",
+            "generation_graph.finish_node.callback.finish",
+            correlation_id=correlation_id,
+        )
+    except Exception as exc:  # noqa: BLE001
+        _log_event(
+            "error",
+            "generation_graph.finish_node.callback.error",
+            correlation_id=correlation_id,
+            error=str(exc),
+        )
+
+
+def _build_execute_node(
+    tool_executor: protocols.ToolExecutorPort,
+    checkpoint_port: protocols.CheckpointPort | None,
+) -> tuple[typ.Any, str]:
+    """Return *(execute_node_fn, execute_target)* for the graph.
+
+    When *checkpoint_port* is ``None``, returns the direct execute node
+    targeting ``"finish"``. Otherwise returns the suspend-before-execute node
+    targeting ``END``.
+    """
+    if checkpoint_port is None:
+
+        async def _run_execute_node(
+            state: GenerationGraphState,
+        ) -> dict[str, tuple[dto.ActionExecutionResult, ...]]:
+            """Async entry point for the execute graph node."""
+            return await _execute_node(state, tool_executor=tool_executor)
+
+        return _run_execute_node, "finish"
+
+    async def _run_suspend_execute_node(
+        state: GenerationGraphState,
+    ) -> dict[str, dto.SuspendedWorkflowResult]:
+        """Async entry point for the suspend-before-execute graph node."""
+        return await _suspend_execute_node(
+            state,
+            checkpoint_port=checkpoint_port,
+        )
+
+    return _run_suspend_execute_node, END
+
+
 def build_generation_orchestration_graph(
     *,
     planner: protocols.PlannerPort,
@@ -647,58 +707,19 @@ def build_generation_orchestration_graph(
         """Async entry point for the plan graph node."""
         return await _plan_node(state, planner=planner)
 
-    async def _run_execute_node(
-        state: GenerationGraphState,
-    ) -> dict[str, tuple[dto.ActionExecutionResult, ...]]:
-        """Async entry point for the execute graph node."""
-        return await _execute_node(state, tool_executor=tool_executor)
-
     def _run_finish_node(
         state: GenerationGraphState,
     ) -> dict[str, dto.GenerationOrchestrationResult]:
         """Entry point for the finish graph node."""
         result = _finish_node(state)
         if finish_callback is not None:
-            try:
-                finish_callback(result["orchestration_result"])
-                _log_event(
-                    "debug",
-                    "generation_graph.finish_node.callback.finish",
-                    correlation_id=(
-                        state.request.correlation_id
-                        if state.request is not None
-                        else None
-                    ),
-                )
-            except Exception as exc:  # noqa: BLE001
-                _log_event(
-                    "error",
-                    "generation_graph.finish_node.callback.error",
-                    correlation_id=(
-                        state.request.correlation_id
-                        if state.request is not None
-                        else None
-                    ),
-                    error=str(exc),
-                )
+            _invoke_finish_callback(finish_callback, state, result)
         return result
 
-    if checkpoint_port is None:
-        execute_node = _run_execute_node
-        execute_target = "finish"
-    else:
-
-        async def _run_suspend_execute_node(
-            state: GenerationGraphState,
-        ) -> dict[str, dto.SuspendedWorkflowResult]:
-            """Async entry point for the suspend-before-execute graph node."""
-            return await _suspend_execute_node(
-                state,
-                checkpoint_port=checkpoint_port,
-            )
-
-        execute_node = _run_suspend_execute_node
-        execute_target = END
+    execute_node, execute_target = _build_execute_node(
+        tool_executor,
+        checkpoint_port,
+    )
 
     graph.add_node("plan", _run_plan_node)
     graph.add_node("execute", execute_node)

--- a/episodic/orchestration/langgraph.py
+++ b/episodic/orchestration/langgraph.py
@@ -63,6 +63,22 @@ else:
     protocols = importlib.import_module("episodic.orchestration._protocols")
 
 
+type ExecuteNodeResult = (
+    dict[str, tuple[dto.ActionExecutionResult, ...]]
+    | dict[str, dto.SuspendedWorkflowResult]
+)
+
+
+class ExecuteNodeFn(typ.Protocol):
+    """Callable protocol for async execute graph nodes."""
+
+    def __call__(
+        self, state: GenerationGraphState
+    ) -> cabc.Awaitable[ExecuteNodeResult]:
+        """Return the async execute-node update for *state*."""
+        ...
+
+
 async def _plan_node(
     state: GenerationGraphState,
     *,
@@ -228,7 +244,7 @@ def _invoke_finish_callback(
 def _build_execute_node(
     tool_executor: protocols.ToolExecutorPort,
     checkpoint_port: protocols.CheckpointPort | None,
-) -> tuple[typ.Any, str]:
+) -> tuple[ExecuteNodeFn, str]:
     """Return *(execute_node_fn, execute_target)* for the graph.
 
     When *checkpoint_port* is ``None``, returns the direct execute node

--- a/episodic/orchestration/langgraph.py
+++ b/episodic/orchestration/langgraph.py
@@ -223,7 +223,9 @@ def _invoke_finish_callback(
 
     Logs a debug event on success and an error event on failure.
     Exceptions are swallowed so that callback failures do not replace
-    the already-computed graph result.
+    the already-computed graph result. The callback is invoked synchronously
+    in the graph execution context; callbacks shared across concurrent graph
+    invocations must provide their own synchronisation.
     """
     try:
         finish_callback(result["orchestration_result"])
@@ -306,7 +308,10 @@ def build_generation_orchestration_graph(
             `GenerationOrchestrationResult` produced by the finish node.
             Invoked only on the direct plan -> execute -> finish path, not
             the checkpoint suspend path. Callback exceptions are logged
-            without replacing the computed graph result.
+            without replacing the computed graph result. The graph does not
+            serialise concurrent invocations of the same callback; callbacks
+            that mutate shared state must be thread-safe or otherwise
+            synchronise their own state.
     """
     graph = StateGraph(GenerationGraphState)
 

--- a/episodic/orchestration/langgraph.py
+++ b/episodic/orchestration/langgraph.py
@@ -637,7 +637,19 @@ def build_generation_orchestration_graph(
         """Entry point for the finish graph node."""
         result = _finish_node(state)
         if finish_callback is not None:
-            finish_callback(state)
+            try:
+                finish_callback(state)
+            except Exception as exc:  # noqa: BLE001
+                _log_event(
+                    "error",
+                    "generation_graph.finish_node.callback_error",
+                    correlation_id=(
+                        state.request.correlation_id
+                        if state.request is not None
+                        else None
+                    ),
+                    error=str(exc),
+                )
         return result
 
     if checkpoint_port is None:

--- a/episodic/orchestration/langgraph.py
+++ b/episodic/orchestration/langgraph.py
@@ -225,7 +225,7 @@ def _invoke_finish_callback(
     Exceptions are swallowed so that callback failures do not replace
     the already-computed graph result. The callback is invoked synchronously
     in the graph execution context; callbacks shared across concurrent graph
-    invocations must provide their own synchronisation.
+    invocations must provide their own synchronization.
     """
     try:
         finish_callback(result["orchestration_result"])
@@ -309,9 +309,9 @@ def build_generation_orchestration_graph(
             Invoked only on the direct plan -> execute -> finish path, not
             the checkpoint suspend path. Callback exceptions are logged
             without replacing the computed graph result. The graph does not
-            serialise concurrent invocations of the same callback; callbacks
+            serialize concurrent invocations of the same callback; callbacks
             that mutate shared state must be thread-safe or otherwise
-            synchronise their own state.
+            synchronize their own state.
     """
     graph = StateGraph(GenerationGraphState)
 

--- a/episodic/orchestration/langgraph.py
+++ b/episodic/orchestration/langgraph.py
@@ -616,7 +616,26 @@ def build_generation_orchestration_graph(
     GenerationGraphState,
     GenerationGraphState,
 ]:
-    """Build the minimal in-process generation orchestration graph."""
+    """Build the in-process generation orchestration graph.
+
+    The returned graph plans a structured generation request, either executes
+    the first planned action directly and aggregates a final
+    `GenerationOrchestrationResult`, or suspends after planning when
+    `checkpoint_port` is provided.
+
+    Args:
+        planner: Port used by the `plan` node to produce an execution plan.
+        tool_executor: Port used by the direct `execute` node to run planned
+            actions.
+        checkpoint_port: Optional persistence port. When provided, the graph
+            writes a checkpoint after planning and returns a suspended result
+            instead of running the direct finish path.
+        finish_callback: Optional callable invoked as
+            `finish_callback(state)` after finish-node aggregation and before
+            returning from the direct-execute path. It receives the
+            `GenerationGraphState` that entered the finish node; callback
+            exceptions are logged and propagated to the caller.
+    """
     graph = StateGraph(GenerationGraphState)
 
     async def _run_plan_node(
@@ -637,12 +656,25 @@ def build_generation_orchestration_graph(
         """Entry point for the finish graph node."""
         result = _finish_node(state)
         if finish_callback is not None:
+            callback_state = dc.replace(
+                state,
+                orchestration_result=result["orchestration_result"],
+            )
             try:
-                finish_callback(state)
-            except Exception as exc:  # noqa: BLE001
+                finish_callback(callback_state)
+                _log_event(
+                    "debug",
+                    "generation_graph.finish_node.callback.finish",
+                    correlation_id=(
+                        state.request.correlation_id
+                        if state.request is not None
+                        else None
+                    ),
+                )
+            except Exception as exc:
                 _log_event(
                     "error",
-                    "generation_graph.finish_node.callback_error",
+                    "generation_graph.finish_node.callback.error",
                     correlation_id=(
                         state.request.correlation_id
                         if state.request is not None
@@ -650,6 +682,7 @@ def build_generation_orchestration_graph(
                     ),
                     error=str(exc),
                 )
+                raise
         return result
 
     if checkpoint_port is None:

--- a/episodic/orchestration/langgraph.py
+++ b/episodic/orchestration/langgraph.py
@@ -606,16 +606,15 @@ def _finish_node(
 
 def _invoke_finish_callback(
     finish_callback: cabc.Callable[[dto.GenerationOrchestrationResult], None],
-    state: GenerationGraphState,
     result: dict[str, dto.GenerationOrchestrationResult],
+    correlation_id: str | None,
 ) -> None:
-    """Invoke *finish_callback* with the post-aggregation result.
+    """Invoke *finish_callback* with the aggregated domain result.
 
-    Logs a debug event on success and an error event on failure. Exceptions are
-    swallowed so callback failures do not replace the already-computed graph
-    result.
+    Logs a debug event on success and an error event on failure.
+    Exceptions are swallowed so that callback failures do not replace
+    the already-computed graph result.
     """
-    correlation_id = state.request.correlation_id if state.request is not None else None
     try:
         finish_callback(result["orchestration_result"])
         _log_event(
@@ -713,13 +712,13 @@ def build_generation_orchestration_graph(
         """Entry point for the finish graph node."""
         result = _finish_node(state)
         if finish_callback is not None:
-            _invoke_finish_callback(finish_callback, state, result)
+            correlation_id = (
+                state.request.correlation_id if state.request is not None else None
+            )
+            _invoke_finish_callback(finish_callback, result, correlation_id)
         return result
 
-    execute_node, execute_target = _build_execute_node(
-        tool_executor,
-        checkpoint_port,
-    )
+    execute_node, execute_target = _build_execute_node(tool_executor, checkpoint_port)
 
     graph.add_node("plan", _run_plan_node)
     graph.add_node("execute", execute_node)

--- a/episodic/orchestration/langgraph.py
+++ b/episodic/orchestration/langgraph.py
@@ -8,16 +8,46 @@ a `SuspendedWorkflowResult`; `resume_generation_orchestration` later rebuilds
 the saved planner state and folds in an externally supplied action result.
 """
 
-import dataclasses as dc
-import enum
 import importlib
 import time
 import typing as typ
-import uuid
 
 from langgraph.graph import END, START, StateGraph
 
-from episodic.llm import LLMUsage
+from episodic.orchestration._checkpoint_payload import (
+    _action_result_from_payload as _action_result_from_payload,
+)
+from episodic.orchestration._checkpoint_payload import (
+    _action_result_to_payload as _action_result_to_payload,
+)
+from episodic.orchestration._checkpoint_payload import (
+    _plan_from_payload as _plan_from_payload,
+)
+from episodic.orchestration._checkpoint_payload import (
+    _plan_to_payload as _plan_to_payload,
+)
+from episodic.orchestration._checkpoint_payload import (
+    _planner_result_from_payload as _planner_result_from_payload,
+)
+from episodic.orchestration._checkpoint_payload import (
+    _planner_result_to_payload as _planner_result_to_payload,
+)
+from episodic.orchestration._checkpoint_payload import (
+    _usage_from_payload as _usage_from_payload,
+)
+from episodic.orchestration._checkpoint_payload import (
+    _usage_to_payload as _usage_to_payload,
+)
+from episodic.orchestration._checkpoint_resume import (
+    _suspend_execute_node as _suspend_execute_node,
+)
+from episodic.orchestration._checkpoint_resume import (
+    _validate_suspend_preconditions as _validate_suspend_preconditions,
+)
+from episodic.orchestration._checkpoint_resume import (
+    resume_generation_orchestration as resume_generation_orchestration,
+)
+from episodic.orchestration._graph_state import GenerationGraphState
 from episodic.orchestration._types import _log_event
 from episodic.orchestration._usage import build_generation_result
 
@@ -31,268 +61,6 @@ if typ.TYPE_CHECKING:
 else:
     dto = importlib.import_module("episodic.orchestration._dto")
     protocols = importlib.import_module("episodic.orchestration._protocols")
-
-
-@dc.dataclass(slots=True)
-class GenerationGraphState:
-    """Typed graph state for initialize-plan-execute-finish orchestration."""
-
-    request: dto.GenerationOrchestrationRequest | None = None
-    planner_result: dto.PlannerResult | None = None
-    action_results: tuple[dto.ActionExecutionResult, ...] = ()
-    orchestration_result: dto.GenerationOrchestrationResult | None = None
-    suspended_result: dto.SuspendedWorkflowResult | None = None
-
-
-def _usage_to_payload(usage: LLMUsage | None) -> dict[str, int] | None:
-    """Return a JSON-compatible LLMUsage payload."""
-    if usage is None:
-        return None
-    return {
-        "input_tokens": usage.input_tokens,
-        "output_tokens": usage.output_tokens,
-        "total_tokens": usage.total_tokens,
-    }
-
-
-def _as_object_payload(payload: object, context: str) -> dict[str, object]:
-    """Return payload as a string-keyed object."""
-    if not isinstance(payload, dict):
-        msg = f"checkpoint {context} payload must be an object."
-        raise TypeError(msg)
-    return typ.cast("dict[str, object]", payload)
-
-
-def _require_field[FieldT](
-    payload: dict[str, object],
-    field_name: str,
-    expected_type: type[FieldT],
-    *,
-    context: str,
-) -> FieldT:
-    """Return a required typed checkpoint payload field."""
-    try:
-        value = payload[field_name]
-    except KeyError as exc:
-        msg = f"checkpoint {context} missing required field: {field_name}"
-        raise TypeError(msg) from exc
-    if not isinstance(value, expected_type):
-        msg = (
-            f"checkpoint {context} field {field_name} must be a "
-            f"{expected_type.__name__}."
-        )
-        raise TypeError(msg)
-    return value
-
-
-def _required_int(
-    payload: dict[str, object],
-    field_name: str,
-    *,
-    context: str,
-) -> int:
-    """Return an integer field from a checkpoint payload."""
-    return _require_field(payload, field_name, int, context=context)
-
-
-def _required_string(
-    payload: dict[str, object],
-    field_name: str,
-    *,
-    context: str,
-) -> str:
-    """Return a string field from a checkpoint payload."""
-    return _require_field(payload, field_name, str, context=context)
-
-
-def _required_enum[EnumT: enum.Enum](
-    payload: dict[str, object],
-    field_name: str,
-    enum_type: type[EnumT],
-    *,
-    context: str,
-) -> EnumT:
-    """Return an enum field from a checkpoint payload."""
-    value = _required_string(payload, field_name, context=context)
-    try:
-        return enum_type(value)
-    except ValueError as exc:
-        msg = (
-            f"checkpoint {context} field {field_name} must be a valid "
-            f"{enum_type.__name__}."
-        )
-        raise TypeError(msg) from exc
-
-
-def _usage_from_payload(payload: object) -> LLMUsage:
-    """Return LLMUsage from a checkpoint payload."""
-    usage_payload = _as_object_payload(payload, "usage")
-    return LLMUsage(
-        input_tokens=_required_int(usage_payload, "input_tokens", context="usage"),
-        output_tokens=_required_int(usage_payload, "output_tokens", context="usage"),
-        total_tokens=_required_int(usage_payload, "total_tokens", context="usage"),
-    )
-
-
-def _plan_to_payload(plan: dto.ExecutionPlan) -> dict[str, object]:
-    """Return a JSON-compatible execution-plan checkpoint payload."""
-    return {
-        "plan_version": plan.plan_version,
-        "selected_planning_model": plan.selected_planning_model,
-        "selected_execution_model": plan.selected_execution_model,
-        "steps": [
-            {
-                "action_id": action.action_id,
-                "action_kind": str(action.action_kind),
-                "rationale": action.rationale,
-                "model_tier": str(action.model_tier),
-                "required_inputs": list(action.required_inputs),
-            }
-            for action in plan.steps
-        ],
-    }
-
-
-def _plan_from_payload(payload: object) -> dto.ExecutionPlan:
-    """Return an ExecutionPlan from a checkpoint payload."""
-    plan_payload = _as_object_payload(payload, "plan")
-    steps = plan_payload.get("steps")
-    if not isinstance(steps, list):
-        msg = "checkpoint plan steps must be a list."
-        raise TypeError(msg)
-    return dto.ExecutionPlan(
-        plan_version=_required_string(
-            plan_payload,
-            "plan_version",
-            context="plan",
-        ),
-        selected_planning_model=_required_string(
-            plan_payload,
-            "selected_planning_model",
-            context="plan",
-        ),
-        selected_execution_model=_required_string(
-            plan_payload,
-            "selected_execution_model",
-            context="plan",
-        ),
-        steps=tuple(
-            dto.PlannedAction(
-                action_id=_required_string(step, "action_id", context="plan step"),
-                action_kind=_required_enum(
-                    step,
-                    "action_kind",
-                    dto.ActionKind,
-                    context="plan step",
-                ),
-                rationale=_required_string(step, "rationale", context="plan step"),
-                model_tier=_required_enum(
-                    step,
-                    "model_tier",
-                    dto.ModelTier,
-                    context="plan step",
-                ),
-                required_inputs=tuple(
-                    str(item)
-                    for item in typ.cast(
-                        "list[object]",
-                        _require_field(
-                            step,
-                            "required_inputs",
-                            list,
-                            context="plan step",
-                        ),
-                    )
-                ),
-            )
-            for step in typ.cast("list[dict[str, object]]", steps)
-        ),
-    )
-
-
-def _planner_result_to_payload(result: dto.PlannerResult) -> dict[str, object]:
-    """Return a JSON-compatible planner-result checkpoint payload."""
-    return {
-        "plan": _plan_to_payload(result.plan),
-        "usage": _usage_to_payload(result.usage),
-        "model": result.model,
-        "provider_response_id": result.provider_response_id,
-        "finish_reason": result.finish_reason,
-    }
-
-
-def _planner_result_from_payload(payload: object) -> dto.PlannerResult:
-    """Return a PlannerResult from a checkpoint payload."""
-    planner_payload = _as_object_payload(payload, "planner_result")
-    try:
-        plan_payload = planner_payload["plan"]
-    except KeyError as exc:
-        msg = "checkpoint planner_result missing required field: plan"
-        raise TypeError(msg) from exc
-    return dto.PlannerResult(
-        plan=_plan_from_payload(plan_payload),
-        usage=(
-            None
-            if planner_payload.get("usage") is None
-            else _usage_from_payload(planner_payload["usage"])
-        ),
-        model=_required_string(planner_payload, "model", context="planner_result"),
-        provider_response_id=_required_string(
-            planner_payload,
-            "provider_response_id",
-            context="planner_result",
-        ),
-        finish_reason=(
-            None
-            if planner_payload.get("finish_reason") is None
-            else _required_string(
-                planner_payload,
-                "finish_reason",
-                context="planner_result",
-            )
-        ),
-    )
-
-
-def _action_result_to_payload(result: dto.ActionExecutionResult) -> dict[str, object]:
-    """Return a JSON-compatible action-result checkpoint payload."""
-    return {
-        "action_id": result.action_id,
-        "action_kind": str(result.action_kind),
-        "model_tier": str(result.model_tier),
-        "model": result.model,
-        "summary": result.summary,
-        "usage": _usage_to_payload(result.usage),
-    }
-
-
-def _action_result_from_payload(payload: object) -> dto.ActionExecutionResult:
-    """Return an ActionExecutionResult from a checkpoint payload."""
-    action_payload = _as_object_payload(payload, "action_result")
-    return dto.ActionExecutionResult(
-        action_id=_required_string(
-            action_payload, "action_id", context="action_result"
-        ),
-        action_kind=_required_enum(
-            action_payload,
-            "action_kind",
-            dto.ActionKind,
-            context="action_result",
-        ),
-        model_tier=_required_enum(
-            action_payload,
-            "model_tier",
-            dto.ModelTier,
-            context="action_result",
-        ),
-        model=_required_string(action_payload, "model", context="action_result"),
-        summary=_required_string(action_payload, "summary", context="action_result"),
-        usage=(
-            None
-            if action_payload.get("usage") is None
-            else _usage_from_payload(action_payload["usage"])
-        ),
-    )
 
 
 async def _plan_node(
@@ -386,180 +154,6 @@ async def _execute_node(
         "debug",
         "generation_graph.execute_node.finish",
         correlation_id=request.correlation_id,
-    )
-    return result
-
-
-def _build_execute_step_identity(
-    *,
-    request: dto.GenerationOrchestrationRequest,
-    action: dto.PlannedAction,
-    workflow_type: str,
-) -> dto.WorkflowStepIdentity:
-    """Return the idempotency identity for the execute workflow step."""
-    return dto.WorkflowStepIdentity(
-        workflow_id=request.correlation_id,
-        workflow_type=workflow_type,
-        step_name="execute",
-        action_id=action.action_id,
-    )
-
-
-def _build_checkpoint_payload(
-    *,
-    request: dto.GenerationOrchestrationRequest,
-    planner_result: dto.PlannerResult,
-) -> dict[str, object]:
-    """Return the persisted suspend payload for generation resume."""
-    return {
-        "request": {
-            "correlation_id": request.correlation_id,
-        },
-        "planner_result": _planner_result_to_payload(planner_result),
-    }
-
-
-def _validate_suspend_preconditions(
-    state: GenerationGraphState,
-) -> tuple[
-    dto.GenerationOrchestrationRequest,
-    dto.PlannerResult,
-    dto.PlannedAction,
-]:
-    """Validate and extract required state fields for a suspend checkpoint."""
-    request = state.request
-    if request is None:
-        msg = "missing required state value: request"
-        raise ValueError(msg)
-    planner_result = state.planner_result
-    if planner_result is None:
-        msg = "missing required state value: planner_result"
-        raise ValueError(msg)
-    if len(planner_result.plan.steps) != 1:
-        msg = "cannot suspend a workflow with no planned steps"
-        if planner_result.plan.steps:
-            msg = (
-                "suspend_generation_orchestration currently supports exactly "
-                "one planned step per suspended checkpoint."
-            )
-        raise ValueError(msg)
-    return request, planner_result, planner_result.plan.steps[0]
-
-
-async def _suspend_execute_node(
-    state: GenerationGraphState,
-    *,
-    checkpoint_port: protocols.CheckpointPort,
-    workflow_type: str = "generation_orchestration",
-) -> dict[str, dto.SuspendedWorkflowResult]:
-    """Persist or reuse a checkpoint before executing the first action."""
-    request, planner_result, action = _validate_suspend_preconditions(state)
-    identity = _build_execute_step_identity(
-        request=request,
-        action=action,
-        workflow_type=workflow_type,
-    )
-    idempotency_key = dto.build_workflow_step_idempotency_key(
-        identity,
-    )
-    _log_event(
-        "debug",
-        "generation_graph.suspend_execute_node.start",
-        correlation_id=request.correlation_id,
-        workflow_id=identity.workflow_id,
-        workflow_type=identity.workflow_type,
-        step_name=identity.step_name,
-        action_id=identity.action_id,
-        idempotency_key=idempotency_key,
-    )
-    fresh_id = str(uuid.uuid4())
-    existing = await checkpoint_port.save_or_reuse(
-        dto.WorkflowCheckpoint(
-            checkpoint_id=fresh_id,
-            workflow_id=identity.workflow_id,
-            workflow_type=identity.workflow_type,
-            step_name=identity.step_name,
-            idempotency_key=idempotency_key,
-            payload=_build_checkpoint_payload(
-                request=request,
-                planner_result=planner_result,
-            ),
-        )
-    )
-    reused_checkpoint = existing.checkpoint_id != fresh_id
-    _log_event(
-        "debug",
-        "generation_graph.suspend_execute_node.finish",
-        correlation_id=request.correlation_id,
-        checkpoint_id=existing.checkpoint_id,
-        idempotency_key=existing.idempotency_key,
-        reused_checkpoint=reused_checkpoint,
-    )
-    suspended_result = dto.SuspendedWorkflowResult(
-        checkpoint_id=existing.checkpoint_id,
-        workflow_id=existing.workflow_id,
-        step_name=existing.step_name,
-        idempotency_key=existing.idempotency_key,
-    )
-    return {"suspended_result": suspended_result}
-
-
-async def resume_generation_orchestration(
-    *,
-    checkpoint_port: protocols.CheckpointPort,
-    resume_port: protocols.TaskResumePort,
-    command: dto.ResumeWorkflowCommand,
-) -> dto.GenerationOrchestrationResult:
-    """Resume a suspended generation workflow and return the final result.
-
-    `resume_generation_orchestration` currently assumes one suspended action
-    per checkpoint: `resume_port.resume(command)` returns one action result, and
-    `build_generation_result(planner_result, (action_result,))` finalises that
-    single result. Any future model that allows one checkpoint to cover
-    multiple `planner_result.plan.steps` entries must update this code path.
-
-    Raises
-    ------
-        ValueError: If the command references an unknown checkpoint.
-        TypeError: If the stored checkpoint payload cannot be deserialised into
-            the expected planner-result shape.
-    """
-    _log_event(
-        "debug",
-        "generation_graph.resume.start",
-        checkpoint_id=command.checkpoint_id,
-    )
-    checkpoint = await checkpoint_port.get(command.checkpoint_id)
-    if checkpoint is None:
-        _log_event(
-            "error",
-            "generation_graph.resume.unknown_checkpoint",
-            checkpoint_id=command.checkpoint_id,
-        )
-        msg = f"unknown checkpoint: {command.checkpoint_id}"
-        raise ValueError(msg)
-    payload = checkpoint.payload
-    try:
-        planner_result_payload = payload["planner_result"]
-    except KeyError as exc:
-        msg = "checkpoint payload missing required field: planner_result"
-        raise TypeError(msg) from exc
-    planner_result = _planner_result_from_payload(planner_result_payload)
-    if len(planner_result.plan.steps) != 1:
-        msg = (
-            "resume_generation_orchestration currently supports exactly one "
-            "planned step per suspended checkpoint."
-        )
-        raise ValueError(msg)
-    action_result = await resume_port.resume(command)
-    result = build_generation_result(planner_result, (action_result,))
-    resumed_checkpoint = await checkpoint_port.mark_resumed(checkpoint.checkpoint_id)
-    _log_event(
-        "debug",
-        "generation_graph.resume.finish",
-        checkpoint_id=resumed_checkpoint.checkpoint_id,
-        idempotency_key=resumed_checkpoint.idempotency_key,
-        status=resumed_checkpoint.status,
     )
     return result
 

--- a/tests/__snapshots__/test_generation_orchestration_snapshots.ambr
+++ b/tests/__snapshots__/test_generation_orchestration_snapshots.ambr
@@ -142,7 +142,7 @@
     'non_list_required_inputs': 'required_inputs must be a list of strings.',
     'non_list_steps': 'steps must be a list.',
     'non_object_step': 'step must be an object.',
-    'unknown_action_kind': 'action_kind must be one of: generate_show_notes.',
+    'unknown_action_kind': 'action_kind must be one of: generate_show_notes, generate_guest_bios.',
     'unknown_model_tier': 'model_tier must be one of: planning, execution.',
   })
 # ---

--- a/tests/__snapshots__/test_generation_orchestration_snapshots.ambr
+++ b/tests/__snapshots__/test_generation_orchestration_snapshots.ambr
@@ -135,3 +135,14 @@
     }),
   })
 # ---
+# name: test_planner_format_error_messages_snapshot
+  dict({
+    'missing_action_id': 'action_id must be a non-empty string.',
+    'missing_plan_version': 'plan_version must be a non-empty string.',
+    'non_list_required_inputs': 'required_inputs must be a list of strings.',
+    'non_list_steps': 'steps must be a list.',
+    'non_object_step': 'step must be an object.',
+    'unknown_action_kind': 'action_kind must be one of: generate_show_notes.',
+    'unknown_model_tier': 'model_tier must be one of: planning, execution.',
+  })
+# ---

--- a/tests/_orchestration_property_support.py
+++ b/tests/_orchestration_property_support.py
@@ -1,0 +1,328 @@
+"""Shared strategies and fakes for orchestration property tests."""
+
+import dataclasses as dc
+import json
+import string
+import typing as typ
+
+import hypothesis.strategies as st
+
+from episodic.generation import ShowNotesResult
+from episodic.llm import LLMUsage
+from episodic.orchestration import (
+    ActionExecutionResult,
+    ActionKind,
+    ExecutionPlan,
+    GenerationOrchestrationRequest,
+    ModelTier,
+    PlannedAction,
+    PlannerResult,
+)
+
+KNOWN_ACTION_KIND_STRINGS = {m.value for m in ActionKind}
+
+
+@dc.dataclass(slots=True)
+class GraphEventRecorder:
+    """Collect explicitly injected graph-node events for ordering assertions."""
+
+    events: list[str] = dc.field(default_factory=list)
+
+    def record(self, event: str) -> None:
+        """Append one observed graph-node event."""
+        self.events.append(event)
+
+
+class PropGraphPlanner:
+    """Emit canned planner payloads for Hypothesis graph probes."""
+
+    def __init__(
+        self,
+        *,
+        result: PlannerResult,
+        event_recorder: GraphEventRecorder | None = None,
+    ) -> None:
+        self._result = result
+        self._event_recorder = event_recorder
+
+    async def plan(self, request: GenerationOrchestrationRequest) -> PlannerResult:
+        """Record the plan node when requested and return the canned result."""
+        if not request.script_tei_xml.startswith("<TEI>"):
+            msg = f"expected TEI input, got {request.script_tei_xml!r}"
+            raise AssertionError(msg)
+        if not request.correlation_id:
+            msg = "expected non-empty correlation_id"
+            raise AssertionError(msg)
+        if self._event_recorder is not None:
+            self._event_recorder.record("plan")
+        return self._result
+
+
+class PropGraphToolExecutor:
+    """Emit canned tool payloads for Hypothesis graph probes."""
+
+    def __init__(
+        self,
+        result: ActionExecutionResult,
+        *,
+        event_recorder: GraphEventRecorder | None = None,
+    ) -> None:
+        self._result = result
+        self._event_recorder = event_recorder
+
+    async def execute(
+        self,
+        action: PlannedAction,
+        context: GenerationOrchestrationRequest,
+    ) -> ActionExecutionResult:
+        """Record the execute node when requested and return the canned result."""
+        if not context.script_tei_xml.startswith("<TEI>"):
+            msg = f"expected TEI input, got {context.script_tei_xml!r}"
+            raise AssertionError(msg)
+        if action.action_kind is not ActionKind.GENERATE_SHOW_NOTES:
+            msg = f"expected show-notes action, got {action.action_kind!r}"
+            raise AssertionError(msg)
+        if self._event_recorder is not None:
+            self._event_recorder.record("execute")
+        return self._result
+
+
+class PropShowNotesGenerator:
+    """Return an empty show-notes result for model-tier boundary probes."""
+
+    @staticmethod
+    async def generate(
+        script_tei_xml: str,
+        *,
+        template_structure: dict[str, object] | None = None,
+    ) -> ShowNotesResult:
+        """Return a minimal structured show-notes result."""
+        if not script_tei_xml.startswith("<TEI>"):
+            msg = f"expected TEI input, got {script_tei_xml!r}"
+            raise AssertionError(msg)
+        if template_structure is None:
+            msg = "expected template structure"
+            raise AssertionError(msg)
+        return ShowNotesResult(
+            entries=(),
+            usage=LLMUsage(input_tokens=1, output_tokens=0, total_tokens=1),
+            model="prop-exec-model",
+            provider_response_id="prop-exec-response",
+            finish_reason="stop",
+        )
+
+
+@dc.dataclass(frozen=True, slots=True)
+class PropTokenInputs:
+    """Bundled token-count inputs for LangGraph property tests."""
+
+    planner_input: int
+    planner_output: int
+    action_input: int
+    action_output: int
+
+
+token_inputs_strategy: st.SearchStrategy[PropTokenInputs] = st.builds(
+    PropTokenInputs,
+    planner_input=st.integers(min_value=0, max_value=10_000),
+    planner_output=st.integers(min_value=0, max_value=10_000),
+    action_input=st.integers(min_value=0, max_value=10_000),
+    action_output=st.integers(min_value=0, max_value=10_000),
+)
+
+
+@dc.dataclass(frozen=True, slots=True)
+class PropStepKeyInputs:
+    """Bundled workflow step identity inputs for idempotency key tests."""
+
+    workflow_id: str
+    workflow_type: str
+    step_name: str
+    action_id: str
+
+
+step_key_inputs_strategy: st.SearchStrategy[PropStepKeyInputs] = st.builds(
+    PropStepKeyInputs,
+    workflow_id=st.text(
+        min_size=1,
+        max_size=32,
+        alphabet=string.ascii_letters + string.digits + "-",
+    ),
+    workflow_type=st.text(
+        min_size=1,
+        max_size=32,
+        alphabet=string.ascii_letters + string.digits + "_",
+    ),
+    step_name=st.text(
+        min_size=1,
+        max_size=32,
+        alphabet=string.ascii_letters + string.digits + "_",
+    ),
+    action_id=st.text(
+        min_size=1,
+        max_size=32,
+        alphabet=string.ascii_letters + string.digits + "-",
+    ),
+)
+
+prop_text = st.text(
+    min_size=1,
+    max_size=32,
+    alphabet=string.ascii_letters + string.digits + "-_ .",
+).filter(lambda value: bool(value.strip()))
+
+usage_strategy = st.builds(
+    LLMUsage,
+    input_tokens=st.integers(min_value=0, max_value=10_000),
+    output_tokens=st.integers(min_value=0, max_value=10_000),
+    total_tokens=st.integers(min_value=0, max_value=20_000),
+)
+
+planned_action_strategy = st.builds(
+    PlannedAction,
+    action_id=prop_text,
+    action_kind=st.just(ActionKind.GENERATE_SHOW_NOTES),
+    rationale=prop_text,
+    model_tier=st.just(ModelTier.EXECUTION),
+    required_inputs=st.lists(prop_text, max_size=4).map(tuple),
+)
+
+execution_plan_strategy = st.builds(
+    ExecutionPlan,
+    plan_version=prop_text,
+    selected_planning_model=prop_text,
+    selected_execution_model=prop_text,
+    steps=st.lists(planned_action_strategy, min_size=1, max_size=4).map(tuple),
+)
+
+planner_result_strategy = st.builds(
+    PlannerResult,
+    plan=execution_plan_strategy,
+    usage=st.one_of(st.none(), usage_strategy),
+    model=prop_text,
+    provider_response_id=prop_text,
+    finish_reason=st.one_of(st.none(), prop_text),
+)
+
+action_result_strategy = st.builds(
+    ActionExecutionResult,
+    action_id=prop_text,
+    action_kind=st.just(ActionKind.GENERATE_SHOW_NOTES),
+    model_tier=st.just(ModelTier.EXECUTION),
+    model=prop_text,
+    summary=prop_text,
+    usage=st.one_of(st.none(), usage_strategy),
+)
+
+
+def valid_plan_object() -> dict[str, object]:
+    """Return one valid raw planner object suitable for targeted corruption."""
+    return {
+        "plan_version": "1.0",
+        "steps": [
+            {
+                "action_id": "action-1",
+                "action_kind": ActionKind.GENERATE_SHOW_NOTES.value,
+                "rationale": "Generate publication-ready show notes.",
+                "model_tier": ModelTier.EXECUTION.value,
+                "required_inputs": ["script_tei_xml", "template_structure"],
+            }
+        ],
+    }
+
+
+def invalid_plan_without_plan_version() -> str:
+    """Return JSON for a plan object with the required version field omitted."""
+    payload = valid_plan_object()
+    payload = {key: value for key, value in payload.items() if key != "plan_version"}
+    return json.dumps(payload)
+
+
+def invalid_plan_with_top_level_field(field_name: str, value: object) -> str:
+    """Return JSON for a plan object with one top-level field replaced."""
+    return json.dumps(valid_plan_object() | {field_name: value})
+
+
+def invalid_plan_with_step_field(field_name: str, value: object) -> str:
+    """Return JSON for a plan object with one first-step field replaced."""
+    step = typ.cast("list[dict[str, object]]", valid_plan_object()["steps"])[0]
+    return json.dumps(valid_plan_object() | {"steps": [step | {field_name: value}]})
+
+
+def invalid_plan_without_step_field(field_name: str) -> str:
+    """Return JSON for a plan object with one required first-step field omitted."""
+    step = typ.cast("list[dict[str, object]]", valid_plan_object()["steps"])[0]
+    narrowed_step = {key: value for key, value in step.items() if key != field_name}
+    return json.dumps(valid_plan_object() | {"steps": [narrowed_step]})
+
+
+unknown_action_kind_values = st.one_of(
+    st.none(),
+    st.integers(),
+    st.text(min_size=1, max_size=512).filter(
+        lambda value: value.strip() not in {kind.value for kind in ActionKind}
+    ),
+)
+
+unknown_model_tier_values = st.one_of(
+    st.none(),
+    st.integers(),
+    st.text(min_size=1, max_size=512).filter(
+        lambda value: value.strip() not in {tier.value for tier in ModelTier}
+    ),
+)
+
+invalid_required_inputs_values = st.one_of(
+    st.integers(),
+    st.lists(
+        st.one_of(st.none(), st.integers(), st.just("")),
+        min_size=1,
+        max_size=10,
+    ),
+)
+
+PLANNER_FORMAT_ERROR_PATTERN = (
+    r"plan_version must be a non-empty string"
+    r"|steps must be a list"
+    r"|step must be an object"
+    r"|action_id must be a non-empty string"
+    r"|action_kind must be a non-empty string"
+    r"|action_kind must be one of: generate_show_notes"
+    r"|rationale must be a non-empty string"
+    r"|model_tier must be a non-empty string"
+    r"|model_tier must be one of: planning, execution"
+    r"|required_inputs must be a list of strings"
+    r"|required_inputs must contain only non-empty strings"
+)
+
+invalid_plan_payloads = st.one_of(
+    st.just(invalid_plan_without_plan_version()),
+    st.sampled_from(("", " ", "\t")).map(
+        lambda value: invalid_plan_with_top_level_field("plan_version", value)
+    ),
+    st.one_of(
+        st.none(),
+        st.integers(),
+        st.text(max_size=512),
+        st.dictionaries(st.text(min_size=1, max_size=4), st.integers(), max_size=2),
+    ).map(lambda value: invalid_plan_with_top_level_field("steps", value)),
+    st.one_of(st.none(), st.integers(), st.text(max_size=512)).map(
+        lambda value: invalid_plan_with_top_level_field("steps", [value])
+    ),
+    st.just(invalid_plan_without_step_field("action_id")),
+    st.sampled_from(("", " ", "\n")).map(
+        lambda value: invalid_plan_with_step_field("action_id", value)
+    ),
+    unknown_action_kind_values.map(
+        lambda value: invalid_plan_with_step_field("action_kind", value)
+    ),
+    st.sampled_from(("", " ", "\r\n")).map(
+        lambda value: invalid_plan_with_step_field("rationale", value)
+    ),
+    unknown_model_tier_values.map(
+        lambda value: invalid_plan_with_step_field("model_tier", value)
+    ),
+    invalid_required_inputs_values.map(
+        lambda value: invalid_plan_with_step_field("required_inputs", value)
+    ),
+)

--- a/tests/_orchestration_property_support.py
+++ b/tests/_orchestration_property_support.py
@@ -171,11 +171,20 @@ prop_text = st.text(
     alphabet=string.ascii_letters + string.digits + "-_ .",
 ).filter(lambda value: bool(value.strip()))
 
+
+def _usage_from_counts(input_tokens: int, output_tokens: int) -> LLMUsage:
+    """Build internally consistent LLM token usage counts."""
+    return LLMUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=input_tokens + output_tokens,
+    )
+
+
 usage_strategy = st.builds(
-    LLMUsage,
+    _usage_from_counts,
     input_tokens=st.integers(min_value=0, max_value=10_000),
     output_tokens=st.integers(min_value=0, max_value=10_000),
-    total_tokens=st.integers(min_value=0, max_value=20_000),
 )
 
 planned_action_strategy = st.builds(

--- a/tests/test_generation_orchestration_snapshots.py
+++ b/tests/test_generation_orchestration_snapshots.py
@@ -1,6 +1,7 @@
 """Syrupy regression snapshots for typed generation artefacts."""
 
 import dataclasses
+import typing as typ
 
 from syrupy.assertion import SnapshotAssertion
 
@@ -15,6 +16,7 @@ from episodic.orchestration import (
     ModelTier,
     PlannedAction,
     PlannerResult,
+    PlanningResponseFormatError,
     StructuredGenerationPlanner,
 )
 from episodic.orchestration.langgraph import (
@@ -35,7 +37,67 @@ class _UnusedLLMPort:
         raise RuntimeError(msg)
 
 
+def _valid_plan_payload() -> dict[str, object]:
+    """Return one raw planner payload used as the basis for error snapshots."""
+    return {
+        "plan_version": "1.0",
+        "steps": [
+            {
+                "action_id": "action-1",
+                "action_kind": ActionKind.GENERATE_SHOW_NOTES.value,
+                "rationale": "Generate show notes.",
+                "model_tier": ModelTier.EXECUTION.value,
+                "required_inputs": ["script_tei_xml"],
+            }
+        ],
+    }
+
+
+def _valid_plan_step() -> dict[str, object]:
+    """Return the first valid raw planner step for targeted corruption."""
+    steps = _valid_plan_payload()["steps"]
+    assert isinstance(steps, list)
+    step = steps[0]
+    assert isinstance(step, dict)
+    return typ.cast("dict[str, object]", step)
+
+
+def _plan_payload_with_step_field(field_name: str, value: object) -> dict[str, object]:
+    """Return a planner payload with one step field replaced."""
+    return _valid_plan_payload() | {"steps": [_valid_plan_step() | {field_name: value}]}
+
+
+def _plan_payload_without_step_field(field_name: str) -> dict[str, object]:
+    """Return a planner payload with one required step field omitted."""
+    return _valid_plan_payload() | {
+        "steps": [
+            {
+                key: value
+                for key, value in _valid_plan_step().items()
+                if key != field_name
+            }
+        ]
+    }
+
+
+def _capture_plan_format_error(payload: dict[str, object]) -> str:
+    """Return the structured-planner format error for a malformed payload."""
+    try:
+        StructuredGenerationPlanner._parse_plan(
+            payload,
+            config=GenerationOrchestrationConfig(
+                planning_model="gpt-4.1",
+                execution_model="gpt-4o-mini",
+            ),
+        )
+    except PlanningResponseFormatError as exc:
+        return str(exc)
+    msg = f"Expected PlanningResponseFormatError for payload: {payload!r}"
+    raise AssertionError(msg)
+
+
 def test_build_prompt_snapshot(snapshot: SnapshotAssertion) -> None:
+    """Snapshot the JSON planner prompt rendered for a minimal request."""
     cfg = GenerationOrchestrationConfig(
         planning_model="gpt-4.1",
         execution_model="gpt-4o-mini",
@@ -50,6 +112,7 @@ def test_build_prompt_snapshot(snapshot: SnapshotAssertion) -> None:
 
 
 def test_execution_plan_serialisation_snapshot(snapshot: SnapshotAssertion) -> None:
+    """Snapshot dataclass serialisation for execution plans."""
     planned = PlannedAction(
         action_id="a1",
         action_kind=ActionKind.GENERATE_SHOW_NOTES,
@@ -69,6 +132,7 @@ def test_execution_plan_serialisation_snapshot(snapshot: SnapshotAssertion) -> N
 def test_generation_orchestration_result_snapshot(
     snapshot: SnapshotAssertion,
 ) -> None:
+    """Snapshot dataclass serialisation for aggregated orchestration results."""
     planned = PlannedAction(
         action_id="a1",
         action_kind=ActionKind.GENERATE_SHOW_NOTES,
@@ -100,6 +164,7 @@ def test_generation_orchestration_result_snapshot(
 
 
 def test_checkpoint_payload_snapshot(snapshot: SnapshotAssertion) -> None:
+    """Snapshot checkpoint payload conversion for planner and action results."""
     planned = PlannedAction(
         action_id="a1",
         action_kind=ActionKind.GENERATE_SHOW_NOTES,
@@ -132,4 +197,33 @@ def test_checkpoint_payload_snapshot(snapshot: SnapshotAssertion) -> None:
     assert {
         "planner_result": _planner_result_to_payload(planner_result),
         "action_result": _action_result_to_payload(action_result),
+    } == snapshot
+
+
+def test_planner_format_error_messages_snapshot(snapshot: SnapshotAssertion) -> None:
+    """Snapshot representative strict-planner format error messages."""
+    assert {
+        "missing_action_id": _capture_plan_format_error(
+            _plan_payload_without_step_field("action_id")
+        ),
+        "missing_plan_version": _capture_plan_format_error({
+            key: value
+            for key, value in _valid_plan_payload().items()
+            if key != "plan_version"
+        }),
+        "non_list_required_inputs": _capture_plan_format_error(
+            _plan_payload_with_step_field("required_inputs", "script_tei_xml")
+        ),
+        "non_list_steps": _capture_plan_format_error(
+            _valid_plan_payload() | {"steps": "not-a-list"}
+        ),
+        "non_object_step": _capture_plan_format_error(
+            _valid_plan_payload() | {"steps": ["not-an-object"]}
+        ),
+        "unknown_action_kind": _capture_plan_format_error(
+            _plan_payload_with_step_field("action_kind", "unknown_action")
+        ),
+        "unknown_model_tier": _capture_plan_format_error(
+            _plan_payload_with_step_field("model_tier", "training")
+        ),
     } == snapshot

--- a/tests/test_generation_orchestration_snapshots.py
+++ b/tests/test_generation_orchestration_snapshots.py
@@ -1,4 +1,11 @@
-"""Syrupy regression snapshots for typed generation artefacts."""
+"""Syrupy regression snapshots for structured generation orchestration.
+
+Issue #72 added property coverage for orchestration invariants; this module
+keeps stable snapshots alongside `tests/test_orchestration_properties.py` and
+the focused orchestration unit tests. The snapshots pin the planner prompt,
+execution-plan and orchestration-result serialisation, checkpoint payload
+conversion, and representative planner-format error messages.
+"""
 
 import dataclasses
 import typing as typ

--- a/tests/test_orchestration_config_model_tier_properties.py
+++ b/tests/test_orchestration_config_model_tier_properties.py
@@ -64,8 +64,8 @@ def test_config_rejects_arbitrary_unknown_action_kind_strings(unknown: str) -> N
 
 
 @pytest.mark.parametrize(
-    "model_tier",
-    [tier for tier in ModelTier if tier is not ModelTier.EXECUTION],
+    ("model_tier",),  # noqa: PT006 - requested tuple-shaped parameter list.
+    [(tier,) for tier in ModelTier if tier is not ModelTier.EXECUTION],
 )
 @pytest.mark.asyncio
 async def test_planned_action_model_tier_rejection_for_all_non_execution_tiers(

--- a/tests/test_orchestration_config_model_tier_properties.py
+++ b/tests/test_orchestration_config_model_tier_properties.py
@@ -64,8 +64,8 @@ def test_config_rejects_arbitrary_unknown_action_kind_strings(unknown: str) -> N
 
 
 @pytest.mark.parametrize(
-    ("model_tier",),  # noqa: PT006 - requested tuple-shaped parameter list.
-    [(tier,) for tier in ModelTier if tier is not ModelTier.EXECUTION],
+    "model_tier",
+    [tier for tier in ModelTier if tier is not ModelTier.EXECUTION],
 )
 @pytest.mark.asyncio
 async def test_planned_action_model_tier_rejection_for_all_non_execution_tiers(

--- a/tests/test_orchestration_config_model_tier_properties.py
+++ b/tests/test_orchestration_config_model_tier_properties.py
@@ -1,0 +1,108 @@
+"""Property and boundary tests for orchestration config and model tiers."""
+
+import hypothesis.strategies as st
+import pytest
+from hypothesis import given, settings
+
+from episodic.llm import LLMProviderOperation
+from episodic.orchestration import (
+    ActionKind,
+    GenerationOrchestrationConfig,
+    ModelTier,
+    PlannedAction,
+    ShowNotesToolExecutor,
+    UnsupportedActionError,
+)
+from tests._orchestration_fakes import (
+    _config,
+    _FakeLLMPort,
+    _request,
+)
+from tests._orchestration_property_support import (
+    KNOWN_ACTION_KIND_STRINGS,
+    PropShowNotesGenerator,
+)
+
+_ACTION_KIND_SAMPLES: tuple[ActionKind | str, ...] = tuple(ActionKind) + tuple(
+    m.value for m in ActionKind
+)
+
+
+@given(st.lists(st.sampled_from(_ACTION_KIND_SAMPLES), min_size=1, max_size=48))
+@settings(max_examples=50)
+def test_config_normalises_arbitrary_string_and_enum_mixes(
+    kinds: list[ActionKind | str],
+) -> None:
+    """Property test: heterogeneous action vocabularies become ``ActionKind``."""
+    cfg = GenerationOrchestrationConfig(
+        planning_model="hyp-plan-model",
+        execution_model="hyp-exec-model",
+        planning_provider_operation=LLMProviderOperation.CHAT_COMPLETIONS,
+        execution_provider_operation=LLMProviderOperation.CHAT_COMPLETIONS,
+        enabled_action_kinds=tuple(kinds),
+    )
+    assert all(isinstance(kind, ActionKind) for kind in cfg.enabled_action_kinds)
+    assert cfg.enabled_action_kinds == tuple(ActionKind(str(kind)) for kind in kinds)
+
+
+@given(
+    unknown=st.text(min_size=1, max_size=512).filter(
+        lambda s: bool(s.strip()) and s.strip() not in KNOWN_ACTION_KIND_STRINGS
+    )
+)
+@settings(max_examples=50)
+def test_config_rejects_arbitrary_unknown_action_kind_strings(unknown: str) -> None:
+    """Property test: unknown action strings invalidate configuration."""
+    with pytest.raises(ValueError, match="Unknown action kind"):
+        GenerationOrchestrationConfig(
+            planning_model="hyp-plan-model",
+            execution_model="hyp-exec-model",
+            planning_provider_operation=LLMProviderOperation.CHAT_COMPLETIONS,
+            execution_provider_operation=LLMProviderOperation.CHAT_COMPLETIONS,
+            enabled_action_kinds=(unknown,),
+        )
+
+
+@pytest.mark.parametrize(
+    ("model_tier",),  # noqa: PT006 - requested tuple-shaped parameter list.
+    [(tier,) for tier in ModelTier if tier is not ModelTier.EXECUTION],
+)
+@pytest.mark.asyncio
+async def test_planned_action_model_tier_rejection_for_all_non_execution_tiers(
+    model_tier: ModelTier,
+) -> None:
+    """Every planner tier besides execution must be rejected by show-notes."""
+    fake_llm = _FakeLLMPort([])
+    tool_executor = ShowNotesToolExecutor(llm=fake_llm, config=_config())
+    planning_tier_action = PlannedAction(
+        action_id="action-1",
+        action_kind=ActionKind.GENERATE_SHOW_NOTES,
+        rationale="Hypothesis rejects non-execution tiers.",
+        model_tier=model_tier,
+        required_inputs=("script_tei_xml",),
+    )
+    with pytest.raises(UnsupportedActionError, match=r"requires ModelTier\.EXECUTION"):
+        await tool_executor.execute(planning_tier_action, _request())
+
+
+@pytest.mark.asyncio
+async def test_planned_action_execution_model_tier_is_accepted() -> None:
+    """Boundary check: execution-tier actions are eligible for show-notes tooling."""
+    fake_llm = _FakeLLMPort([])
+    tool_executor = ShowNotesToolExecutor(
+        llm=fake_llm,
+        config=_config(),
+        generator=PropShowNotesGenerator(),
+    )
+    action = PlannedAction(
+        action_id="action-1",
+        action_kind=ActionKind.GENERATE_SHOW_NOTES,
+        rationale="Hypothesis boundary check for execution tier.",
+        model_tier=ModelTier.EXECUTION,
+        required_inputs=("script_tei_xml",),
+    )
+
+    result = await tool_executor.execute(action, _request())
+
+    assert result.model_tier is ModelTier.EXECUTION
+    assert result.summary == "Generated 0 show-notes entries."

--- a/tests/test_orchestration_graph_invariant_properties.py
+++ b/tests/test_orchestration_graph_invariant_properties.py
@@ -1,5 +1,6 @@
 """Property tests for LangGraph orchestration invariants."""
 
+import asyncio
 import string
 
 import hypothesis.strategies as st
@@ -291,3 +292,28 @@ async def test_langgraph_finish_callback_errors_do_not_replace_result() -> None:
     assert state["orchestration_result"] is not None
     assert state["planner_result"] == planner_result
     assert state["action_results"] == (tool_result,)
+
+
+@pytest.mark.asyncio
+async def test_finish_callback_records_concurrent_direct_results() -> None:
+    """Concurrent direct execution invokes the shared finish callback once each."""
+    expected_invocations = 4
+    observed_results: list[GenerationOrchestrationResult] = []
+    graph = build_generation_orchestration_graph(
+        planner=PropGraphPlanner(result=_planner_result()),
+        tool_executor=PropGraphToolExecutor(result=_tool_result()),
+        finish_callback=observed_results.append,
+    )
+
+    states = await asyncio.gather(
+        *(
+            graph.ainvoke(
+                GenerationGraphState(request=_request(f"callback-concurrent-{index}"))
+            )
+            for index in range(expected_invocations)
+        )
+    )
+
+    assert len(observed_results) == expected_invocations
+    assert all(result is not None for result in observed_results)
+    assert [state["orchestration_result"] for state in states] == observed_results

--- a/tests/test_orchestration_graph_invariant_properties.py
+++ b/tests/test_orchestration_graph_invariant_properties.py
@@ -1,0 +1,232 @@
+"""Property tests for LangGraph orchestration invariants."""
+
+import string
+
+import hypothesis.strategies as st
+import pytest
+from hypothesis import given, settings
+
+from episodic.llm import LLMUsage
+from episodic.orchestration import (
+    ActionExecutionResult,
+    ActionKind,
+    ExecutionPlan,
+    GenerationGraphState,
+    GenerationOrchestrationRequest,
+    ModelTier,
+    PlannedAction,
+    PlannerResult,
+    build_generation_orchestration_graph,
+)
+from tests._orchestration_property_support import (
+    GraphEventRecorder,
+    PropGraphPlanner,
+    PropGraphToolExecutor,
+    PropTokenInputs,
+    token_inputs_strategy,
+)
+
+
+@given(
+    tokens=token_inputs_strategy,
+    correlation_id=st.text(
+        min_size=1,
+        max_size=48,
+        alphabet=string.ascii_letters + string.digits + "-",
+    ),
+)
+@settings(max_examples=50)
+@pytest.mark.asyncio
+async def test_langgraph_total_tokens_non_negative(
+    tokens: PropTokenInputs,
+    correlation_id: str,
+) -> None:
+    """Property test: LangGraph rollups keep total token counts semiring-safe."""
+    planner_usage = LLMUsage(
+        tokens.planner_input,
+        tokens.planner_output,
+        tokens.planner_input + tokens.planner_output,
+    )
+    tool_usage = LLMUsage(
+        tokens.action_input,
+        tokens.action_output,
+        tokens.action_input + tokens.action_output,
+    )
+    planner_result = PlannerResult(
+        plan=ExecutionPlan(
+            plan_version="1.0",
+            selected_planning_model="prop-plan-model",
+            selected_execution_model="prop-exec-model",
+            steps=(
+                PlannedAction(
+                    action_id="action-1",
+                    action_kind=ActionKind.GENERATE_SHOW_NOTES,
+                    rationale="prop graph rationale",
+                    model_tier=ModelTier.EXECUTION,
+                    required_inputs=("script_tei_xml",),
+                ),
+            ),
+        ),
+        usage=planner_usage,
+        model="gpt-4.1",
+        provider_response_id="prop-planner",
+        finish_reason="stop",
+    )
+    tool_result = ActionExecutionResult(
+        action_id="action-1",
+        action_kind=ActionKind.GENERATE_SHOW_NOTES,
+        model_tier=ModelTier.EXECUTION,
+        model="prop-exec-model",
+        summary="prop graph synthesis",
+        usage=tool_usage,
+    )
+
+    graph = build_generation_orchestration_graph(
+        planner=PropGraphPlanner(result=planner_result),
+        tool_executor=PropGraphToolExecutor(result=tool_result),
+    )
+
+    request = GenerationOrchestrationRequest(
+        correlation_id=correlation_id,
+        script_tei_xml=(
+            "<TEI><text><body><p>Hypothesis-driven graph workload</p></body>"
+            "</text></TEI>"
+        ),
+        template_structure=None,
+    )
+    state = await graph.ainvoke(GenerationGraphState(request=request))
+    orchestration_result = state["orchestration_result"]
+    expected_total_tokens = planner_usage.total_tokens + tool_usage.total_tokens
+    assert orchestration_result.total_usage.input_tokens >= 0
+    assert orchestration_result.total_usage.output_tokens >= 0
+    assert orchestration_result.total_usage.total_tokens >= 0
+    assert orchestration_result.total_usage.total_tokens == expected_total_tokens
+    assert state["planner_result"] == planner_result
+    assert state["action_results"][0].model == "prop-exec-model"
+
+
+@given(
+    request=st.builds(
+        GenerationOrchestrationRequest,
+        correlation_id=st.text(
+            min_size=1,
+            max_size=48,
+            alphabet=string.ascii_letters + string.digits + "-",
+        ),
+        script_tei_xml=st.text(
+            min_size=1,
+            max_size=80,
+            alphabet=string.ascii_letters + string.digits + " .,_-",
+        ).map(lambda body: f"<TEI><text><body><p>{body}</p></body></text></TEI>"),
+        template_structure=st.one_of(
+            st.none(),
+            st.just({"sections": ["intro", "analysis"]}),
+        ),
+    )
+)
+@settings(max_examples=50)
+@pytest.mark.asyncio
+async def test_langgraph_respects_plan_execute_finish_order(
+    request: GenerationOrchestrationRequest,
+) -> None:
+    """Property test: valid requests always traverse plan, execute, then finish."""
+    event_recorder = GraphEventRecorder()
+    planner = PropGraphPlanner(
+        event_recorder=event_recorder,
+        result=PlannerResult(
+            plan=ExecutionPlan(
+                plan_version="1.0",
+                selected_planning_model="prop-plan-model",
+                selected_execution_model="prop-exec-model",
+                steps=(
+                    PlannedAction(
+                        action_id="action-1",
+                        action_kind=ActionKind.GENERATE_SHOW_NOTES,
+                        rationale="prop graph rationale",
+                        model_tier=ModelTier.EXECUTION,
+                        required_inputs=("script_tei_xml",),
+                    ),
+                ),
+            ),
+            usage=LLMUsage(input_tokens=1, output_tokens=1, total_tokens=2),
+            model="prop-plan-model",
+            provider_response_id="prop-planner",
+            finish_reason="stop",
+        ),
+    )
+    tool_executor = PropGraphToolExecutor(
+        ActionExecutionResult(
+            action_id="action-1",
+            action_kind=ActionKind.GENERATE_SHOW_NOTES,
+            model_tier=ModelTier.EXECUTION,
+            model="prop-exec-model",
+            summary="prop graph synthesis",
+            usage=LLMUsage(input_tokens=1, output_tokens=1, total_tokens=2),
+        ),
+        event_recorder=event_recorder,
+    )
+    graph = build_generation_orchestration_graph(
+        planner=planner,
+        tool_executor=tool_executor,
+        finish_callback=lambda _state: event_recorder.record("finish"),
+    )
+
+    state = await graph.ainvoke(GenerationGraphState(request=request))
+
+    assert event_recorder.events == ["plan", "execute", "finish"]
+    assert state["planner_result"] is not None
+    assert state["action_results"]
+    assert state["orchestration_result"] is not None
+
+
+@pytest.mark.asyncio
+async def test_langgraph_finish_callback_errors_do_not_replace_result() -> None:
+    """Finish callback failures must not discard the computed graph result."""
+    planner_result = PlannerResult(
+        plan=ExecutionPlan(
+            plan_version="1.0",
+            selected_planning_model="prop-plan-model",
+            selected_execution_model="prop-exec-model",
+            steps=(
+                PlannedAction(
+                    action_id="action-1",
+                    action_kind=ActionKind.GENERATE_SHOW_NOTES,
+                    rationale="prop graph rationale",
+                    model_tier=ModelTier.EXECUTION,
+                    required_inputs=("script_tei_xml",),
+                ),
+            ),
+        ),
+        usage=LLMUsage(input_tokens=1, output_tokens=1, total_tokens=2),
+        model="prop-plan-model",
+        provider_response_id="prop-planner",
+        finish_reason="stop",
+    )
+    tool_result = ActionExecutionResult(
+        action_id="action-1",
+        action_kind=ActionKind.GENERATE_SHOW_NOTES,
+        model_tier=ModelTier.EXECUTION,
+        model="prop-exec-model",
+        summary="prop graph synthesis",
+        usage=LLMUsage(input_tokens=1, output_tokens=1, total_tokens=2),
+    )
+
+    def _raise_callback(_state: GenerationGraphState) -> None:
+        msg = "callback failed after result computation"
+        raise RuntimeError(msg)
+
+    graph = build_generation_orchestration_graph(
+        planner=PropGraphPlanner(result=planner_result),
+        tool_executor=PropGraphToolExecutor(result=tool_result),
+        finish_callback=_raise_callback,
+    )
+    request = GenerationOrchestrationRequest(
+        correlation_id="callback-error",
+        script_tei_xml="<TEI><text><body><p>body</p></body></text></TEI>",
+    )
+
+    state = await graph.ainvoke(GenerationGraphState(request=request))
+
+    assert state["orchestration_result"] is not None
+    assert state["planner_result"] == planner_result
+    assert state["action_results"] == (tool_result,)

--- a/tests/test_orchestration_graph_invariant_properties.py
+++ b/tests/test_orchestration_graph_invariant_properties.py
@@ -226,17 +226,30 @@ async def test_langgraph_respects_plan_execute_finish_order(
     assert state["orchestration_result"] is not None
 
 
-@pytest.mark.asyncio
-async def test_finish_callback_is_invoked_in_direct_execute_path() -> None:
-    """Direct execution invokes the finish callback with finished state."""
+async def _invoke_with_callback(
+    *,
+    checkpoint_port: InMemoryCheckpointStore | None = None,
+) -> tuple[dict[str, object], list[GenerationOrchestrationResult]]:
+    """Build a graph with a recording finish_callback and invoke it once.
+
+    Returns the final graph state and the list of domain results the
+    callback received, in invocation order.
+    """
     observed_results: list[GenerationOrchestrationResult] = []
     graph = build_generation_orchestration_graph(
         planner=PropGraphPlanner(result=_planner_result()),
         tool_executor=PropGraphToolExecutor(result=_tool_result()),
+        checkpoint_port=checkpoint_port,
         finish_callback=observed_results.append,
     )
-
     state = await graph.ainvoke(GenerationGraphState(request=_request()))
+    return state, observed_results
+
+
+@pytest.mark.asyncio
+async def test_finish_callback_is_invoked_in_direct_execute_path() -> None:
+    """Direct execution invokes the finish callback with finished state."""
+    state, observed_results = await _invoke_with_callback()
 
     assert len(observed_results) == 1
     assert observed_results[0] is not None
@@ -246,15 +259,9 @@ async def test_finish_callback_is_invoked_in_direct_execute_path() -> None:
 @pytest.mark.asyncio
 async def test_finish_callback_is_not_invoked_in_suspend_path() -> None:
     """Checkpointed execution stops before the finish callback hook."""
-    observed_results: list[GenerationOrchestrationResult] = []
-    graph = build_generation_orchestration_graph(
-        planner=PropGraphPlanner(result=_planner_result()),
-        tool_executor=PropGraphToolExecutor(result=_tool_result()),
-        checkpoint_port=InMemoryCheckpointStore(),
-        finish_callback=observed_results.append,
+    state, observed_results = await _invoke_with_callback(
+        checkpoint_port=InMemoryCheckpointStore()
     )
-
-    state = await graph.ainvoke(GenerationGraphState(request=_request()))
 
     assert not observed_results
     assert isinstance(state["suspended_result"], SuspendedWorkflowResult)

--- a/tests/test_orchestration_graph_invariant_properties.py
+++ b/tests/test_orchestration_graph_invariant_properties.py
@@ -1,6 +1,7 @@
 """Property tests for LangGraph orchestration invariants."""
 
 import asyncio
+import collections
 import string
 
 import hypothesis.strategies as st
@@ -316,4 +317,6 @@ async def test_finish_callback_records_concurrent_direct_results() -> None:
 
     assert len(observed_results) == expected_invocations
     assert all(result is not None for result in observed_results)
-    assert [state["orchestration_result"] for state in states] == observed_results
+    assert collections.Counter(
+        state["orchestration_result"] for state in states
+    ) == collections.Counter(observed_results)

--- a/tests/test_orchestration_graph_invariant_properties.py
+++ b/tests/test_orchestration_graph_invariant_properties.py
@@ -13,9 +13,11 @@ from episodic.orchestration import (
     ExecutionPlan,
     GenerationGraphState,
     GenerationOrchestrationRequest,
+    InMemoryCheckpointStore,
     ModelTier,
     PlannedAction,
     PlannerResult,
+    SuspendedWorkflowResult,
     build_generation_orchestration_graph,
 )
 from tests._orchestration_property_support import (
@@ -25,6 +27,50 @@ from tests._orchestration_property_support import (
     PropTokenInputs,
     token_inputs_strategy,
 )
+
+
+def _planner_result() -> PlannerResult:
+    """Build a minimal planner result for graph callback probes."""
+    return PlannerResult(
+        plan=ExecutionPlan(
+            plan_version="1.0",
+            selected_planning_model="prop-plan-model",
+            selected_execution_model="prop-exec-model",
+            steps=(
+                PlannedAction(
+                    action_id="action-1",
+                    action_kind=ActionKind.GENERATE_SHOW_NOTES,
+                    rationale="prop graph rationale",
+                    model_tier=ModelTier.EXECUTION,
+                    required_inputs=("script_tei_xml",),
+                ),
+            ),
+        ),
+        usage=LLMUsage(input_tokens=1, output_tokens=1, total_tokens=2),
+        model="prop-plan-model",
+        provider_response_id="prop-planner",
+        finish_reason="stop",
+    )
+
+
+def _tool_result() -> ActionExecutionResult:
+    """Build a minimal action result for graph callback probes."""
+    return ActionExecutionResult(
+        action_id="action-1",
+        action_kind=ActionKind.GENERATE_SHOW_NOTES,
+        model_tier=ModelTier.EXECUTION,
+        model="prop-exec-model",
+        summary="prop graph synthesis",
+        usage=LLMUsage(input_tokens=1, output_tokens=1, total_tokens=2),
+    )
+
+
+def _request(correlation_id: str = "callback-probe") -> GenerationOrchestrationRequest:
+    """Build a minimal generation request for graph callback probes."""
+    return GenerationOrchestrationRequest(
+        correlation_id=correlation_id,
+        script_tei_xml="<TEI><text><body><p>body</p></body></text></TEI>",
+    )
 
 
 @given(
@@ -180,53 +226,53 @@ async def test_langgraph_respects_plan_execute_finish_order(
 
 
 @pytest.mark.asyncio
-async def test_langgraph_finish_callback_errors_do_not_replace_result() -> None:
-    """Finish callback failures must not discard the computed graph result."""
-    planner_result = PlannerResult(
-        plan=ExecutionPlan(
-            plan_version="1.0",
-            selected_planning_model="prop-plan-model",
-            selected_execution_model="prop-exec-model",
-            steps=(
-                PlannedAction(
-                    action_id="action-1",
-                    action_kind=ActionKind.GENERATE_SHOW_NOTES,
-                    rationale="prop graph rationale",
-                    model_tier=ModelTier.EXECUTION,
-                    required_inputs=("script_tei_xml",),
-                ),
-            ),
-        ),
-        usage=LLMUsage(input_tokens=1, output_tokens=1, total_tokens=2),
-        model="prop-plan-model",
-        provider_response_id="prop-planner",
-        finish_reason="stop",
+async def test_finish_callback_is_invoked_in_direct_execute_path() -> None:
+    """Direct execution invokes the finish callback with finished state."""
+    observed_states: list[GenerationGraphState] = []
+    graph = build_generation_orchestration_graph(
+        planner=PropGraphPlanner(result=_planner_result()),
+        tool_executor=PropGraphToolExecutor(result=_tool_result()),
+        finish_callback=observed_states.append,
     )
-    tool_result = ActionExecutionResult(
-        action_id="action-1",
-        action_kind=ActionKind.GENERATE_SHOW_NOTES,
-        model_tier=ModelTier.EXECUTION,
-        model="prop-exec-model",
-        summary="prop graph synthesis",
-        usage=LLMUsage(input_tokens=1, output_tokens=1, total_tokens=2),
+
+    state = await graph.ainvoke(GenerationGraphState(request=_request()))
+
+    assert len(observed_states) == 1
+    assert observed_states[0].orchestration_result is not None
+    assert state["orchestration_result"] == observed_states[0].orchestration_result
+
+
+@pytest.mark.asyncio
+async def test_finish_callback_is_not_invoked_in_suspend_path() -> None:
+    """Checkpointed execution stops before the finish callback hook."""
+    observed_states: list[GenerationGraphState] = []
+    graph = build_generation_orchestration_graph(
+        planner=PropGraphPlanner(result=_planner_result()),
+        tool_executor=PropGraphToolExecutor(result=_tool_result()),
+        checkpoint_port=InMemoryCheckpointStore(),
+        finish_callback=observed_states.append,
     )
+
+    state = await graph.ainvoke(GenerationGraphState(request=_request()))
+
+    assert not observed_states
+    assert isinstance(state["suspended_result"], SuspendedWorkflowResult)
+    assert state["orchestration_result"] is None
+
+
+@pytest.mark.asyncio
+async def test_langgraph_finish_callback_errors_are_logged_and_propagated() -> None:
+    """Finish callback failures propagate after callback error logging."""
 
     def _raise_callback(_state: GenerationGraphState) -> None:
         msg = "callback failed after result computation"
         raise RuntimeError(msg)
 
     graph = build_generation_orchestration_graph(
-        planner=PropGraphPlanner(result=planner_result),
-        tool_executor=PropGraphToolExecutor(result=tool_result),
+        planner=PropGraphPlanner(result=_planner_result()),
+        tool_executor=PropGraphToolExecutor(result=_tool_result()),
         finish_callback=_raise_callback,
     )
-    request = GenerationOrchestrationRequest(
-        correlation_id="callback-error",
-        script_tei_xml="<TEI><text><body><p>body</p></body></text></TEI>",
-    )
 
-    state = await graph.ainvoke(GenerationGraphState(request=request))
-
-    assert state["orchestration_result"] is not None
-    assert state["planner_result"] == planner_result
-    assert state["action_results"] == (tool_result,)
+    with pytest.raises(RuntimeError, match="callback failed after result computation"):
+        await graph.ainvoke(GenerationGraphState(request=_request("callback-error")))

--- a/tests/test_orchestration_graph_invariant_properties.py
+++ b/tests/test_orchestration_graph_invariant_properties.py
@@ -13,6 +13,7 @@ from episodic.orchestration import (
     ExecutionPlan,
     GenerationGraphState,
     GenerationOrchestrationRequest,
+    GenerationOrchestrationResult,
     InMemoryCheckpointStore,
     ModelTier,
     PlannedAction,
@@ -228,34 +229,34 @@ async def test_langgraph_respects_plan_execute_finish_order(
 @pytest.mark.asyncio
 async def test_finish_callback_is_invoked_in_direct_execute_path() -> None:
     """Direct execution invokes the finish callback with finished state."""
-    observed_states: list[GenerationGraphState] = []
+    observed_results: list[GenerationOrchestrationResult] = []
     graph = build_generation_orchestration_graph(
         planner=PropGraphPlanner(result=_planner_result()),
         tool_executor=PropGraphToolExecutor(result=_tool_result()),
-        finish_callback=observed_states.append,
+        finish_callback=observed_results.append,
     )
 
     state = await graph.ainvoke(GenerationGraphState(request=_request()))
 
-    assert len(observed_states) == 1
-    assert observed_states[0].orchestration_result is not None
-    assert state["orchestration_result"] == observed_states[0].orchestration_result
+    assert len(observed_results) == 1
+    assert observed_results[0] is not None
+    assert state["orchestration_result"] == observed_results[0]
 
 
 @pytest.mark.asyncio
 async def test_finish_callback_is_not_invoked_in_suspend_path() -> None:
     """Checkpointed execution stops before the finish callback hook."""
-    observed_states: list[GenerationGraphState] = []
+    observed_results: list[GenerationOrchestrationResult] = []
     graph = build_generation_orchestration_graph(
         planner=PropGraphPlanner(result=_planner_result()),
         tool_executor=PropGraphToolExecutor(result=_tool_result()),
         checkpoint_port=InMemoryCheckpointStore(),
-        finish_callback=observed_states.append,
+        finish_callback=observed_results.append,
     )
 
     state = await graph.ainvoke(GenerationGraphState(request=_request()))
 
-    assert not observed_states
+    assert not observed_results
     assert isinstance(state["suspended_result"], SuspendedWorkflowResult)
     assert state["orchestration_result"] is None
 
@@ -266,7 +267,7 @@ async def test_langgraph_finish_callback_errors_do_not_replace_result() -> None:
     planner_result = _planner_result()
     tool_result = _tool_result()
 
-    def _raise_callback(_state: GenerationGraphState) -> None:
+    def _raise_callback(_result: GenerationOrchestrationResult) -> None:
         msg = "callback failed after result computation"
         raise RuntimeError(msg)
 

--- a/tests/test_orchestration_graph_invariant_properties.py
+++ b/tests/test_orchestration_graph_invariant_properties.py
@@ -261,18 +261,25 @@ async def test_finish_callback_is_not_invoked_in_suspend_path() -> None:
 
 
 @pytest.mark.asyncio
-async def test_langgraph_finish_callback_errors_are_logged_and_propagated() -> None:
-    """Finish callback failures propagate after callback error logging."""
+async def test_langgraph_finish_callback_errors_do_not_replace_result() -> None:
+    """Finish callback failures do not discard the computed graph result."""
+    planner_result = _planner_result()
+    tool_result = _tool_result()
 
     def _raise_callback(_state: GenerationGraphState) -> None:
         msg = "callback failed after result computation"
         raise RuntimeError(msg)
 
     graph = build_generation_orchestration_graph(
-        planner=PropGraphPlanner(result=_planner_result()),
-        tool_executor=PropGraphToolExecutor(result=_tool_result()),
+        planner=PropGraphPlanner(result=planner_result),
+        tool_executor=PropGraphToolExecutor(result=tool_result),
         finish_callback=_raise_callback,
     )
 
-    with pytest.raises(RuntimeError, match="callback failed after result computation"):
-        await graph.ainvoke(GenerationGraphState(request=_request("callback-error")))
+    state = await graph.ainvoke(
+        GenerationGraphState(request=_request("callback-error"))
+    )
+
+    assert state["orchestration_result"] is not None
+    assert state["planner_result"] == planner_result
+    assert state["action_results"] == (tool_result,)

--- a/tests/test_orchestration_langgraph_properties.py
+++ b/tests/test_orchestration_langgraph_properties.py
@@ -19,16 +19,16 @@ from episodic.orchestration import (
     PlannerResult,
     build_generation_orchestration_graph,
 )
-from tests.test_orchestration_properties import (
-    _PropGraphPlanner,
-    _PropGraphToolExecutor,
-    _PropTokenInputs,
-    _token_inputs_strategy,
+from tests._orchestration_property_support import (
+    PropGraphPlanner,
+    PropGraphToolExecutor,
+    PropTokenInputs,
+    token_inputs_strategy,
 )
 
 
 def _build_planner_and_action(
-    tokens: _PropTokenInputs,
+    tokens: PropTokenInputs,
     correlation_id: str,
 ) -> tuple[PlannerResult, list[ActionExecutionResult]]:
     """Build graph planner and action results for one token-input example."""
@@ -81,8 +81,8 @@ async def _run_graph_and_collect(
 ) -> GenerationOrchestrationResult:
     """Run the graph and return its orchestration result."""
     graph = build_generation_orchestration_graph(
-        planner=_PropGraphPlanner(result=planner_result),
-        tool_executor=_PropGraphToolExecutor(result=actions[0]),
+        planner=PropGraphPlanner(result=planner_result),
+        tool_executor=PropGraphToolExecutor(result=actions[0]),
     )
     request = GenerationOrchestrationRequest(
         correlation_id=correlation_id,
@@ -114,7 +114,7 @@ def _assert_usage_rollup(
 
 
 @given(
-    tokens=_token_inputs_strategy,
+    tokens=token_inputs_strategy,
     correlation_id=st.text(
         min_size=1,
         max_size=48,
@@ -124,7 +124,7 @@ def _assert_usage_rollup(
 @settings(max_examples=50)
 @pytest.mark.asyncio
 async def test_langgraph_total_tokens_non_negative(
-    tokens: _PropTokenInputs,
+    tokens: PropTokenInputs,
     correlation_id: str,
 ) -> None:
     """Property test: LangGraph rollups keep total token counts semiring-safe."""

--- a/tests/test_orchestration_planner_format_properties.py
+++ b/tests/test_orchestration_planner_format_properties.py
@@ -24,65 +24,69 @@ from tests._orchestration_property_support import (
 )
 
 
-@given(
-    noise=st.one_of(
-        st.integers(),
-        st.floats(allow_nan=False, allow_infinity=False),
-        st.lists(st.text(max_size=512), max_size=10),
-        st.text(max_size=512),
-    )
-)
-@settings(max_examples=50)
-@pytest.mark.asyncio
-async def test_planning_response_format_error_for_arbitrary_non_object_json(
-    noise: object,
-) -> None:
-    """Property test: non-object JSON bodies fail strict planner validation."""
-    blob = json.dumps(noise)
+class TestStructuredGenerationPlannerFormatProperties:
+    """Property tests for structured generation planner format validation."""
 
-    response = LLMResponse(
-        text=blob,
-        model="gpt-4.1",
-        provider_response_id="hyp-planner-response",
-        finish_reason="stop",
-        usage=_usage(input_tokens=1, output_tokens=1),
+    @given(
+        noise=st.one_of(
+            st.integers(),
+            st.floats(allow_nan=False, allow_infinity=False),
+            st.lists(st.text(max_size=512), max_size=10),
+            st.text(max_size=512),
+        )
     )
-    planner = StructuredGenerationPlanner(
-        llm=_FakeLLMPort([response]),
-        config=_config(),
-    )
-    request = GenerationOrchestrationRequest(
-        correlation_id="hyp-corr",
-        script_tei_xml="<TEI><body><p>noise</p></body></TEI>",
-    )
-    with pytest.raises(
-        PlanningResponseFormatError,
-        match=r"planner response must be an object",
-    ):
-        await planner.plan(request)
+    @settings(max_examples=50)
+    @pytest.mark.asyncio
+    async def test_planning_response_format_error_for_arbitrary_non_object_json(
+        self,
+        noise: object,
+    ) -> None:
+        """Property test: non-object JSON bodies fail strict planner validation."""
+        blob = json.dumps(noise)
 
+        response = LLMResponse(
+            text=blob,
+            model="gpt-4.1",
+            provider_response_id="hyp-planner-response",
+            finish_reason="stop",
+            usage=_usage(input_tokens=1, output_tokens=1),
+        )
+        planner = StructuredGenerationPlanner(
+            llm=_FakeLLMPort([response]),
+            config=_config(),
+        )
+        request = GenerationOrchestrationRequest(
+            correlation_id="hyp-corr",
+            script_tei_xml="<TEI><body><p>noise</p></body></TEI>",
+        )
+        with pytest.raises(
+            PlanningResponseFormatError,
+            match=r"planner response must be an object",
+        ):
+            await planner.plan(request)
 
-@given(payload=invalid_plan_payloads)
-@settings(max_examples=100)
-@pytest.mark.asyncio
-async def test_planning_response_format_error_for_invalid_plan_objects(
-    payload: str,
-) -> None:
-    """Property test: structurally invalid plan objects preserve format errors."""
-    response = LLMResponse(
-        text=payload,
-        model="gpt-4.1",
-        provider_response_id="hyp-invalid-plan-response",
-        finish_reason="stop",
-        usage=_usage(input_tokens=1, output_tokens=1),
-    )
-    planner = StructuredGenerationPlanner(
-        llm=_FakeLLMPort([response]),
-        config=_config(),
-    )
+    @given(payload=invalid_plan_payloads)
+    @settings(max_examples=100)
+    @pytest.mark.asyncio
+    async def test_planning_response_format_error_for_invalid_plan_objects(
+        self,
+        payload: str,
+    ) -> None:
+        """Property test: structurally invalid plan objects preserve format errors."""
+        response = LLMResponse(
+            text=payload,
+            model="gpt-4.1",
+            provider_response_id="hyp-invalid-plan-response",
+            finish_reason="stop",
+            usage=_usage(input_tokens=1, output_tokens=1),
+        )
+        planner = StructuredGenerationPlanner(
+            llm=_FakeLLMPort([response]),
+            config=_config(),
+        )
 
-    with pytest.raises(
-        PlanningResponseFormatError,
-        match=PLANNER_FORMAT_ERROR_PATTERN,
-    ):
-        await planner.plan(_request())
+        with pytest.raises(
+            PlanningResponseFormatError,
+            match=PLANNER_FORMAT_ERROR_PATTERN,
+        ):
+            await planner.plan(_request())

--- a/tests/test_orchestration_planner_format_properties.py
+++ b/tests/test_orchestration_planner_format_properties.py
@@ -1,0 +1,88 @@
+"""Property tests for planner response format errors."""
+
+import json
+
+import hypothesis.strategies as st
+import pytest
+from hypothesis import given, settings
+
+from episodic.llm import LLMResponse
+from episodic.orchestration import (
+    GenerationOrchestrationRequest,
+    PlanningResponseFormatError,
+    StructuredGenerationPlanner,
+)
+from tests._orchestration_fakes import (
+    _config,
+    _FakeLLMPort,
+    _request,
+    _usage,
+)
+from tests._orchestration_property_support import (
+    PLANNER_FORMAT_ERROR_PATTERN,
+    invalid_plan_payloads,
+)
+
+
+@given(
+    noise=st.one_of(
+        st.integers(),
+        st.floats(allow_nan=False, allow_infinity=False),
+        st.lists(st.text(max_size=512), max_size=10),
+        st.text(max_size=512),
+    )
+)
+@settings(max_examples=50)
+@pytest.mark.asyncio
+async def test_planning_response_format_error_for_arbitrary_non_object_json(
+    noise: object,
+) -> None:
+    """Property test: non-object JSON bodies fail strict planner validation."""
+    blob = json.dumps(noise)
+
+    response = LLMResponse(
+        text=blob,
+        model="gpt-4.1",
+        provider_response_id="hyp-planner-response",
+        finish_reason="stop",
+        usage=_usage(input_tokens=1, output_tokens=1),
+    )
+    planner = StructuredGenerationPlanner(
+        llm=_FakeLLMPort([response]),
+        config=_config(),
+    )
+    request = GenerationOrchestrationRequest(
+        correlation_id="hyp-corr",
+        script_tei_xml="<TEI><body><p>noise</p></body></TEI>",
+    )
+    with pytest.raises(
+        PlanningResponseFormatError,
+        match=r"planner response must be an object",
+    ):
+        await planner.plan(request)
+
+
+@given(payload=invalid_plan_payloads)
+@settings(max_examples=100)
+@pytest.mark.asyncio
+async def test_planning_response_format_error_for_invalid_plan_objects(
+    payload: str,
+) -> None:
+    """Property test: structurally invalid plan objects preserve format errors."""
+    response = LLMResponse(
+        text=payload,
+        model="gpt-4.1",
+        provider_response_id="hyp-invalid-plan-response",
+        finish_reason="stop",
+        usage=_usage(input_tokens=1, output_tokens=1),
+    )
+    planner = StructuredGenerationPlanner(
+        llm=_FakeLLMPort([response]),
+        config=_config(),
+    )
+
+    with pytest.raises(
+        PlanningResponseFormatError,
+        match=PLANNER_FORMAT_ERROR_PATTERN,
+    ):
+        await planner.plan(_request())

--- a/tests/test_orchestration_properties.py
+++ b/tests/test_orchestration_properties.py
@@ -468,10 +468,12 @@ def test_config_rejects_arbitrary_unknown_action_kind_strings(unknown: str) -> N
         )
 
 
-@pytest.mark.parametrize(
-    "model_tier",
-    [tier for tier in ModelTier if tier is not ModelTier.EXECUTION],
+@given(
+    model_tier=st.sampled_from([
+        tier for tier in ModelTier if tier is not ModelTier.EXECUTION
+    ])
 )
+@settings(max_examples=10)
 @pytest.mark.asyncio
 async def test_planned_action_model_tier_rejection_for_all_non_execution_tiers(
     model_tier: ModelTier,

--- a/tests/test_orchestration_properties.py
+++ b/tests/test_orchestration_properties.py
@@ -311,7 +311,25 @@ _unknown_model_tier_values = st.one_of(
 
 _invalid_required_inputs_values = st.one_of(
     st.integers(),
-    st.lists(st.one_of(st.none(), st.integers(), st.just("")), min_size=1),
+    st.lists(
+        st.one_of(st.none(), st.integers(), st.just("")),
+        min_size=1,
+        max_size=10,
+    ),
+)
+
+_PLANNER_FORMAT_ERROR_PATTERN = (
+    r"plan_version must be a non-empty string"
+    r"|steps must be a list"
+    r"|step must be an object"
+    r"|action_id must be a non-empty string"
+    r"|action_kind must be a non-empty string"
+    r"|action_kind must be one of: generate_show_notes"
+    r"|rationale must be a non-empty string"
+    r"|model_tier must be a non-empty string"
+    r"|model_tier must be one of: planning, execution"
+    r"|required_inputs must be a list of strings"
+    r"|required_inputs must contain only non-empty strings"
 )
 
 _invalid_plan_payloads = st.one_of(
@@ -552,7 +570,10 @@ async def test_planning_response_format_error_for_invalid_plan_objects(
         config=_config(),
     )
 
-    with pytest.raises(PlanningResponseFormatError):
+    with pytest.raises(
+        PlanningResponseFormatError,
+        match=_PLANNER_FORMAT_ERROR_PATTERN,
+    ):
         await planner.plan(_request())
 
 
@@ -697,10 +718,10 @@ async def test_langgraph_respects_plan_execute_finish_order(
     graph = build_generation_orchestration_graph(
         planner=planner,
         tool_executor=tool_executor,
+        finish_callback=lambda _state: event_recorder.record("finish"),
     )
 
     state = await graph.ainvoke(GenerationGraphState(request=request))
-    event_recorder.record("finish")
 
     assert event_recorder.events == ["plan", "execute", "finish"]
     assert state["planner_result"] is not None

--- a/tests/test_orchestration_properties.py
+++ b/tests/test_orchestration_properties.py
@@ -1,13 +1,24 @@
-"""Hypothesis property-based tests for orchestration invariants."""
+"""Hypothesis property-based tests for orchestration invariants.
+
+Issue #72 called out that the PR #69 orchestration suite had strong
+deterministic unit coverage but lacked generative exploration of boundary
+inputs. This module complements `test_orchestration_dto_validation.py`,
+`test_orchestration_planner.py`, `test_show_notes_executor.py`, and
+`test_generation_orchestration_langgraph.py` with property tests for enum
+normalisation, model-tier validation, planner JSON error preservation, and the
+LangGraph plan-execute-finish ordering contract.
+"""
 
 import dataclasses as dc
 import json
 import string
+import typing as typ
 
 import hypothesis.strategies as st
 import pytest
 from hypothesis import given, settings
 
+from episodic.generation import ShowNotesResult
 from episodic.llm import (
     LLMProviderOperation,
     LLMResponse,
@@ -17,6 +28,7 @@ from episodic.orchestration import (
     ActionExecutionResult,
     ActionKind,
     ExecutionPlan,
+    GenerationGraphState,
     GenerationOrchestrationConfig,
     GenerationOrchestrationRequest,
     ModelTier,
@@ -27,6 +39,7 @@ from episodic.orchestration import (
     StructuredGenerationPlanner,
     UnsupportedActionError,
     WorkflowStepIdentity,
+    build_generation_orchestration_graph,
     build_workflow_step_idempotency_key,
 )
 from episodic.orchestration.langgraph import (
@@ -50,36 +63,86 @@ _ACTION_KIND_SAMPLES: tuple[ActionKind | str, ...] = tuple(ActionKind) + tuple(
 _KNOWN_ACTION_KIND_STRINGS = {m.value for m in ActionKind}
 
 
+@dc.dataclass(slots=True)
+class _GraphEventRecorder:
+    """Collect explicitly injected graph-node events for ordering assertions."""
+
+    events: list[str] = dc.field(default_factory=list)
+
+    def record(self, event: str) -> None:
+        """Append one observed graph-node event."""
+        self.events.append(event)
+
+
 class _PropGraphPlanner:
     """Emit canned planner payloads for Hypothesis graph probes."""
 
-    def __init__(self, *, result: PlannerResult) -> None:
+    def __init__(
+        self,
+        *,
+        result: PlannerResult,
+        event_recorder: _GraphEventRecorder | None = None,
+    ) -> None:
         self._result = result
+        self._event_recorder = event_recorder
 
     async def plan(self, request: GenerationOrchestrationRequest) -> PlannerResult:
+        """Record the plan node when requested and return the canned result."""
         assert request.script_tei_xml.startswith("<TEI>"), (
             f"expected TEI input, got {request.script_tei_xml!r}"
         )
         assert request.correlation_id, "expected non-empty correlation_id"
+        if self._event_recorder is not None:
+            self._event_recorder.record("plan")
         return self._result
 
 
 class _PropGraphToolExecutor:
     """Emit canned tool payloads for Hypothesis graph probes."""
 
-    def __init__(self, result: ActionExecutionResult) -> None:
+    def __init__(
+        self,
+        result: ActionExecutionResult,
+        *,
+        event_recorder: _GraphEventRecorder | None = None,
+    ) -> None:
         self._result = result
+        self._event_recorder = event_recorder
 
     async def execute(
         self,
         action: PlannedAction,
         context: GenerationOrchestrationRequest,
     ) -> ActionExecutionResult:
+        """Record the execute node when requested and return the canned result."""
         assert context.script_tei_xml.startswith("<TEI>"), (
             f"expected TEI input, got {context.script_tei_xml!r}"
         )
         assert action.action_kind is ActionKind.GENERATE_SHOW_NOTES
+        if self._event_recorder is not None:
+            self._event_recorder.record("execute")
         return self._result
+
+
+class _PropShowNotesGenerator:
+    """Return an empty show-notes result for model-tier boundary probes."""
+
+    async def generate(
+        self,
+        script_tei_xml: str,
+        *,
+        template_structure: dict[str, object] | None = None,
+    ) -> ShowNotesResult:
+        """Return a minimal structured show-notes result."""
+        assert script_tei_xml.startswith("<TEI>")
+        assert template_structure is not None
+        return ShowNotesResult(
+            entries=(),
+            usage=LLMUsage(input_tokens=1, output_tokens=0, total_tokens=1),
+            model="prop-exec-model",
+            provider_response_id="prop-exec-response",
+            finish_reason="stop",
+        )
 
 
 @dc.dataclass(frozen=True, slots=True)
@@ -185,6 +248,101 @@ _action_result_strategy = st.builds(
 )
 
 
+def _valid_plan_object() -> dict[str, object]:
+    """Return one valid raw planner object suitable for targeted corruption."""
+    return {
+        "plan_version": "1.0",
+        "steps": [
+            {
+                "action_id": "action-1",
+                "action_kind": ActionKind.GENERATE_SHOW_NOTES.value,
+                "rationale": "Generate publication-ready show notes.",
+                "model_tier": ModelTier.EXECUTION.value,
+                "required_inputs": ["script_tei_xml", "template_structure"],
+            }
+        ],
+    }
+
+
+def _invalid_plan_without_plan_version() -> str:
+    """Return JSON for a plan object with the required version field omitted."""
+    payload = _valid_plan_object()
+    payload = {key: value for key, value in payload.items() if key != "plan_version"}
+    return json.dumps(payload)
+
+
+def _invalid_plan_with_top_level_field(field_name: str, value: object) -> str:
+    """Return JSON for a plan object with one top-level field replaced."""
+    return json.dumps(_valid_plan_object() | {field_name: value})
+
+
+def _invalid_plan_with_step_field(field_name: str, value: object) -> str:
+    """Return JSON for a plan object with one first-step field replaced."""
+    step = typ.cast("list[dict[str, object]]", _valid_plan_object()["steps"])[0]
+    return json.dumps(_valid_plan_object() | {"steps": [step | {field_name: value}]})
+
+
+def _invalid_plan_without_step_field(field_name: str) -> str:
+    """Return JSON for a plan object with one required first-step field omitted."""
+    step = typ.cast("list[dict[str, object]]", _valid_plan_object()["steps"])[0]
+    narrowed_step = {key: value for key, value in step.items() if key != field_name}
+    return json.dumps(_valid_plan_object() | {"steps": [narrowed_step]})
+
+
+_unknown_action_kind_values = st.one_of(
+    st.none(),
+    st.integers(),
+    st.text(min_size=1, max_size=512).filter(
+        lambda value: value.strip() not in {kind.value for kind in ActionKind}
+    ),
+)
+
+_unknown_model_tier_values = st.one_of(
+    st.none(),
+    st.integers(),
+    st.text(min_size=1, max_size=512).filter(
+        lambda value: value.strip() not in {tier.value for tier in ModelTier}
+    ),
+)
+
+_invalid_required_inputs_values = st.one_of(
+    st.integers(),
+    st.lists(st.one_of(st.none(), st.integers(), st.just("")), min_size=1),
+)
+
+_invalid_plan_payloads = st.one_of(
+    st.just(_invalid_plan_without_plan_version()),
+    st.sampled_from(("", " ", "\t")).map(
+        lambda value: _invalid_plan_with_top_level_field("plan_version", value)
+    ),
+    st.one_of(
+        st.none(),
+        st.integers(),
+        st.text(max_size=512),
+        st.dictionaries(st.text(min_size=1, max_size=4), st.integers(), max_size=2),
+    ).map(lambda value: _invalid_plan_with_top_level_field("steps", value)),
+    st.one_of(st.none(), st.integers(), st.text(max_size=512)).map(
+        lambda value: _invalid_plan_with_top_level_field("steps", [value])
+    ),
+    st.just(_invalid_plan_without_step_field("action_id")),
+    st.sampled_from(("", " ", "\n")).map(
+        lambda value: _invalid_plan_with_step_field("action_id", value)
+    ),
+    _unknown_action_kind_values.map(
+        lambda value: _invalid_plan_with_step_field("action_kind", value)
+    ),
+    st.sampled_from(("", " ", "\r\n")).map(
+        lambda value: _invalid_plan_with_step_field("rationale", value)
+    ),
+    _unknown_model_tier_values.map(
+        lambda value: _invalid_plan_with_step_field("model_tier", value)
+    ),
+    _invalid_required_inputs_values.map(
+        lambda value: _invalid_plan_with_step_field("required_inputs", value)
+    ),
+)
+
+
 def test_step_idempotency_key_negative_attempt_raises_value_error() -> None:
     """Negative attempts should be rejected before building a step key."""
     step = WorkflowStepIdentity(
@@ -267,10 +425,11 @@ def test_config_normalises_arbitrary_string_and_enum_mixes(
         enabled_action_kinds=tuple(kinds),
     )
     assert all(isinstance(kind, ActionKind) for kind in cfg.enabled_action_kinds)
+    assert cfg.enabled_action_kinds == tuple(ActionKind(str(kind)) for kind in kinds)
 
 
 @given(
-    unknown=st.text(min_size=1).filter(
+    unknown=st.text(min_size=1, max_size=512).filter(
         lambda s: bool(s.strip()) and s.strip() not in _KNOWN_ACTION_KIND_STRINGS
     )
 )
@@ -287,13 +446,15 @@ def test_config_rejects_arbitrary_unknown_action_kind_strings(unknown: str) -> N
         )
 
 
-@given(model_tier=st.sampled_from([t for t in ModelTier if t != ModelTier.EXECUTION]))
-@settings(max_examples=len(ModelTier))
+@pytest.mark.parametrize(
+    "model_tier",
+    [tier for tier in ModelTier if tier is not ModelTier.EXECUTION],
+)
 @pytest.mark.asyncio
 async def test_planned_action_model_tier_rejection_for_all_non_execution_tiers(
     model_tier: ModelTier,
 ) -> None:
-    """Property test: planner tiers besides execution never reach show-notes tool."""
+    """Every planner tier besides execution must be rejected by show-notes."""
     fake_llm = _FakeLLMPort([])
     tool_executor = ShowNotesToolExecutor(llm=fake_llm, config=_config())
     planning_tier_action = PlannedAction(
@@ -307,12 +468,35 @@ async def test_planned_action_model_tier_rejection_for_all_non_execution_tiers(
         await tool_executor.execute(planning_tier_action, _request())
 
 
+@pytest.mark.asyncio
+async def test_planned_action_execution_model_tier_is_accepted() -> None:
+    """Boundary check: execution-tier actions are eligible for show-notes tooling."""
+    fake_llm = _FakeLLMPort([])
+    tool_executor = ShowNotesToolExecutor(
+        llm=fake_llm,
+        config=_config(),
+        generator=_PropShowNotesGenerator(),
+    )
+    action = PlannedAction(
+        action_id="action-1",
+        action_kind=ActionKind.GENERATE_SHOW_NOTES,
+        rationale="Hypothesis boundary check for execution tier.",
+        model_tier=ModelTier.EXECUTION,
+        required_inputs=("script_tei_xml",),
+    )
+
+    result = await tool_executor.execute(action, _request())
+
+    assert result.model_tier is ModelTier.EXECUTION
+    assert result.summary == "Generated 0 show-notes entries."
+
+
 @given(
     noise=st.one_of(
         st.integers(),
         st.floats(allow_nan=False, allow_infinity=False),
-        st.lists(st.text()),
-        st.text(),
+        st.lists(st.text(max_size=512), max_size=10),
+        st.text(max_size=512),
     )
 )
 @settings(max_examples=50)
@@ -343,3 +527,178 @@ async def test_planning_response_format_error_for_arbitrary_non_object_json(
         match=r"planner response must be an object",
     ):
         await planner.plan(request)
+
+
+@given(payload=_invalid_plan_payloads)
+@settings(max_examples=100)
+@pytest.mark.asyncio
+async def test_planning_response_format_error_for_invalid_plan_objects(
+    payload: str,
+) -> None:
+    """Property test: structurally invalid plan objects preserve format errors."""
+    response = LLMResponse(
+        text=payload,
+        model="gpt-4.1",
+        provider_response_id="hyp-invalid-plan-response",
+        finish_reason="stop",
+        usage=_usage(input_tokens=1, output_tokens=1),
+    )
+    planner = StructuredGenerationPlanner(
+        llm=_FakeLLMPort([response]),
+        config=_config(),
+    )
+
+    with pytest.raises(PlanningResponseFormatError):
+        await planner.plan(_request())
+
+
+@given(
+    tokens=_token_inputs_strategy,
+    correlation_id=st.text(
+        min_size=1,
+        max_size=48,
+        alphabet=string.ascii_letters + string.digits + "-",
+    ),
+)
+@settings(max_examples=50)
+@pytest.mark.asyncio
+async def test_langgraph_total_tokens_non_negative(
+    tokens: _PropTokenInputs,
+    correlation_id: str,
+) -> None:
+    """Property test: LangGraph rollups keep total token counts semiring-safe."""
+    planner_usage = LLMUsage(
+        tokens.planner_input,
+        tokens.planner_output,
+        tokens.planner_input + tokens.planner_output,
+    )
+    tool_usage = LLMUsage(
+        tokens.action_input,
+        tokens.action_output,
+        tokens.action_input + tokens.action_output,
+    )
+    planner_result = PlannerResult(
+        plan=ExecutionPlan(
+            plan_version="1.0",
+            selected_planning_model="prop-plan-model",
+            selected_execution_model="prop-exec-model",
+            steps=(
+                PlannedAction(
+                    action_id="action-1",
+                    action_kind=ActionKind.GENERATE_SHOW_NOTES,
+                    rationale="prop graph rationale",
+                    model_tier=ModelTier.EXECUTION,
+                    required_inputs=("script_tei_xml",),
+                ),
+            ),
+        ),
+        usage=planner_usage,
+        model="gpt-4.1",
+        provider_response_id="prop-planner",
+        finish_reason="stop",
+    )
+    tool_result = ActionExecutionResult(
+        action_id="action-1",
+        action_kind=ActionKind.GENERATE_SHOW_NOTES,
+        model_tier=ModelTier.EXECUTION,
+        model="prop-exec-model",
+        summary="prop graph synthesis",
+        usage=tool_usage,
+    )
+
+    graph = build_generation_orchestration_graph(
+        planner=_PropGraphPlanner(result=planner_result),
+        tool_executor=_PropGraphToolExecutor(result=tool_result),
+    )
+
+    request = GenerationOrchestrationRequest(
+        correlation_id=correlation_id,
+        script_tei_xml=(
+            "<TEI><text><body><p>Hypothesis-driven graph workload</p></body>"
+            "</text></TEI>"
+        ),
+        template_structure=None,
+    )
+    state = await graph.ainvoke(GenerationGraphState(request=request))
+    orchestration_result = state["orchestration_result"]
+    expected_total_tokens = planner_usage.total_tokens + tool_usage.total_tokens
+    assert orchestration_result.total_usage.input_tokens >= 0
+    assert orchestration_result.total_usage.output_tokens >= 0
+    assert orchestration_result.total_usage.total_tokens >= 0
+    assert orchestration_result.total_usage.total_tokens == expected_total_tokens
+    assert state["planner_result"] == planner_result
+    assert state["action_results"][0].model == "prop-exec-model"
+
+
+@given(
+    request=st.builds(
+        GenerationOrchestrationRequest,
+        correlation_id=st.text(
+            min_size=1,
+            max_size=48,
+            alphabet=string.ascii_letters + string.digits + "-",
+        ),
+        script_tei_xml=st.text(
+            min_size=1,
+            max_size=80,
+            alphabet=string.ascii_letters + string.digits + " .,_-",
+        ).map(lambda body: f"<TEI><text><body><p>{body}</p></body></text></TEI>"),
+        template_structure=st.one_of(
+            st.none(),
+            st.just({"sections": ["intro", "analysis"]}),
+        ),
+    )
+)
+@settings(max_examples=50)
+@pytest.mark.asyncio
+async def test_langgraph_respects_plan_execute_finish_order(
+    request: GenerationOrchestrationRequest,
+) -> None:
+    """Property test: valid requests always traverse plan, execute, then finish."""
+    event_recorder = _GraphEventRecorder()
+    planner = _PropGraphPlanner(
+        event_recorder=event_recorder,
+        result=PlannerResult(
+            plan=ExecutionPlan(
+                plan_version="1.0",
+                selected_planning_model="prop-plan-model",
+                selected_execution_model="prop-exec-model",
+                steps=(
+                    PlannedAction(
+                        action_id="action-1",
+                        action_kind=ActionKind.GENERATE_SHOW_NOTES,
+                        rationale="prop graph rationale",
+                        model_tier=ModelTier.EXECUTION,
+                        required_inputs=("script_tei_xml",),
+                    ),
+                ),
+            ),
+            usage=LLMUsage(input_tokens=1, output_tokens=1, total_tokens=2),
+            model="prop-plan-model",
+            provider_response_id="prop-planner",
+            finish_reason="stop",
+        ),
+    )
+    tool_executor = _PropGraphToolExecutor(
+        ActionExecutionResult(
+            action_id="action-1",
+            action_kind=ActionKind.GENERATE_SHOW_NOTES,
+            model_tier=ModelTier.EXECUTION,
+            model="prop-exec-model",
+            summary="prop graph synthesis",
+            usage=LLMUsage(input_tokens=1, output_tokens=1, total_tokens=2),
+        ),
+        event_recorder=event_recorder,
+    )
+    graph = build_generation_orchestration_graph(
+        planner=planner,
+        tool_executor=tool_executor,
+    )
+
+    state = await graph.ainvoke(GenerationGraphState(request=request))
+    event_recorder.record("finish")
+
+    assert event_recorder.events == ["plan", "execute", "finish"]
+    assert state["planner_result"] is not None
+    assert state["action_results"]
+    assert state["orchestration_result"] is not None

--- a/tests/test_orchestration_properties.py
+++ b/tests/test_orchestration_properties.py
@@ -9,6 +9,10 @@ normalisation, model-tier validation, planner JSON error preservation, and the
 LangGraph plan-execute-finish ordering contract.
 """
 
+# Keep the related orchestration properties together so each invariant can share
+# the same domain-specific strategies and fakes.
+# pylint: disable=too-many-lines
+
 import dataclasses as dc
 import json
 import string

--- a/tests/test_orchestration_properties.py
+++ b/tests/test_orchestration_properties.py
@@ -1,49 +1,20 @@
-"""Hypothesis property-based tests for orchestration invariants.
+"""Hypothesis property-based tests for orchestration DTO payload invariants.
 
 Issue #72 called out that the PR #69 orchestration suite had strong
 deterministic unit coverage but lacked generative exploration of boundary
-inputs. This module complements `test_orchestration_dto_validation.py`,
-`test_orchestration_planner.py`, `test_show_notes_executor.py`, and
-`test_generation_orchestration_langgraph.py` with property tests for enum
-normalisation, model-tier validation, planner JSON error preservation, and the
-LangGraph plan-execute-finish ordering contract.
+inputs. This module keeps checkpoint and workflow-step key properties together;
+other orchestration properties live in the focused sibling modules.
 """
-
-# Keep the related orchestration properties together so each invariant can share
-# the same domain-specific strategies and fakes.
-# pylint: disable=too-many-lines
-
-import dataclasses as dc
-import json
-import string
-import typing as typ
 
 import hypothesis.strategies as st
 import pytest
 from hypothesis import given, settings
 
-from episodic.generation import ShowNotesResult
-from episodic.llm import (
-    LLMProviderOperation,
-    LLMResponse,
-    LLMUsage,
-)
 from episodic.orchestration import (
     ActionExecutionResult,
-    ActionKind,
     ExecutionPlan,
-    GenerationGraphState,
-    GenerationOrchestrationConfig,
-    GenerationOrchestrationRequest,
-    ModelTier,
-    PlannedAction,
     PlannerResult,
-    PlanningResponseFormatError,
-    ShowNotesToolExecutor,
-    StructuredGenerationPlanner,
-    UnsupportedActionError,
     WorkflowStepIdentity,
-    build_generation_orchestration_graph,
     build_workflow_step_idempotency_key,
 )
 from episodic.orchestration.langgraph import (
@@ -54,314 +25,12 @@ from episodic.orchestration.langgraph import (
     _planner_result_from_payload,
     _planner_result_to_payload,
 )
-from tests._orchestration_fakes import (
-    _config,
-    _FakeLLMPort,
-    _request,
-    _usage,
-)
-
-_ACTION_KIND_SAMPLES: tuple[ActionKind | str, ...] = tuple(ActionKind) + tuple(
-    m.value for m in ActionKind
-)
-_KNOWN_ACTION_KIND_STRINGS = {m.value for m in ActionKind}
-
-
-@dc.dataclass(slots=True)
-class _GraphEventRecorder:
-    """Collect explicitly injected graph-node events for ordering assertions."""
-
-    events: list[str] = dc.field(default_factory=list)
-
-    def record(self, event: str) -> None:
-        """Append one observed graph-node event."""
-        self.events.append(event)
-
-
-class _PropGraphPlanner:
-    """Emit canned planner payloads for Hypothesis graph probes."""
-
-    def __init__(
-        self,
-        *,
-        result: PlannerResult,
-        event_recorder: _GraphEventRecorder | None = None,
-    ) -> None:
-        self._result = result
-        self._event_recorder = event_recorder
-
-    async def plan(self, request: GenerationOrchestrationRequest) -> PlannerResult:
-        """Record the plan node when requested and return the canned result."""
-        assert request.script_tei_xml.startswith("<TEI>"), (
-            f"expected TEI input, got {request.script_tei_xml!r}"
-        )
-        assert request.correlation_id, "expected non-empty correlation_id"
-        if self._event_recorder is not None:
-            self._event_recorder.record("plan")
-        return self._result
-
-
-class _PropGraphToolExecutor:
-    """Emit canned tool payloads for Hypothesis graph probes."""
-
-    def __init__(
-        self,
-        result: ActionExecutionResult,
-        *,
-        event_recorder: _GraphEventRecorder | None = None,
-    ) -> None:
-        self._result = result
-        self._event_recorder = event_recorder
-
-    async def execute(
-        self,
-        action: PlannedAction,
-        context: GenerationOrchestrationRequest,
-    ) -> ActionExecutionResult:
-        """Record the execute node when requested and return the canned result."""
-        assert context.script_tei_xml.startswith("<TEI>"), (
-            f"expected TEI input, got {context.script_tei_xml!r}"
-        )
-        assert action.action_kind is ActionKind.GENERATE_SHOW_NOTES
-        if self._event_recorder is not None:
-            self._event_recorder.record("execute")
-        return self._result
-
-
-class _PropShowNotesGenerator:
-    """Return an empty show-notes result for model-tier boundary probes."""
-
-    async def generate(
-        self,
-        script_tei_xml: str,
-        *,
-        template_structure: dict[str, object] | None = None,
-    ) -> ShowNotesResult:
-        """Return a minimal structured show-notes result."""
-        assert script_tei_xml.startswith("<TEI>")
-        assert template_structure is not None
-        return ShowNotesResult(
-            entries=(),
-            usage=LLMUsage(input_tokens=1, output_tokens=0, total_tokens=1),
-            model="prop-exec-model",
-            provider_response_id="prop-exec-response",
-            finish_reason="stop",
-        )
-
-
-@dc.dataclass(frozen=True, slots=True)
-class _PropTokenInputs:
-    """Bundled token-count inputs for LangGraph property tests."""
-
-    planner_input: int
-    planner_output: int
-    action_input: int
-    action_output: int
-
-
-_token_inputs_strategy: st.SearchStrategy[_PropTokenInputs] = st.builds(
-    _PropTokenInputs,
-    planner_input=st.integers(min_value=0, max_value=10_000),
-    planner_output=st.integers(min_value=0, max_value=10_000),
-    action_input=st.integers(min_value=0, max_value=10_000),
-    action_output=st.integers(min_value=0, max_value=10_000),
-)
-
-
-@dc.dataclass(frozen=True, slots=True)
-class _PropStepKeyInputs:
-    """Bundled workflow step identity inputs for idempotency key tests."""
-
-    workflow_id: str
-    workflow_type: str
-    step_name: str
-    action_id: str
-
-
-_step_key_inputs_strategy: st.SearchStrategy[_PropStepKeyInputs] = st.builds(
-    _PropStepKeyInputs,
-    workflow_id=st.text(
-        min_size=1,
-        max_size=32,
-        alphabet=string.ascii_letters + string.digits + "-",
-    ),
-    workflow_type=st.text(
-        min_size=1,
-        max_size=32,
-        alphabet=string.ascii_letters + string.digits + "_",
-    ),
-    step_name=st.text(
-        min_size=1,
-        max_size=32,
-        alphabet=string.ascii_letters + string.digits + "_",
-    ),
-    action_id=st.text(
-        min_size=1,
-        max_size=32,
-        alphabet=string.ascii_letters + string.digits + "-",
-    ),
-)
-
-_prop_text = st.text(
-    min_size=1,
-    max_size=32,
-    alphabet=string.ascii_letters + string.digits + "-_ .",
-).filter(lambda value: bool(value.strip()))
-
-_usage_strategy = st.builds(
-    LLMUsage,
-    input_tokens=st.integers(min_value=0, max_value=10_000),
-    output_tokens=st.integers(min_value=0, max_value=10_000),
-    total_tokens=st.integers(min_value=0, max_value=20_000),
-)
-
-_planned_action_strategy = st.builds(
-    PlannedAction,
-    action_id=_prop_text,
-    action_kind=st.just(ActionKind.GENERATE_SHOW_NOTES),
-    rationale=_prop_text,
-    model_tier=st.just(ModelTier.EXECUTION),
-    required_inputs=st.lists(_prop_text, max_size=4).map(tuple),
-)
-
-_execution_plan_strategy = st.builds(
-    ExecutionPlan,
-    plan_version=_prop_text,
-    selected_planning_model=_prop_text,
-    selected_execution_model=_prop_text,
-    steps=st.lists(_planned_action_strategy, min_size=1, max_size=4).map(tuple),
-)
-
-_planner_result_strategy = st.builds(
-    PlannerResult,
-    plan=_execution_plan_strategy,
-    usage=st.one_of(st.none(), _usage_strategy),
-    model=_prop_text,
-    provider_response_id=_prop_text,
-    finish_reason=st.one_of(st.none(), _prop_text),
-)
-
-_action_result_strategy = st.builds(
-    ActionExecutionResult,
-    action_id=_prop_text,
-    action_kind=st.just(ActionKind.GENERATE_SHOW_NOTES),
-    model_tier=st.just(ModelTier.EXECUTION),
-    model=_prop_text,
-    summary=_prop_text,
-    usage=st.one_of(st.none(), _usage_strategy),
-)
-
-
-def _valid_plan_object() -> dict[str, object]:
-    """Return one valid raw planner object suitable for targeted corruption."""
-    return {
-        "plan_version": "1.0",
-        "steps": [
-            {
-                "action_id": "action-1",
-                "action_kind": ActionKind.GENERATE_SHOW_NOTES.value,
-                "rationale": "Generate publication-ready show notes.",
-                "model_tier": ModelTier.EXECUTION.value,
-                "required_inputs": ["script_tei_xml", "template_structure"],
-            }
-        ],
-    }
-
-
-def _invalid_plan_without_plan_version() -> str:
-    """Return JSON for a plan object with the required version field omitted."""
-    payload = _valid_plan_object()
-    payload = {key: value for key, value in payload.items() if key != "plan_version"}
-    return json.dumps(payload)
-
-
-def _invalid_plan_with_top_level_field(field_name: str, value: object) -> str:
-    """Return JSON for a plan object with one top-level field replaced."""
-    return json.dumps(_valid_plan_object() | {field_name: value})
-
-
-def _invalid_plan_with_step_field(field_name: str, value: object) -> str:
-    """Return JSON for a plan object with one first-step field replaced."""
-    step = typ.cast("list[dict[str, object]]", _valid_plan_object()["steps"])[0]
-    return json.dumps(_valid_plan_object() | {"steps": [step | {field_name: value}]})
-
-
-def _invalid_plan_without_step_field(field_name: str) -> str:
-    """Return JSON for a plan object with one required first-step field omitted."""
-    step = typ.cast("list[dict[str, object]]", _valid_plan_object()["steps"])[0]
-    narrowed_step = {key: value for key, value in step.items() if key != field_name}
-    return json.dumps(_valid_plan_object() | {"steps": [narrowed_step]})
-
-
-_unknown_action_kind_values = st.one_of(
-    st.none(),
-    st.integers(),
-    st.text(min_size=1, max_size=512).filter(
-        lambda value: value.strip() not in {kind.value for kind in ActionKind}
-    ),
-)
-
-_unknown_model_tier_values = st.one_of(
-    st.none(),
-    st.integers(),
-    st.text(min_size=1, max_size=512).filter(
-        lambda value: value.strip() not in {tier.value for tier in ModelTier}
-    ),
-)
-
-_invalid_required_inputs_values = st.one_of(
-    st.integers(),
-    st.lists(
-        st.one_of(st.none(), st.integers(), st.just("")),
-        min_size=1,
-        max_size=10,
-    ),
-)
-
-_PLANNER_FORMAT_ERROR_PATTERN = (
-    r"plan_version must be a non-empty string"
-    r"|steps must be a list"
-    r"|step must be an object"
-    r"|action_id must be a non-empty string"
-    r"|action_kind must be a non-empty string"
-    r"|action_kind must be one of: generate_show_notes"
-    r"|rationale must be a non-empty string"
-    r"|model_tier must be a non-empty string"
-    r"|model_tier must be one of: planning, execution"
-    r"|required_inputs must be a list of strings"
-    r"|required_inputs must contain only non-empty strings"
-)
-
-_invalid_plan_payloads = st.one_of(
-    st.just(_invalid_plan_without_plan_version()),
-    st.sampled_from(("", " ", "\t")).map(
-        lambda value: _invalid_plan_with_top_level_field("plan_version", value)
-    ),
-    st.one_of(
-        st.none(),
-        st.integers(),
-        st.text(max_size=512),
-        st.dictionaries(st.text(min_size=1, max_size=4), st.integers(), max_size=2),
-    ).map(lambda value: _invalid_plan_with_top_level_field("steps", value)),
-    st.one_of(st.none(), st.integers(), st.text(max_size=512)).map(
-        lambda value: _invalid_plan_with_top_level_field("steps", [value])
-    ),
-    st.just(_invalid_plan_without_step_field("action_id")),
-    st.sampled_from(("", " ", "\n")).map(
-        lambda value: _invalid_plan_with_step_field("action_id", value)
-    ),
-    _unknown_action_kind_values.map(
-        lambda value: _invalid_plan_with_step_field("action_kind", value)
-    ),
-    st.sampled_from(("", " ", "\r\n")).map(
-        lambda value: _invalid_plan_with_step_field("rationale", value)
-    ),
-    _unknown_model_tier_values.map(
-        lambda value: _invalid_plan_with_step_field("model_tier", value)
-    ),
-    _invalid_required_inputs_values.map(
-        lambda value: _invalid_plan_with_step_field("required_inputs", value)
-    ),
+from tests._orchestration_property_support import (
+    PropStepKeyInputs,
+    action_result_strategy,
+    execution_plan_strategy,
+    planner_result_strategy,
+    step_key_inputs_strategy,
 )
 
 
@@ -379,12 +48,12 @@ def test_step_idempotency_key_negative_attempt_raises_value_error() -> None:
 
 
 @given(
-    inputs=_step_key_inputs_strategy,
+    inputs=step_key_inputs_strategy,
     attempt=st.integers(min_value=0, max_value=100),
 )
 @settings(max_examples=50)
 def test_step_idempotency_keys_are_deterministic(
-    inputs: _PropStepKeyInputs,
+    inputs: PropStepKeyInputs,
     attempt: int,
 ) -> None:
     """Property test: identical workflow step inputs produce identical keys."""
@@ -406,7 +75,7 @@ def test_step_idempotency_keys_are_deterministic(
     assert first.endswith(f":{attempt}")
 
 
-@given(plan=_execution_plan_strategy)
+@given(plan=execution_plan_strategy)
 @settings(max_examples=50)
 def test_execution_plan_checkpoint_payload_round_trips(
     plan: ExecutionPlan,
@@ -415,7 +84,7 @@ def test_execution_plan_checkpoint_payload_round_trips(
     assert _plan_from_payload(_plan_to_payload(plan)) == plan
 
 
-@given(result=_planner_result_strategy)
+@given(result=planner_result_strategy)
 @settings(max_examples=50)
 def test_planner_result_checkpoint_payload_round_trips(
     result: PlannerResult,
@@ -424,308 +93,10 @@ def test_planner_result_checkpoint_payload_round_trips(
     assert _planner_result_from_payload(_planner_result_to_payload(result)) == result
 
 
-@given(result=_action_result_strategy)
+@given(result=action_result_strategy)
 @settings(max_examples=50)
 def test_action_result_checkpoint_payload_round_trips(
     result: ActionExecutionResult,
 ) -> None:
     """Property test: checkpoint action payloads preserve action results."""
     assert _action_result_from_payload(_action_result_to_payload(result)) == result
-
-
-@given(st.lists(st.sampled_from(_ACTION_KIND_SAMPLES), min_size=1, max_size=48))
-@settings(max_examples=50)
-def test_config_normalises_arbitrary_string_and_enum_mixes(
-    kinds: list[ActionKind | str],
-) -> None:
-    """Property test: heterogeneous action vocabularies become ``ActionKind``."""
-    cfg = GenerationOrchestrationConfig(
-        planning_model="hyp-plan-model",
-        execution_model="hyp-exec-model",
-        planning_provider_operation=LLMProviderOperation.CHAT_COMPLETIONS,
-        execution_provider_operation=LLMProviderOperation.CHAT_COMPLETIONS,
-        enabled_action_kinds=tuple(kinds),
-    )
-    assert all(isinstance(kind, ActionKind) for kind in cfg.enabled_action_kinds)
-    assert cfg.enabled_action_kinds == tuple(ActionKind(str(kind)) for kind in kinds)
-
-
-@given(
-    unknown=st.text(min_size=1, max_size=512).filter(
-        lambda s: bool(s.strip()) and s.strip() not in _KNOWN_ACTION_KIND_STRINGS
-    )
-)
-@settings(max_examples=50)
-def test_config_rejects_arbitrary_unknown_action_kind_strings(unknown: str) -> None:
-    """Property test: unknown action strings invalidate configuration."""
-    with pytest.raises(ValueError, match="Unknown action kind"):
-        GenerationOrchestrationConfig(
-            planning_model="hyp-plan-model",
-            execution_model="hyp-exec-model",
-            planning_provider_operation=LLMProviderOperation.CHAT_COMPLETIONS,
-            execution_provider_operation=LLMProviderOperation.CHAT_COMPLETIONS,
-            enabled_action_kinds=(unknown,),
-        )
-
-
-@given(
-    model_tier=st.sampled_from([
-        tier for tier in ModelTier if tier is not ModelTier.EXECUTION
-    ])
-)
-@settings(max_examples=10)
-@pytest.mark.asyncio
-async def test_planned_action_model_tier_rejection_for_all_non_execution_tiers(
-    model_tier: ModelTier,
-) -> None:
-    """Every planner tier besides execution must be rejected by show-notes."""
-    fake_llm = _FakeLLMPort([])
-    tool_executor = ShowNotesToolExecutor(llm=fake_llm, config=_config())
-    planning_tier_action = PlannedAction(
-        action_id="action-1",
-        action_kind=ActionKind.GENERATE_SHOW_NOTES,
-        rationale="Hypothesis rejects non-execution tiers.",
-        model_tier=model_tier,
-        required_inputs=("script_tei_xml",),
-    )
-    with pytest.raises(UnsupportedActionError, match=r"requires ModelTier\.EXECUTION"):
-        await tool_executor.execute(planning_tier_action, _request())
-
-
-@pytest.mark.asyncio
-async def test_planned_action_execution_model_tier_is_accepted() -> None:
-    """Boundary check: execution-tier actions are eligible for show-notes tooling."""
-    fake_llm = _FakeLLMPort([])
-    tool_executor = ShowNotesToolExecutor(
-        llm=fake_llm,
-        config=_config(),
-        generator=_PropShowNotesGenerator(),
-    )
-    action = PlannedAction(
-        action_id="action-1",
-        action_kind=ActionKind.GENERATE_SHOW_NOTES,
-        rationale="Hypothesis boundary check for execution tier.",
-        model_tier=ModelTier.EXECUTION,
-        required_inputs=("script_tei_xml",),
-    )
-
-    result = await tool_executor.execute(action, _request())
-
-    assert result.model_tier is ModelTier.EXECUTION
-    assert result.summary == "Generated 0 show-notes entries."
-
-
-@given(
-    noise=st.one_of(
-        st.integers(),
-        st.floats(allow_nan=False, allow_infinity=False),
-        st.lists(st.text(max_size=512), max_size=10),
-        st.text(max_size=512),
-    )
-)
-@settings(max_examples=50)
-@pytest.mark.asyncio
-async def test_planning_response_format_error_for_arbitrary_non_object_json(
-    noise: object,
-) -> None:
-    """Property test: non-object JSON bodies fail strict planner validation."""
-    blob = json.dumps(noise)
-
-    response = LLMResponse(
-        text=blob,
-        model="gpt-4.1",
-        provider_response_id="hyp-planner-response",
-        finish_reason="stop",
-        usage=_usage(input_tokens=1, output_tokens=1),
-    )
-    planner = StructuredGenerationPlanner(
-        llm=_FakeLLMPort([response]),
-        config=_config(),
-    )
-    request = GenerationOrchestrationRequest(
-        correlation_id="hyp-corr",
-        script_tei_xml="<TEI><body><p>noise</p></body></TEI>",
-    )
-    with pytest.raises(
-        PlanningResponseFormatError,
-        match=r"planner response must be an object",
-    ):
-        await planner.plan(request)
-
-
-@given(payload=_invalid_plan_payloads)
-@settings(max_examples=100)
-@pytest.mark.asyncio
-async def test_planning_response_format_error_for_invalid_plan_objects(
-    payload: str,
-) -> None:
-    """Property test: structurally invalid plan objects preserve format errors."""
-    response = LLMResponse(
-        text=payload,
-        model="gpt-4.1",
-        provider_response_id="hyp-invalid-plan-response",
-        finish_reason="stop",
-        usage=_usage(input_tokens=1, output_tokens=1),
-    )
-    planner = StructuredGenerationPlanner(
-        llm=_FakeLLMPort([response]),
-        config=_config(),
-    )
-
-    with pytest.raises(
-        PlanningResponseFormatError,
-        match=_PLANNER_FORMAT_ERROR_PATTERN,
-    ):
-        await planner.plan(_request())
-
-
-@given(
-    tokens=_token_inputs_strategy,
-    correlation_id=st.text(
-        min_size=1,
-        max_size=48,
-        alphabet=string.ascii_letters + string.digits + "-",
-    ),
-)
-@settings(max_examples=50)
-@pytest.mark.asyncio
-async def test_langgraph_total_tokens_non_negative(
-    tokens: _PropTokenInputs,
-    correlation_id: str,
-) -> None:
-    """Property test: LangGraph rollups keep total token counts semiring-safe."""
-    planner_usage = LLMUsage(
-        tokens.planner_input,
-        tokens.planner_output,
-        tokens.planner_input + tokens.planner_output,
-    )
-    tool_usage = LLMUsage(
-        tokens.action_input,
-        tokens.action_output,
-        tokens.action_input + tokens.action_output,
-    )
-    planner_result = PlannerResult(
-        plan=ExecutionPlan(
-            plan_version="1.0",
-            selected_planning_model="prop-plan-model",
-            selected_execution_model="prop-exec-model",
-            steps=(
-                PlannedAction(
-                    action_id="action-1",
-                    action_kind=ActionKind.GENERATE_SHOW_NOTES,
-                    rationale="prop graph rationale",
-                    model_tier=ModelTier.EXECUTION,
-                    required_inputs=("script_tei_xml",),
-                ),
-            ),
-        ),
-        usage=planner_usage,
-        model="gpt-4.1",
-        provider_response_id="prop-planner",
-        finish_reason="stop",
-    )
-    tool_result = ActionExecutionResult(
-        action_id="action-1",
-        action_kind=ActionKind.GENERATE_SHOW_NOTES,
-        model_tier=ModelTier.EXECUTION,
-        model="prop-exec-model",
-        summary="prop graph synthesis",
-        usage=tool_usage,
-    )
-
-    graph = build_generation_orchestration_graph(
-        planner=_PropGraphPlanner(result=planner_result),
-        tool_executor=_PropGraphToolExecutor(result=tool_result),
-    )
-
-    request = GenerationOrchestrationRequest(
-        correlation_id=correlation_id,
-        script_tei_xml=(
-            "<TEI><text><body><p>Hypothesis-driven graph workload</p></body>"
-            "</text></TEI>"
-        ),
-        template_structure=None,
-    )
-    state = await graph.ainvoke(GenerationGraphState(request=request))
-    orchestration_result = state["orchestration_result"]
-    expected_total_tokens = planner_usage.total_tokens + tool_usage.total_tokens
-    assert orchestration_result.total_usage.input_tokens >= 0
-    assert orchestration_result.total_usage.output_tokens >= 0
-    assert orchestration_result.total_usage.total_tokens >= 0
-    assert orchestration_result.total_usage.total_tokens == expected_total_tokens
-    assert state["planner_result"] == planner_result
-    assert state["action_results"][0].model == "prop-exec-model"
-
-
-@given(
-    request=st.builds(
-        GenerationOrchestrationRequest,
-        correlation_id=st.text(
-            min_size=1,
-            max_size=48,
-            alphabet=string.ascii_letters + string.digits + "-",
-        ),
-        script_tei_xml=st.text(
-            min_size=1,
-            max_size=80,
-            alphabet=string.ascii_letters + string.digits + " .,_-",
-        ).map(lambda body: f"<TEI><text><body><p>{body}</p></body></text></TEI>"),
-        template_structure=st.one_of(
-            st.none(),
-            st.just({"sections": ["intro", "analysis"]}),
-        ),
-    )
-)
-@settings(max_examples=50)
-@pytest.mark.asyncio
-async def test_langgraph_respects_plan_execute_finish_order(
-    request: GenerationOrchestrationRequest,
-) -> None:
-    """Property test: valid requests always traverse plan, execute, then finish."""
-    event_recorder = _GraphEventRecorder()
-    planner = _PropGraphPlanner(
-        event_recorder=event_recorder,
-        result=PlannerResult(
-            plan=ExecutionPlan(
-                plan_version="1.0",
-                selected_planning_model="prop-plan-model",
-                selected_execution_model="prop-exec-model",
-                steps=(
-                    PlannedAction(
-                        action_id="action-1",
-                        action_kind=ActionKind.GENERATE_SHOW_NOTES,
-                        rationale="prop graph rationale",
-                        model_tier=ModelTier.EXECUTION,
-                        required_inputs=("script_tei_xml",),
-                    ),
-                ),
-            ),
-            usage=LLMUsage(input_tokens=1, output_tokens=1, total_tokens=2),
-            model="prop-plan-model",
-            provider_response_id="prop-planner",
-            finish_reason="stop",
-        ),
-    )
-    tool_executor = _PropGraphToolExecutor(
-        ActionExecutionResult(
-            action_id="action-1",
-            action_kind=ActionKind.GENERATE_SHOW_NOTES,
-            model_tier=ModelTier.EXECUTION,
-            model="prop-exec-model",
-            summary="prop graph synthesis",
-            usage=LLMUsage(input_tokens=1, output_tokens=1, total_tokens=2),
-        ),
-        event_recorder=event_recorder,
-    )
-    graph = build_generation_orchestration_graph(
-        planner=planner,
-        tool_executor=tool_executor,
-        finish_callback=lambda _state: event_recorder.record("finish"),
-    )
-
-    state = await graph.ainvoke(GenerationGraphState(request=request))
-
-    assert event_recorder.events == ["plan", "execute", "finish"]
-    assert state["planner_result"] is not None
-    assert state["action_results"]
-    assert state["orchestration_result"] is not None


### PR DESCRIPTION
## Summary

This branch adds Hypothesis coverage for the structured generation orchestration contracts raised in issue #72. It exercises enum normalisation across mixed `ActionKind` inputs, rejects every non-execution `ModelTier`, broadens planner format-error preservation across malformed JSON and invalid plan objects, and checks LangGraph ordering and token aggregation invariants.

Review follow-up changes expand the module documentation, make graph event recording an explicit injected dependency, bound generated malformed payloads, and pin representative `PlanningResponseFormatError` messages with Syrupy snapshots.

Closes #72.

## Review walkthrough

- Start with [tests/test_orchestration_properties.py](https://github.com/leynos/episodic/blob/issue-72-hypothesis-property-based-tests-for-episodic-orchestration/tests/test_orchestration_properties.py) for the Hypothesis strategies and orchestration invariants.
- Review [tests/test_generation_orchestration_snapshots.py](https://github.com/leynos/episodic/blob/issue-72-hypothesis-property-based-tests-for-episodic-orchestration/tests/test_generation_orchestration_snapshots.py) for representative planner error-message snapshots.
- Finish with [tests/__snapshots__/test_generation_orchestration_snapshots.ambr](https://github.com/leynos/episodic/blob/issue-72-hypothesis-property-based-tests-for-episodic-orchestration/tests/__snapshots__/test_generation_orchestration_snapshots.ambr) for the pinned diagnostics.

## Validation

- `make check-fmt`: passed
- `make lint`: passed
- `make test PYTEST_XDIST_WORKERS=1`: passed, 481 passed, 3 skipped
- `make typecheck`: passed

## Notes

`hypothesis` was already present in the dev dependency group, so no dependency or lockfile change was required. One full-suite run hit a transient `py-pglite` fixture setup timeout in an unrelated reference-document pagination case; the isolated case passed immediately, and the subsequent full-suite retry passed.