### PR TITLE
Document checkpoint atomicity boundaries (2.4.2) (#91)

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -901,6 +901,47 @@ checkpoint resumed, and returns the final `GenerationOrchestrationResult`. It
 raises `ValueError` for unknown checkpoints and `TypeError` for malformed
 stored planner-result payloads.
 
+### Checkpoint atomicity and observability
+
+Durable checkpoint suspend uses `CheckpointPort.save_or_reuse(...)` as the
+atomic idempotency boundary. Callers do not perform a pre-save lookup. They
+construct a fresh `WorkflowCheckpoint`, call `save_or_reuse(...)`, and treat
+the returned checkpoint identifier as authoritative. The SQLAlchemy adapter
+inserts inside a nested savepoint and relies on the `idempotency_key`
+uniqueness constraint for first-write-wins convergence. Concurrent suspend
+attempts for the same workflow step therefore either persist the first
+checkpoint or reuse the checkpoint that already owns the idempotency key.
+
+`mark_resumed(...)` participates in the caller's unit of work. A committed unit
+of work records the checkpoint as `resumed`; a rolled-back unit leaves the
+checkpoint `suspended`, so the recovery path is non-destructive. Any retry
+after a resume-side partial failure depends on the concrete `TaskResumePort`
+adapter treating duplicate resume commands idempotently.
+
+Checkpoint storage metrics use the shared `MetricsPort` contract from
+`episodic.observability` and must keep labels bounded. The SQLAlchemy adapter
+emits:
+
+- `workflow_checkpoint.save_or_reuse.operations` with `outcome` values
+  `persisted`, `reused`, or `recovery_failure`.
+- `workflow_checkpoint.save_or_reuse.idempotency_conflicts` with `outcome` set
+  to `conflict`.
+- `workflow_checkpoint.save_or_reuse.latency_ms` with the same `outcome` labels
+  as the save operation counter.
+- `workflow_checkpoint.mark_resumed.operations` and
+  `workflow_checkpoint.mark_resumed.latency_ms` with `outcome` values `marked`
+  or `unknown_checkpoint`.
+- `workflow_checkpoint.recovery_failures` with `operation=save_or_reuse` and
+  `reason=conflict_missing_checkpoint`.
+
+Production alerting should page on any non-zero
+`workflow_checkpoint.recovery_failures{reason="conflict_missing_checkpoint"}`
+event, because it means duplicate-key convergence failed after the database
+reported an idempotency conflict. Trend
+`workflow_checkpoint.save_or_reuse.idempotency_conflicts` and save latency for
+load and retry pressure, but do not label checkpoint metrics with workflow ids,
+checkpoint ids, or idempotency keys.
+
 ### Maintainer rules
 
 - Keep the planner strict: parse model output into typed DTOs immediately and

--- a/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md
+++ b/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md
@@ -757,3 +757,15 @@ API, and screen-reader descriptions now precede the suspend-and-resume sequence
 diagrams. The snapshot import comment was already resolved in the current code
 and required no change. Focused checkpoint, migration-drift, and
 malformed-payload tests passed.
+
+Revision note 2026-05-26: PR #98 / issue #91 follow-up documented checkpoint
+atomicity boundaries in the developer guide. The note records
+`save_or_reuse(...)` first-write-wins convergence through the idempotency key,
+the SQLAlchemy nested-savepoint duplicate-key recovery path, and
+`mark_resumed(...)` unit-of-work semantics for commit versus rollback. The
+SQLAlchemy checkpoint store now emits bounded metrics through the shared
+`MetricsPort` for save-or-reuse outcomes, idempotency conflict rates, operation
+latency, mark-resumed outcomes, and `conflict_missing_checkpoint` recovery
+failures. The developer guide also records the required alert: any non-zero
+`workflow_checkpoint.recovery_failures{reason="conflict_missing_checkpoint"}`
+event indicates failed distributed idempotency recovery and should page.

--- a/episodic/canonical/storage/uow.py
+++ b/episodic/canonical/storage/uow.py
@@ -39,6 +39,8 @@ if typ.TYPE_CHECKING:
 
     from sqlalchemy.ext.asyncio import AsyncSession
 
+    from episodic.observability import MetricsPort, MonotonicClockPort
+
 logger = get_logger(__name__)
 
 
@@ -78,8 +80,16 @@ class SqlAlchemyUnitOfWork(CanonicalUnitOfWork):
         Repository for reusable reference binding persistence.
     """
 
-    def __init__(self, session_factory: cabc.Callable[[], AsyncSession]) -> None:
+    def __init__(
+        self,
+        session_factory: cabc.Callable[[], AsyncSession],
+        *,
+        metrics: MetricsPort | None = None,
+        clock: MonotonicClockPort | None = None,
+    ) -> None:
         self._session_factory = session_factory
+        self._metrics = metrics
+        self._clock = clock
         self._session: AsyncSession | None = None
 
     async def __aenter__(self) -> SqlAlchemyUnitOfWork:
@@ -109,7 +119,11 @@ class SqlAlchemyUnitOfWork(CanonicalUnitOfWork):
             SqlAlchemyReferenceDocumentRevisionRepository(self._session)
         )
         self.reference_bindings = SqlAlchemyReferenceBindingRepository(self._session)
-        self.workflow_checkpoints = SqlAlchemyWorkflowCheckpointStore(self._session)
+        self.workflow_checkpoints = SqlAlchemyWorkflowCheckpointStore(
+            self._session,
+            metrics=self._metrics,
+            clock=self._clock,
+        )
         return self
 
     async def __aexit__(

--- a/episodic/canonical/storage/uow.py
+++ b/episodic/canonical/storage/uow.py
@@ -51,6 +51,12 @@ class SqlAlchemyUnitOfWork(CanonicalUnitOfWork):
     ----------
     session_factory : collections.abc.Callable[[], AsyncSession]
         Factory that produces new async sessions for the unit-of-work scope.
+    metrics : MetricsPort | None, optional
+        Optional metrics collector used to record UoW counters and timings,
+        forwarded to the workflow checkpoint store.  Defaults to *None*.
+    clock : MonotonicClockPort | None, optional
+        Optional monotonic clock used to measure elapsed operation time,
+        forwarded to the workflow checkpoint store.  Defaults to *None*.
 
     Attributes
     ----------

--- a/episodic/canonical/storage/workflow_checkpoints.py
+++ b/episodic/canonical/storage/workflow_checkpoints.py
@@ -1,11 +1,10 @@
-"""SQLAlchemy checkpoint adapter for resumable orchestration workflows.
+"""Checkpoint adapter for resumable orchestration workflows.
 
 This adapter implements the orchestration-layer `CheckpointPort` at the
-canonical storage boundary. LangGraph nodes hand it typed
-`WorkflowCheckpoint` DTOs; the adapter maps those DTOs to the
-`workflow_checkpoints` table and relies on the table's unique idempotency key
-to make repeated suspend attempts converge on the first persisted checkpoint.
-It does not import graph code, LLM adapters, or Celery concerns.
+canonical storage boundary. Repeated suspend attempts for the same workflow
+step converge on one durable checkpoint, while resume markers remain governed
+by the caller's unit-of-work decision. It does not import graph code, LLM
+adapters, or Celery concerns.
 """
 
 import typing as typ
@@ -40,7 +39,7 @@ def _map_checkpoint(record: WorkflowCheckpointRecord) -> WorkflowCheckpoint:
 
 
 class SqlAlchemyWorkflowCheckpointStore:
-    """Durable SQLAlchemy implementation of the orchestration `CheckpointPort`."""
+    """Durable implementation of the orchestration `CheckpointPort`."""
 
     def __init__(self, session: "AsyncSession") -> None:  # noqa: UP037
         self._session = session
@@ -85,18 +84,15 @@ class SqlAlchemyWorkflowCheckpointStore:
     async def save_or_reuse(self, checkpoint: WorkflowCheckpoint) -> WorkflowCheckpoint:
         """Persist a checkpoint or return the existing record for its key.
 
-        The insert runs inside a SQL savepoint via ``begin_nested()`` so a
-        unique-constraint conflict on ``idempotency_key`` rolls back only the
-        attempted insert, not the caller's outer unit-of-work transaction.
-        This gives first-write-wins semantics: concurrent callers racing on
-        one idempotency key converge on the existing checkpoint instead of
-        surfacing an ``IntegrityError``.
+        Concurrent callers racing on one idempotency key converge on the first
+        checkpoint that reaches durable storage. The returned checkpoint may be
+        the new record or a previously persisted record, and callers should use
+        its identifier as the authoritative suspend token.
 
-        This method flushes but does not commit. Durability belongs to the
-        caller's unit of work. If the conflict path cannot find the existing
-        checkpoint after the unique constraint fires, the original
-        ``IntegrityError`` is re-raised; that path should be unreachable while
-        the database constraint and lookup use the same key.
+        The method participates in the caller's unit of work and does not make
+        the checkpoint durable on its own. If convergence cannot recover the
+        existing checkpoint for a conflicting key, the storage failure is
+        propagated so the caller can retry or fail the suspend attempt.
         """
         record = WorkflowCheckpointRecord(
             id=uuid.UUID(checkpoint.checkpoint_id),
@@ -108,6 +104,8 @@ class SqlAlchemyWorkflowCheckpointStore:
             status=WorkflowCheckpointStatus(checkpoint.status),
         )
         try:
+            # Keep a duplicate insert attempt isolated from the caller's outer
+            # transaction; the public contract above is convergence by key.
             async with self._session.begin_nested():
                 self._session.add(record)
                 await self._session.flush()
@@ -126,17 +124,21 @@ class SqlAlchemyWorkflowCheckpointStore:
             existing = await self.get_by_idempotency_key(checkpoint.idempotency_key)
             if existing is not None:
                 return existing
+            _log_event(
+                "error",
+                "sql_checkpoint_store.save_or_reuse.conflict_missing_checkpoint",
+                idempotency_key=checkpoint.idempotency_key,
+            )
             raise
         return _map_checkpoint(record)
 
     async def mark_resumed(self, checkpoint_id: str) -> WorkflowCheckpoint:
         """Mark a checkpoint as resumed and return the updated record.
 
-        This method flushes the status update but does not commit it.
-        Durability belongs to the caller's unit of work. If the outer
-        transaction rolls back after the flush, the checkpoint remains in the
-        ``suspended`` state on disk, which is non-destructive and safe for a
-        later retry.
+        The update participates in the caller's unit of work. A committed unit
+        of work records the checkpoint as ``resumed``; a rolled-back unit of
+        work leaves the checkpoint ``suspended`` and available for a later
+        retry.
 
         Raises
         ------

--- a/episodic/canonical/storage/workflow_checkpoints.py
+++ b/episodic/canonical/storage/workflow_checkpoints.py
@@ -83,7 +83,21 @@ class SqlAlchemyWorkflowCheckpointStore:
         return _map_checkpoint(record)
 
     async def save_or_reuse(self, checkpoint: WorkflowCheckpoint) -> WorkflowCheckpoint:
-        """Persist a checkpoint or return the existing record for its key."""
+        """Persist a checkpoint or return the existing record for its key.
+
+        The insert runs inside a SQL savepoint via ``begin_nested()`` so a
+        unique-constraint conflict on ``idempotency_key`` rolls back only the
+        attempted insert, not the caller's outer unit-of-work transaction.
+        This gives first-write-wins semantics: concurrent callers racing on
+        one idempotency key converge on the existing checkpoint instead of
+        surfacing an ``IntegrityError``.
+
+        This method flushes but does not commit. Durability belongs to the
+        caller's unit of work. If the conflict path cannot find the existing
+        checkpoint after the unique constraint fires, the original
+        ``IntegrityError`` is re-raised; that path should be unreachable while
+        the database constraint and lookup use the same key.
+        """
         record = WorkflowCheckpointRecord(
             id=uuid.UUID(checkpoint.checkpoint_id),
             workflow_id=checkpoint.workflow_id,
@@ -116,7 +130,18 @@ class SqlAlchemyWorkflowCheckpointStore:
         return _map_checkpoint(record)
 
     async def mark_resumed(self, checkpoint_id: str) -> WorkflowCheckpoint:
-        """Mark a checkpoint as resumed and return the updated record."""
+        """Mark a checkpoint as resumed and return the updated record.
+
+        This method flushes the status update but does not commit it.
+        Durability belongs to the caller's unit of work. If the outer
+        transaction rolls back after the flush, the checkpoint remains in the
+        ``suspended`` state on disk, which is non-destructive and safe for a
+        later retry.
+
+        Raises
+        ------
+            ValueError: If ``checkpoint_id`` does not identify a checkpoint.
+        """
         record = await self._session.get(
             WorkflowCheckpointRecord,
             uuid.UUID(checkpoint_id),

--- a/episodic/canonical/storage/workflow_checkpoints.py
+++ b/episodic/canonical/storage/workflow_checkpoints.py
@@ -41,7 +41,10 @@ def _map_checkpoint(record: WorkflowCheckpointRecord) -> WorkflowCheckpoint:
 class SqlAlchemyWorkflowCheckpointStore:
     """Durable implementation of the orchestration `CheckpointPort`."""
 
-    def __init__(self, session: "AsyncSession") -> None:  # noqa: UP037
+    def __init__(
+        self,
+        session: "AsyncSession",  # noqa: UP037  # AsyncSession is TYPE_CHECKING-only in __init__.
+    ) -> None:
         self._session = session
 
     async def get(self, checkpoint_id: str) -> WorkflowCheckpoint | None:

--- a/episodic/canonical/storage/workflow_checkpoints.py
+++ b/episodic/canonical/storage/workflow_checkpoints.py
@@ -14,6 +14,12 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 
 from episodic.canonical.domain import WorkflowCheckpointStatus
+from episodic.observability import (
+    MetricsPort,
+    MonotonicClockPort,
+    NoopMetrics,
+    PerfCounterClock,
+)
 from episodic.orchestration import WorkflowCheckpoint
 from episodic.orchestration._types import _log_event
 
@@ -21,6 +27,13 @@ from .models import WorkflowCheckpointRecord
 
 if typ.TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
+
+_METRIC_SAVE_OPERATIONS = "workflow_checkpoint.save_or_reuse.operations"
+_METRIC_SAVE_CONFLICTS = "workflow_checkpoint.save_or_reuse.idempotency_conflicts"
+_METRIC_SAVE_LATENCY_MS = "workflow_checkpoint.save_or_reuse.latency_ms"
+_METRIC_RESUME_OPERATIONS = "workflow_checkpoint.mark_resumed.operations"
+_METRIC_RESUME_LATENCY_MS = "workflow_checkpoint.mark_resumed.latency_ms"
+_METRIC_RECOVERY_FAILURES = "workflow_checkpoint.recovery_failures"
 
 
 def _map_checkpoint(record: WorkflowCheckpointRecord) -> WorkflowCheckpoint:
@@ -44,8 +57,40 @@ class SqlAlchemyWorkflowCheckpointStore:
     def __init__(
         self,
         session: "AsyncSession",  # noqa: UP037  # AsyncSession is TYPE_CHECKING-only in __init__.
+        *,
+        metrics: MetricsPort | None = None,
+        clock: MonotonicClockPort | None = None,
     ) -> None:
         self._session = session
+        self._metrics = metrics or NoopMetrics()
+        self._clock = clock or PerfCounterClock()
+
+    def _record_counter(self, name: str, *, labels: dict[str, str]) -> None:
+        """Record a bounded-cardinality counter through the injected metrics port."""
+        self._metrics.increment_counter(name, labels=labels)
+
+    def _record_latency(
+        self,
+        name: str,
+        started_at: float,
+        *,
+        labels: dict[str, str],
+    ) -> None:
+        """Record elapsed latency through the injected metrics port."""
+        elapsed_ms = (self._clock.monotonic_seconds() - started_at) * 1000
+        self._metrics.observe_latency_ms(name, elapsed_ms, labels=labels)
+
+    def _record_save_outcome(self, started_at: float, outcome: str) -> None:
+        """Record save-or-reuse metrics."""
+        labels = {"outcome": outcome}
+        self._record_counter(_METRIC_SAVE_OPERATIONS, labels=labels)
+        self._record_latency(_METRIC_SAVE_LATENCY_MS, started_at, labels=labels)
+
+    def _record_resume_outcome(self, started_at: float, outcome: str) -> None:
+        """Record mark-resumed metrics."""
+        labels = {"outcome": outcome}
+        self._record_counter(_METRIC_RESUME_OPERATIONS, labels=labels)
+        self._record_latency(_METRIC_RESUME_LATENCY_MS, started_at, labels=labels)
 
     async def get(self, checkpoint_id: str) -> WorkflowCheckpoint | None:
         """Return a checkpoint by identifier."""
@@ -97,6 +142,7 @@ class SqlAlchemyWorkflowCheckpointStore:
         existing checkpoint for a conflicting key, the storage failure is
         propagated so the caller can retry or fail the suspend attempt.
         """
+        started_at = self._clock.monotonic_seconds()
         record = WorkflowCheckpointRecord(
             id=uuid.UUID(checkpoint.checkpoint_id),
             workflow_id=checkpoint.workflow_id,
@@ -118,20 +164,34 @@ class SqlAlchemyWorkflowCheckpointStore:
                     checkpoint_id=checkpoint.checkpoint_id,
                     idempotency_key=checkpoint.idempotency_key,
                 )
+                self._record_save_outcome(started_at, "persisted")
         except IntegrityError:
             _log_event(
                 "warning",
                 "sql_checkpoint_store.save_or_reuse.idempotency_conflict",
                 idempotency_key=checkpoint.idempotency_key,
             )
+            self._record_counter(
+                _METRIC_SAVE_CONFLICTS,
+                labels={"outcome": "conflict"},
+            )
             existing = await self.get_by_idempotency_key(checkpoint.idempotency_key)
             if existing is not None:
+                self._record_save_outcome(started_at, "reused")
                 return existing
             _log_event(
                 "error",
                 "sql_checkpoint_store.save_or_reuse.conflict_missing_checkpoint",
                 idempotency_key=checkpoint.idempotency_key,
             )
+            self._record_counter(
+                _METRIC_RECOVERY_FAILURES,
+                labels={
+                    "operation": "save_or_reuse",
+                    "reason": "conflict_missing_checkpoint",
+                },
+            )
+            self._record_save_outcome(started_at, "recovery_failure")
             raise
         return _map_checkpoint(record)
 
@@ -147,11 +207,13 @@ class SqlAlchemyWorkflowCheckpointStore:
         ------
             ValueError: If ``checkpoint_id`` does not identify a checkpoint.
         """
+        started_at = self._clock.monotonic_seconds()
         record = await self._session.get(
             WorkflowCheckpointRecord,
             uuid.UUID(checkpoint_id),
         )
         if record is None:
+            self._record_resume_outcome(started_at, "unknown_checkpoint")
             msg = f"unknown checkpoint: {checkpoint_id}"
             raise ValueError(msg)
         record.status = WorkflowCheckpointStatus.RESUMED
@@ -161,5 +223,6 @@ class SqlAlchemyWorkflowCheckpointStore:
             "sql_checkpoint_store.mark_resumed",
             checkpoint_id=checkpoint_id,
         )
+        self._record_resume_outcome(started_at, "marked")
         await self._session.refresh(record)
         return _map_checkpoint(record)

--- a/episodic/observability.py
+++ b/episodic/observability.py
@@ -1,0 +1,71 @@
+"""Shared observability ports for bounded metrics and monotonic timing."""
+
+from __future__ import annotations
+
+import dataclasses as dc
+import time
+import typing as typ
+
+if typ.TYPE_CHECKING:
+    from collections import abc as cabc
+
+
+class MetricsPort(typ.Protocol):
+    """Bounded-cardinality metrics sink shared by adapters and services."""
+
+    def increment_counter(
+        self,
+        name: str,
+        *,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Increment a bounded-cardinality counter."""
+
+    def observe_latency_ms(
+        self,
+        name: str,
+        value: float,
+        *,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Observe a latency measurement in milliseconds."""
+
+
+class MonotonicClockPort(typ.Protocol):
+    """Clock port for measuring elapsed operation time."""
+
+    def monotonic_seconds(self) -> float:
+        """Return a monotonic timestamp in seconds."""
+
+
+@dc.dataclass(frozen=True, slots=True)
+class NoopMetrics:
+    """Default metrics sink used when no backend is wired."""
+
+    def increment_counter(
+        self,
+        name: str,
+        *,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Ignore counter increments."""
+
+    def observe_latency_ms(
+        self,
+        name: str,
+        value: float,
+        *,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Ignore latency observations."""
+
+
+@dc.dataclass(frozen=True, slots=True)
+class PerfCounterClock:
+    """Monotonic clock backed by Python's perf counter."""
+
+    read_seconds: cabc.Callable[[], float] = time.perf_counter
+
+    def monotonic_seconds(self) -> float:
+        """Return the current monotonic timestamp in seconds."""
+        return self.read_seconds()

--- a/episodic/orchestration/_checkpoint_resume.py
+++ b/episodic/orchestration/_checkpoint_resume.py
@@ -97,7 +97,19 @@ async def _suspend_execute_node(
     checkpoint_port: protocols.CheckpointPort,
     workflow_type: str = "generation_orchestration",
 ) -> dict[str, dto.SuspendedWorkflowResult]:
-    """Persist or reuse a checkpoint before executing the first action."""
+    """Persist or reuse a checkpoint before executing the first action.
+
+    The suspend path deliberately performs no pre-save lookup. It always asks
+    the checkpoint port to ``save_or_reuse`` a fresh checkpoint and derives
+    reuse from the returned checkpoint id. The database-backed port enforces
+    the idempotency boundary with the unique ``idempotency_key`` constraint, so
+    concurrent invocations for the same workflow step converge on one
+    checkpoint without a time-of-check/time-of-use window.
+
+    The returned ``SuspendedWorkflowResult`` is valid whether this invocation
+    created the checkpoint or reused a checkpoint created by a concurrent
+    caller.
+    """
     request, planner_result, action = _validate_suspend_preconditions(state)
     identity = _build_execute_step_identity(
         request=request,
@@ -162,6 +174,13 @@ async def resume_generation_orchestration(
     `build_generation_result(planner_result, (action_result,))` finalises that
     single result. Any future model that allows one checkpoint to cover
     multiple `planner_result.plan.steps` entries must update this code path.
+
+    The resume action executes before the checkpoint is marked ``resumed``. If
+    the action completes and `checkpoint_port.mark_resumed` fails or the caller
+    rolls back the unit of work, the checkpoint remains ``suspended``. That
+    partial failure is non-destructive, but retry safety then depends on the
+    concrete `TaskResumePort` adapter treating duplicate resume commands
+    idempotently.
 
     Raises
     ------

--- a/episodic/orchestration/_checkpoint_resume.py
+++ b/episodic/orchestration/_checkpoint_resume.py
@@ -97,19 +97,7 @@ async def _suspend_execute_node(
     checkpoint_port: protocols.CheckpointPort,
     workflow_type: str = "generation_orchestration",
 ) -> dict[str, dto.SuspendedWorkflowResult]:
-    """Persist or reuse a checkpoint before executing the first action.
-
-    The suspend path deliberately performs no pre-save lookup. It always asks
-    the checkpoint port to ``save_or_reuse`` a fresh checkpoint and derives
-    reuse from the returned checkpoint id. The database-backed port enforces
-    the idempotency boundary with the unique ``idempotency_key`` constraint, so
-    concurrent invocations for the same workflow step converge on one
-    checkpoint without a time-of-check/time-of-use window.
-
-    The returned ``SuspendedWorkflowResult`` is valid whether this invocation
-    created the checkpoint or reused a checkpoint created by a concurrent
-    caller.
-    """
+    """Persist or reuse a checkpoint before executing the first action."""
     request, planner_result, action = _validate_suspend_preconditions(state)
     identity = _build_execute_step_identity(
         request=request,
@@ -130,6 +118,11 @@ async def _suspend_execute_node(
         idempotency_key=idempotency_key,
     )
     fresh_id = str(uuid.uuid4())
+    # The suspend path deliberately performs no pre-save lookup. It always
+    # asks the checkpoint port to save a fresh checkpoint and derives reuse
+    # from the returned checkpoint id. Concrete ports own the idempotency
+    # boundary, so concurrent invocations for the same workflow step converge
+    # without a time-of-check/time-of-use window.
     existing = await checkpoint_port.save_or_reuse(
         dto.WorkflowCheckpoint(
             checkpoint_id=fresh_id,
@@ -185,7 +178,7 @@ async def resume_generation_orchestration(
     Raises
     ------
         ValueError: If the command references an unknown checkpoint.
-        TypeError: If the stored checkpoint payload cannot be deserialised into
+        TypeError: If the stored checkpoint payload cannot be deserialized into
             the expected planner-result shape.
     """
     _log_event(

--- a/tests/canonical_storage/test_workflow_checkpoints.py
+++ b/tests/canonical_storage/test_workflow_checkpoints.py
@@ -15,10 +15,16 @@ import pytest
 import sqlalchemy as sa
 from hypothesis import HealthCheck, given, settings
 
-from episodic.canonical.storage import SqlAlchemyUnitOfWork, WorkflowCheckpointRecord
+from episodic.canonical.storage import (
+    SqlAlchemyUnitOfWork,
+    SqlAlchemyWorkflowCheckpointStore,
+    WorkflowCheckpointRecord,
+)
 from episodic.orchestration import WorkflowCheckpoint
 
 if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 
@@ -45,6 +51,45 @@ def _checkpoint(
 
 
 _short_delays = st.sampled_from((0.0, 0.001, 0.005))
+
+
+class _RecordingMetrics:
+    """Capture checkpoint metrics for adapter assertions."""
+
+    def __init__(self) -> None:
+        self.counters: list[tuple[str, dict[str, str]]] = []
+        self.latencies: list[tuple[str, float, dict[str, str]]] = []
+
+    def increment_counter(
+        self,
+        name: str,
+        *,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Record a counter increment."""
+        self.counters.append((name, dict(labels)))
+
+    def observe_latency_ms(
+        self,
+        name: str,
+        value: float,
+        *,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Record a latency observation."""
+        self.latencies.append((name, value, dict(labels)))
+
+
+class _StepClock:
+    """Deterministic monotonic clock for metric latency assertions."""
+
+    def __init__(self) -> None:
+        self._seconds = 0.0
+
+    def monotonic_seconds(self) -> float:
+        """Return a timestamp that advances by 1 ms on each call."""
+        self._seconds += 0.001
+        return self._seconds
 
 
 @pytest.mark.asyncio
@@ -113,32 +158,84 @@ async def test_checkpoint_store_reuses_idempotency_key(
 
 
 @pytest.mark.asyncio
+async def test_checkpoint_store_records_checkpoint_metrics(
+    session_factory: object,
+) -> None:
+    """Checkpoint operations should record bounded outcome and latency metrics."""
+    factory = typ.cast("async_sessionmaker[AsyncSession]", session_factory)
+    metrics = _RecordingMetrics()
+    key = "corr-storage:generation_orchestration:execute:metrics:0"
+    checkpoint = _checkpoint(idempotency_key=key)
+    duplicate = _checkpoint(checkpoint_id=str(uuid.uuid4()), idempotency_key=key)
+
+    async with factory() as session:
+        store = SqlAlchemyWorkflowCheckpointStore(
+            session,
+            metrics=metrics,
+            clock=_StepClock(),
+        )
+        first = await store.save_or_reuse(checkpoint)
+        second = await store.save_or_reuse(duplicate)
+        await session.commit()
+
+    async with SqlAlchemyUnitOfWork(factory) as uow:
+        stored = await uow.workflow_checkpoints.save_or_reuse(_checkpoint())
+        await uow.commit()
+
+    async with factory() as session:
+        store = SqlAlchemyWorkflowCheckpointStore(
+            session,
+            metrics=metrics,
+            clock=_StepClock(),
+        )
+        await store.mark_resumed(stored.checkpoint_id)
+        with pytest.raises(ValueError, match="unknown checkpoint"):
+            await store.mark_resumed(str(uuid.uuid4()))
+        await session.rollback()
+
+    assert second.checkpoint_id == first.checkpoint_id
+    assert metrics.counters == [
+        (
+            "workflow_checkpoint.save_or_reuse.operations",
+            {"outcome": "persisted"},
+        ),
+        (
+            "workflow_checkpoint.save_or_reuse.idempotency_conflicts",
+            {"outcome": "conflict"},
+        ),
+        ("workflow_checkpoint.save_or_reuse.operations", {"outcome": "reused"}),
+        ("workflow_checkpoint.mark_resumed.operations", {"outcome": "marked"}),
+        (
+            "workflow_checkpoint.mark_resumed.operations",
+            {"outcome": "unknown_checkpoint"},
+        ),
+    ]
+    assert [(name, labels) for name, _value, labels in metrics.latencies] == [
+        (
+            "workflow_checkpoint.save_or_reuse.latency_ms",
+            {"outcome": "persisted"},
+        ),
+        ("workflow_checkpoint.save_or_reuse.latency_ms", {"outcome": "reused"}),
+        ("workflow_checkpoint.mark_resumed.latency_ms", {"outcome": "marked"}),
+        (
+            "workflow_checkpoint.mark_resumed.latency_ms",
+            {"outcome": "unknown_checkpoint"},
+        ),
+    ]
+    assert all(value > 0 for _name, value, _labels in metrics.latencies)
+
+
+@pytest.mark.asyncio
 async def test_checkpoint_store_reuses_concurrent_idempotency_key(
     session_factory: object,
 ) -> None:
     """Concurrent saves with one step key should persist one checkpoint."""
     factory = typ.cast("async_sessionmaker[AsyncSession]", session_factory)
     key = "corr-storage:generation_orchestration:execute:action-2:0"
-    first = WorkflowCheckpoint(
-        checkpoint_id=str(uuid.uuid4()),
-        workflow_id="corr-storage",
-        workflow_type="generation_orchestration",
-        step_name="execute",
-        idempotency_key=key,
-        payload={"planner_result": {}},
-    )
-    duplicate = WorkflowCheckpoint(
-        checkpoint_id=str(uuid.uuid4()),
-        workflow_id="corr-storage",
-        workflow_type="generation_orchestration",
-        step_name="execute",
-        idempotency_key=key,
-        payload={"planner_result": {}},
-    )
+    first = _checkpoint(checkpoint_id=str(uuid.uuid4()), idempotency_key=key)
+    duplicate = _checkpoint(checkpoint_id=str(uuid.uuid4()), idempotency_key=key)
 
-    async def save_checkpoint(
-        checkpoint: WorkflowCheckpoint,
-    ) -> WorkflowCheckpoint:
+    async def save_checkpoint(checkpoint: WorkflowCheckpoint) -> WorkflowCheckpoint:
         async with SqlAlchemyUnitOfWork(factory) as uow:
             stored = await uow.workflow_checkpoints.save_or_reuse(checkpoint)
             await uow.commit()

--- a/tests/canonical_storage/test_workflow_checkpoints.py
+++ b/tests/canonical_storage/test_workflow_checkpoints.py
@@ -1,7 +1,12 @@
-"""SQLAlchemy checkpoint adapter tests."""
+"""Checkpoint adapter persistence and transaction contract tests.
+
+These tests exercise `SqlAlchemyWorkflowCheckpointStore` through
+`SqlAlchemyUnitOfWork.workflow_checkpoints`. They cover idempotent checkpoint
+creation, concurrent save convergence, resume commit and rollback semantics,
+and the atomicity guarantees expected by orchestration suspend/resume paths.
+"""
 
 import asyncio
-import string
 import typing as typ
 import uuid
 
@@ -39,11 +44,6 @@ def _checkpoint(
     )
 
 
-_idempotency_key_suffixes = st.text(
-    alphabet=string.ascii_letters + string.digits + "-_:",
-    min_size=1,
-    max_size=48,
-)
 _short_delays = st.sampled_from((0.0, 0.001, 0.005))
 
 
@@ -206,7 +206,6 @@ async def test_checkpoint_store_mark_resumed_status(
 
 @pytest.mark.asyncio
 @given(
-    key_suffix=_idempotency_key_suffixes,
     first_delay=_short_delays,
     second_delay=_short_delays,
 )
@@ -217,13 +216,12 @@ async def test_checkpoint_store_mark_resumed_status(
 )
 async def test_checkpoint_store_concurrent_idempotency_property(
     session_factory: object,
-    key_suffix: str,
     first_delay: float,
     second_delay: float,
 ) -> None:
     """Property: racing saves for one idempotency key persist one checkpoint."""
     factory = typ.cast("async_sessionmaker[AsyncSession]", session_factory)
-    key = f"prop:{uuid.uuid4()}:{key_suffix}"
+    key = f"prop:{uuid.uuid4()}:concurrent"
     first = _checkpoint(checkpoint_id=str(uuid.uuid4()), idempotency_key=key)
     duplicate = _checkpoint(checkpoint_id=str(uuid.uuid4()), idempotency_key=key)
 
@@ -256,7 +254,6 @@ async def test_checkpoint_store_concurrent_idempotency_property(
 
 @pytest.mark.asyncio
 @given(
-    key_suffix=_idempotency_key_suffixes,
     resume_mode=st.sampled_from(("commit", "rollback")),
 )
 @settings(
@@ -266,12 +263,11 @@ async def test_checkpoint_store_concurrent_idempotency_property(
 )
 async def test_checkpoint_store_resume_atomicity_property(
     session_factory: object,
-    key_suffix: str,
     resume_mode: str,
 ) -> None:
     """Property: rollback leaves a resume marker retryable; commit persists it."""
     factory = typ.cast("async_sessionmaker[AsyncSession]", session_factory)
-    checkpoint = _checkpoint(idempotency_key=f"prop:{uuid.uuid4()}:{key_suffix}")
+    checkpoint = _checkpoint(idempotency_key=f"prop:{uuid.uuid4()}:resume")
     expected_status = "resumed" if resume_mode == "commit" else "suspended"
 
     async with SqlAlchemyUnitOfWork(factory) as uow:

--- a/tests/canonical_storage/test_workflow_checkpoints.py
+++ b/tests/canonical_storage/test_workflow_checkpoints.py
@@ -1,11 +1,13 @@
 """SQLAlchemy checkpoint adapter tests."""
 
+import asyncio
 import typing as typ
 import uuid
 
 import pytest
+import sqlalchemy as sa
 
-from episodic.canonical.storage import SqlAlchemyUnitOfWork
+from episodic.canonical.storage import SqlAlchemyUnitOfWork, WorkflowCheckpointRecord
 from episodic.orchestration import WorkflowCheckpoint
 
 if typ.TYPE_CHECKING:
@@ -93,6 +95,60 @@ async def test_checkpoint_store_reuses_idempotency_key(
 
 
 @pytest.mark.asyncio
+async def test_checkpoint_store_reuses_concurrent_idempotency_key(
+    session_factory: object,
+) -> None:
+    """Concurrent saves with one step key should persist one checkpoint."""
+    factory = typ.cast("async_sessionmaker[AsyncSession]", session_factory)
+    key = "corr-storage:generation_orchestration:execute:action-2:0"
+    first = WorkflowCheckpoint(
+        checkpoint_id=str(uuid.uuid4()),
+        workflow_id="corr-storage",
+        workflow_type="generation_orchestration",
+        step_name="execute",
+        idempotency_key=key,
+        payload={"planner_result": {}},
+    )
+    duplicate = WorkflowCheckpoint(
+        checkpoint_id=str(uuid.uuid4()),
+        workflow_id="corr-storage",
+        workflow_type="generation_orchestration",
+        step_name="execute",
+        idempotency_key=key,
+        payload={"planner_result": {}},
+    )
+
+    async def save_checkpoint(
+        checkpoint: WorkflowCheckpoint,
+    ) -> WorkflowCheckpoint:
+        async with SqlAlchemyUnitOfWork(factory) as uow:
+            stored = await uow.workflow_checkpoints.save_or_reuse(checkpoint)
+            await uow.commit()
+            return stored
+
+    stored_first, stored_second = await asyncio.gather(
+        save_checkpoint(first),
+        save_checkpoint(duplicate),
+    )
+
+    async with SqlAlchemyUnitOfWork(factory) as uow:
+        persisted = await uow.workflow_checkpoints.get_by_idempotency_key(key)
+
+    async with factory() as session:
+        persisted_count = await session.scalar(
+            sa
+            .select(sa.func.count())
+            .select_from(WorkflowCheckpointRecord)
+            .where(WorkflowCheckpointRecord.idempotency_key == key)
+        )
+
+    assert stored_second.checkpoint_id == stored_first.checkpoint_id
+    assert persisted is not None
+    assert persisted.checkpoint_id == stored_first.checkpoint_id
+    assert persisted_count == 1
+
+
+@pytest.mark.asyncio
 async def test_checkpoint_store_marks_checkpoint_resumed(
     session_factory: object,
 ) -> None:
@@ -111,6 +167,30 @@ async def test_checkpoint_store_marks_checkpoint_resumed(
     assert resumed.status == "resumed"
     assert fetched is not None
     assert fetched.status == "resumed"
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_store_mark_resumed_rollback_leaves_suspended(
+    session_factory: object,
+) -> None:
+    """Rolled-back resume markers should leave checkpoints retryable."""
+    factory = typ.cast("async_sessionmaker[AsyncSession]", session_factory)
+    checkpoint = _checkpoint()
+
+    async with SqlAlchemyUnitOfWork(factory) as uow:
+        stored = await uow.workflow_checkpoints.save_or_reuse(checkpoint)
+        await uow.commit()
+
+    async with SqlAlchemyUnitOfWork(factory) as uow:
+        resumed = await uow.workflow_checkpoints.mark_resumed(stored.checkpoint_id)
+        await uow.rollback()
+
+    async with SqlAlchemyUnitOfWork(factory) as uow:
+        fetched = await uow.workflow_checkpoints.get(stored.checkpoint_id)
+
+    assert resumed.status == "resumed"
+    assert fetched is not None
+    assert fetched.status == "suspended"
 
 
 @pytest.mark.asyncio

--- a/tests/canonical_storage/test_workflow_checkpoints.py
+++ b/tests/canonical_storage/test_workflow_checkpoints.py
@@ -1,11 +1,14 @@
 """SQLAlchemy checkpoint adapter tests."""
 
 import asyncio
+import string
 import typing as typ
 import uuid
 
+import hypothesis.strategies as st
 import pytest
 import sqlalchemy as sa
+from hypothesis import HealthCheck, given, settings
 
 from episodic.canonical.storage import SqlAlchemyUnitOfWork, WorkflowCheckpointRecord
 from episodic.orchestration import WorkflowCheckpoint
@@ -14,19 +17,34 @@ if typ.TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 
-def _checkpoint(*, checkpoint_id: str | None = None) -> WorkflowCheckpoint:
+def _checkpoint(
+    *,
+    checkpoint_id: str | None = None,
+    idempotency_key: str | None = None,
+) -> WorkflowCheckpoint:
     """Return a deterministic checkpoint fixture."""
     return WorkflowCheckpoint(
         checkpoint_id=checkpoint_id or str(uuid.uuid4()),
         workflow_id="corr-storage",
         workflow_type="generation_orchestration",
         step_name="execute",
-        idempotency_key="corr-storage:generation_orchestration:execute:action-1:0",
+        idempotency_key=(
+            idempotency_key
+            or "corr-storage:generation_orchestration:execute:action-1:0"
+        ),
         payload={
             "request": {"correlation_id": "corr-storage"},
             "planner_result": {"plan": {"steps": []}},
         },
     )
+
+
+_idempotency_key_suffixes = st.text(
+    alphabet=string.ascii_letters + string.digits + "-_:",
+    min_size=1,
+    max_size=48,
+)
+_short_delays = st.sampled_from((0.0, 0.001, 0.005))
 
 
 @pytest.mark.asyncio
@@ -150,20 +168,21 @@ async def test_checkpoint_store_reuses_concurrent_idempotency_key(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("commit_resume", "expected_fetched_status"),
+    ("resume_mode", "expected_fetched_status"),
     [
-        (True, "resumed"),
-        (False, "suspended"),
+        ("commit", "resumed"),
+        ("rollback", "suspended"),
     ],
     ids=["commit", "rollback"],
 )
 async def test_checkpoint_store_mark_resumed_status(
     session_factory: object,
-    commit_resume: bool,  # noqa: FBT001
+    resume_mode: str,
     expected_fetched_status: str,
 ) -> None:
     """mark_resumed persists status on commit and leaves it suspended on rollback."""
     factory = typ.cast("async_sessionmaker[AsyncSession]", session_factory)
+    commit_resume = resume_mode == "commit"
     checkpoint = _checkpoint()
 
     async with SqlAlchemyUnitOfWork(factory) as uow:
@@ -183,6 +202,95 @@ async def test_checkpoint_store_mark_resumed_status(
     assert resumed.status == "resumed"
     assert fetched is not None
     assert fetched.status == expected_fetched_status
+
+
+@pytest.mark.asyncio
+@given(
+    key_suffix=_idempotency_key_suffixes,
+    first_delay=_short_delays,
+    second_delay=_short_delays,
+)
+@settings(
+    deadline=None,
+    max_examples=10,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+async def test_checkpoint_store_concurrent_idempotency_property(
+    session_factory: object,
+    key_suffix: str,
+    first_delay: float,
+    second_delay: float,
+) -> None:
+    """Property: racing saves for one idempotency key persist one checkpoint."""
+    factory = typ.cast("async_sessionmaker[AsyncSession]", session_factory)
+    key = f"prop:{uuid.uuid4()}:{key_suffix}"
+    first = _checkpoint(checkpoint_id=str(uuid.uuid4()), idempotency_key=key)
+    duplicate = _checkpoint(checkpoint_id=str(uuid.uuid4()), idempotency_key=key)
+
+    async def save_checkpoint(
+        checkpoint: WorkflowCheckpoint,
+        delay: float,
+    ) -> WorkflowCheckpoint:
+        await asyncio.sleep(delay)
+        async with SqlAlchemyUnitOfWork(factory) as uow:
+            stored = await uow.workflow_checkpoints.save_or_reuse(checkpoint)
+            await uow.commit()
+            return stored
+
+    stored_first, stored_second = await asyncio.gather(
+        save_checkpoint(first, first_delay),
+        save_checkpoint(duplicate, second_delay),
+    )
+
+    async with factory() as session:
+        persisted_count = await session.scalar(
+            sa
+            .select(sa.func.count())
+            .select_from(WorkflowCheckpointRecord)
+            .where(WorkflowCheckpointRecord.idempotency_key == key)
+        )
+
+    assert stored_second.checkpoint_id == stored_first.checkpoint_id
+    assert persisted_count == 1
+
+
+@pytest.mark.asyncio
+@given(
+    key_suffix=_idempotency_key_suffixes,
+    resume_mode=st.sampled_from(("commit", "rollback")),
+)
+@settings(
+    deadline=None,
+    max_examples=10,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+async def test_checkpoint_store_resume_atomicity_property(
+    session_factory: object,
+    key_suffix: str,
+    resume_mode: str,
+) -> None:
+    """Property: rollback leaves a resume marker retryable; commit persists it."""
+    factory = typ.cast("async_sessionmaker[AsyncSession]", session_factory)
+    checkpoint = _checkpoint(idempotency_key=f"prop:{uuid.uuid4()}:{key_suffix}")
+    expected_status = "resumed" if resume_mode == "commit" else "suspended"
+
+    async with SqlAlchemyUnitOfWork(factory) as uow:
+        stored = await uow.workflow_checkpoints.save_or_reuse(checkpoint)
+        await uow.commit()
+
+    async with SqlAlchemyUnitOfWork(factory) as uow:
+        resumed = await uow.workflow_checkpoints.mark_resumed(stored.checkpoint_id)
+        if resume_mode == "commit":
+            await uow.commit()
+        else:
+            await uow.rollback()
+
+    async with SqlAlchemyUnitOfWork(factory) as uow:
+        fetched = await uow.workflow_checkpoints.get(stored.checkpoint_id)
+
+    assert resumed.status == "resumed"
+    assert fetched is not None
+    assert fetched.status == expected_status
 
 
 @pytest.mark.asyncio

--- a/tests/canonical_storage/test_workflow_checkpoints.py
+++ b/tests/canonical_storage/test_workflow_checkpoints.py
@@ -149,31 +149,20 @@ async def test_checkpoint_store_reuses_concurrent_idempotency_key(
 
 
 @pytest.mark.asyncio
-async def test_checkpoint_store_marks_checkpoint_resumed(
+@pytest.mark.parametrize(
+    ("commit_resume", "expected_fetched_status"),
+    [
+        (True, "resumed"),
+        (False, "suspended"),
+    ],
+    ids=["commit", "rollback"],
+)
+async def test_checkpoint_store_mark_resumed_status(
     session_factory: object,
+    commit_resume: bool,  # noqa: FBT001
+    expected_fetched_status: str,
 ) -> None:
-    """`mark_resumed` should persist the resumed checkpoint status."""
-    factory = typ.cast("async_sessionmaker[AsyncSession]", session_factory)
-    checkpoint = _checkpoint()
-
-    async with SqlAlchemyUnitOfWork(factory) as uow:
-        stored = await uow.workflow_checkpoints.save_or_reuse(checkpoint)
-        resumed = await uow.workflow_checkpoints.mark_resumed(stored.checkpoint_id)
-        await uow.commit()
-
-    async with SqlAlchemyUnitOfWork(factory) as uow:
-        fetched = await uow.workflow_checkpoints.get(stored.checkpoint_id)
-
-    assert resumed.status == "resumed"
-    assert fetched is not None
-    assert fetched.status == "resumed"
-
-
-@pytest.mark.asyncio
-async def test_checkpoint_store_mark_resumed_rollback_leaves_suspended(
-    session_factory: object,
-) -> None:
-    """Rolled-back resume markers should leave checkpoints retryable."""
+    """mark_resumed persists status on commit and leaves it suspended on rollback."""
     factory = typ.cast("async_sessionmaker[AsyncSession]", session_factory)
     checkpoint = _checkpoint()
 
@@ -183,14 +172,17 @@ async def test_checkpoint_store_mark_resumed_rollback_leaves_suspended(
 
     async with SqlAlchemyUnitOfWork(factory) as uow:
         resumed = await uow.workflow_checkpoints.mark_resumed(stored.checkpoint_id)
-        await uow.rollback()
+        if commit_resume:
+            await uow.commit()
+        else:
+            await uow.rollback()
 
     async with SqlAlchemyUnitOfWork(factory) as uow:
         fetched = await uow.workflow_checkpoints.get(stored.checkpoint_id)
 
     assert resumed.status == "resumed"
     assert fetched is not None
-    assert fetched.status == "suspended"
+    assert fetched.status == expected_fetched_status
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This branch documents the checkpoint atomicity boundaries for roadmap task (2.4.2) and adds integration coverage for issue #91. It verifies that concurrent SQLAlchemy checkpoint saves converge on one idempotency-key winner, and that a rolled-back resume marker leaves the checkpoint suspended for retry.

Closes #91.

Roadmap task: (2.4.2)

## Review walkthrough

- Start with [episodic/canonical/storage/workflow_checkpoints.py](https://github.com/leynos/episodic/blob/issue-91-atomicity-boundaries-for-checkpoint-suspend-resume-ops/episodic/canonical/storage/workflow_checkpoints.py) to review the `save_or_reuse` and `mark_resumed` transaction-boundary documentation.
- Then review [episodic/orchestration/langgraph.py](https://github.com/leynos/episodic/blob/issue-91-atomicity-boundaries-for-checkpoint-suspend-resume-ops/episodic/orchestration/langgraph.py) for the suspend and resume partial-failure guidance.
- Finish with [tests/canonical_storage/test_workflow_checkpoints.py](https://github.com/leynos/episodic/blob/issue-91-atomicity-boundaries-for-checkpoint-suspend-resume-ops/tests/canonical_storage/test_workflow_checkpoints.py) for the concurrent `save_or_reuse` and rollback recovery tests.

## Validation

- `uv run pytest -v tests/canonical_storage/test_workflow_checkpoints.py`: passed, 8 tests.
- `make check-fmt`: passed.
- `make lint`: passed.
- `make typecheck`: passed.
- `make test`: completed with the new checkpoint tests passing, but two unrelated async fixture setup timeouts occurred: `tests/canonical_storage/test_tei_headers.py::test_tei_header_get_remains_compatible_with_legacy_uncompressed_rows` and `tests/test_binding_resolution.py::test_resolve_bindings_returns_default_binding_when_no_episode_context`.
- `uv run pytest -v tests/canonical_storage/test_tei_headers.py::test_tei_header_get_remains_compatible_with_legacy_uncompressed_rows tests/test_binding_resolution.py::test_resolve_bindings_returns_default_binding_when_no_episode_context`: passed, 2 tests.

## Summary by Sourcery

Document checkpoint atomicity and partial-failure boundaries for suspend/resume operations and extend tests to cover concurrent saves and rollback behavior.

Enhancements:
- Clarify transactional and durability semantics of `save_or_reuse` and `mark_resumed` in the SQLAlchemy checkpoint adapter.
- Document suspend and resume behavior in the orchestration layer, including idempotency and partial-failure handling.

Tests:
- Add integration tests ensuring concurrent checkpoint saves with the same idempotency key converge on a single persisted checkpoint.
- Add tests verifying that rolled-back resume operations leave checkpoints suspended and safe for retry.