### PR TITLE
Document Celery subinterpreter task seams (#66)

### DIFF
--- a/docs/adr/adr-003-celery-worker-scaffold.md
+++ b/docs/adr/adr-003-celery-worker-scaffold.md
@@ -86,6 +86,11 @@ story across developer machines and CI runners.
   process fan-out and the repository's opt-in interpreter-pool path for
   selected pure-Python workloads, with the enabling knobs documented in the
   same place.
+- CPU tasks running in `prefork` workers may optionally delegate inner fan-out
+  to `InterpreterPoolCpuTaskExecutor`, enabled with
+  `EPISODIC_USE_INTERPRETER_POOL`, dispatched with
+  `EPISODIC_INTERPRETER_POOL_MIN_ITEMS`, and capped with
+  `EPISODIC_INTERPRETER_POOL_MAX_WORKERS`.
 - Future roadmap items can add Celery tasks by extending typed dependency seams
   rather than introducing ad hoc globals.
 
@@ -103,7 +108,9 @@ story across developer machines and CI runners.
 ## References
 
 - [docs/execplans/1-5-2-scaffold-celery-workers-with-rabbit-mq-integration.md](../execplans/1-5-2-scaffold-celery-workers-with-rabbit-mq-integration.md)
+- [docs/execplans/upgrade-python-to-3-14-adopt-concurrent-interpreters.md](../execplans/upgrade-python-to-3-14-adopt-concurrent-interpreters.md)
 - [docs/episodic-podcast-generation-system-design.md](../episodic-podcast-generation-system-design.md)
+- [episodic/concurrent_interpreters.py](../../episodic/concurrent_interpreters.py)
 - [episodic/worker/topology.py](../../episodic/worker/topology.py)
 - [episodic/worker/runtime.py](../../episodic/worker/runtime.py)
 - [episodic/worker/tasks.py](../../episodic/worker/tasks.py)

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -49,7 +49,7 @@ The target runs the Hecate architecture import-boundary checker, Ruff, and a
 focused Pylint 4 pass. The Pylint pass is invoked through
 `uv tool run --python pypy` with the pinned `pylint-pypy-shim` wrapper from
 [github.com/leynos/pylint-pypy-shim](https://github.com/leynos/pylint-pypy-shim).
- That wrapper installs the PyPy-specific Astroid compatibility patch before
+That wrapper installs the PyPy-specific Astroid compatibility patch before
 delegating to Pylint.
 
 Pylint's message selection is allow-listed in `pyproject.toml` with
@@ -237,10 +237,14 @@ When adding new worker tasks:
   lifetime and cleanup; inline executors do not need shutdown, while
   interpreter-pool executors must be shut down when their fan-out operation or
   explicit worker-scoped owner is finished.
-- Export CPU-task executor metrics through `CpuTaskExecutorMetricsPort`; it is
-  the shared metrics port for executor selection, interpreter-pool lifecycle,
-  map item count, and shutdown-latency collection. Keep labels bounded to
-  low-cardinality outcome and reason values.
+- Export CPU-task executor metrics through `CpuTaskExecutorMetricsPort`; it
+  extends the shared `BoundedValueMetricsPort` in `episodic/metrics_ports.py`
+  for executor selection, interpreter-pool lifecycle, map item count, and
+  shutdown-latency collection. Keep labels bounded to low-cardinality outcome
+  and reason values. Wire production backends through
+  `DefaultWeightingStrategy(metrics=...)` or by calling
+  `build_cpu_task_executor_from_environment(..., metrics=...)` directly at the
+  composition root.
 
 ## Database migrations
 
@@ -269,7 +273,7 @@ The `make check-migrations` target detects drift between the ORM models and the
 applied migration history. It starts an ephemeral Postgres via py-pglite,
 applies all Alembic migrations, and uses
 `alembic.autogenerate.compare_metadata()` to compare the migrated schema against
- `Base.metadata`. If they differ, the check exits non-zero and reports the
+`Base.metadata`. If they differ, the check exits non-zero and reports the
 discrepancies.
 
 Run it locally before committing model changes:
@@ -339,7 +343,7 @@ Key expectations:
   fixtures raise a clear error instead of silently skipping tests.
 - `make check-migrations` uses the same database technology, but a separate
   bootstrap path. `episodic/canonical/storage/migration_check.py` starts a plain
-   `PGliteManager`, creates an async SQLAlchemy engine from
+  `PGliteManager`, creates an async SQLAlchemy engine from
   `config.get_connection_string()`, applies Alembic migrations, and compares
   the migrated schema against `Base.metadata`.
 
@@ -387,7 +391,7 @@ The `SqlAlchemyUnitOfWork` manages transaction boundaries:
 
 Database-level constraints (unique slugs, foreign keys, and CHECK constraints
 such as the weight bound on source documents) are enforced by Postgres and raise
- `sqlalchemy.exc.IntegrityError` on violation.
+`sqlalchemy.exc.IntegrityError` on violation.
 
 ### Architecture enforcement
 
@@ -606,10 +610,11 @@ Pedante and Chrono are implemented in the `episodic/qa/` package.
 
 - `episodic/qa/chrono.py` contains `ChronoRuntimeEstimator`, typed
   request/result objects, estimator metadata, the deterministic local
-  spoken-runtime heuristic, `ChronoMetricsPort`, and `ChronoClockPort`. The
-  module delegates TEI P5 parsing and spoken-text extraction to
-  `tei-rapporteur`; it must not add a separate XML parser or local TEI
-  traversal path.
+  spoken-runtime heuristic, `ChronoMetricsPort`, and `ChronoClockPort`.
+  `ChronoMetricsPort` extends the shared `BoundedMetricsPort` in
+  `episodic/metrics_ports.py`. The module delegates TEI P5 parsing and
+  spoken-text extraction to `tei-rapporteur`; it must not add a separate XML
+  parser or local TEI traversal path.
 - `episodic/qa/chrono_langgraph.py` contains the in-process LangGraph seam for
   running Chrono as a QA graph node without attaching Large Language Model
   (LLM) usage metadata.
@@ -786,7 +791,7 @@ async def enrich(llm_port, script_tei_xml: str) -> str:
   `<div type="chapters">` element into the TEI body using the representation
   defined by
   [`adr-008-chapter-marker-tei-representation.md`](adr/adr-008-chapter-marker-tei-representation.md).
-   The `<list>` contains one `<item>` per chapter, `<label>` carries the title,
+  The `<list>` contains one `<item>` per chapter, `<label>` carries the title,
   `@n` stores the required start time, and `@corresp` stores an optional source
   locator. Optional DTO `end` and `duration` values are validated but not
   emitted into TEI until the TEI tooling exposes supported attributes.
@@ -963,13 +968,12 @@ stored planner-result payloads.
 ### Testing the orchestration slice
 
 - Unit coverage for DTO validation, planner behaviour, orchestration dispatch,
-  show-notes execution, guest-bio execution, and properties lives in the
-  focused `tests/test_orchestration_*.py`, `tests/test_show_notes_executor.py`,
-  and `tests/test_guest_bios_executor.py` modules.
+  show-notes execution, guest-bio execution, and properties lives in the focused
+  `tests/test_orchestration_*.py`, `tests/test_show_notes_executor.py`, and
+  `tests/test_guest_bios_executor.py` modules.
 - Issue `#72` property coverage lives in
   `tests/test_orchestration_properties.py` and the focused sibling modules for
-  config/model-tier boundaries, planner format errors, and LangGraph
-  invariants.
+  config/model-tier boundaries, planner format errors, and LangGraph invariants.
 - `tests/test_generation_orchestration_snapshots.py` pins planner format-error
   messages and orchestration artefacts with Syrupy snapshots.
 - LangGraph seam coverage lives in
@@ -1037,7 +1041,9 @@ testing and initial deployments:
   coefficients from the series configuration or defaults. The configuration
   dictionary may contain a `"weighting"` key with `"quality_coefficient"`
   (default 0.5), `"freshness_coefficient"` (default 0.3), and
-  `"reliability_coefficient"` (default 0.2).
+  `"reliability_coefficient"` (default 0.2). Pass optional `metrics=` when
+  constructing the strategy so production deployments can wire
+  `CpuTaskExecutorMetricsPort` through to the environment-built executor.
 - `HighestWeightConflictResolver` — selects the highest-weighted source as
   canonical; all others are rejected with provenance preserved.
 
@@ -1140,9 +1146,9 @@ def configure_logging(
 ```
 
 `level` is matched case-insensitively against `LogLevel` members. Returns a
-`tuple[LogLevel, bool]` — the normalized effective level and a flag that is `True`
-when the default (`INFO`) was substituted because the input was absent or
-unrecognized. The first element is always a `LogLevel` member; because
+`tuple[LogLevel, bool]` — the normalized effective level and a flag that is
+`True` when the default (`INFO`) was substituted because the input was absent
+or unrecognized. The first element is always a `LogLevel` member; because
 `LogLevel` is a `StrEnum`, those values are also `str` instances. Passing
 `"WARN"` (any case) normalizes to `WARNING` and emits a `DeprecationWarning`.
 The `force` parameter is forwarded directly to `femtologging.basicConfig`.

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -230,13 +230,17 @@ When adding new worker tasks:
   ```
 
   `EPISODIC_USE_INTERPRETER_POOL=1` enables `InterpreterPoolCpuTaskExecutor`
-  when the injected capability check reports support, and
+  when the runtime supports interpreter pools, and
   `EPISODIC_INTERPRETER_POOL_MAX_WORKERS` caps its worker count. Keep
   `EPISODIC_INTERPRETER_POOL_MIN_ITEMS` as task-level fan-out policy, not
   Celery pool configuration. The task-level owner is responsible for executor
   lifetime and cleanup; inline executors do not need shutdown, while
   interpreter-pool executors must be shut down when their fan-out operation or
   explicit worker-scoped owner is finished.
+- Export CPU-task executor metrics through `CpuTaskExecutorMetricsPort`; it is
+  the shared metrics port for executor selection, interpreter-pool lifecycle,
+  map item count, and shutdown-latency collection. Keep labels bounded to
+  low-cardinality outcome and reason values.
 
 ## Database migrations
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -210,6 +210,31 @@ When adding new worker tasks:
   adapters directly into task code.
 - Extend `SCAFFOLD_TASK_WORKLOADS` and the topology-backed routing metadata, so
   the new task's queue assignment remains explicit.
+- For CPU-bound tasks on `episodic.cpu` that can split pure-Python inner work
+  into independent items, build the task-level executor from the environment:
+
+  ```python
+  from episodic.concurrent_interpreters import (
+      build_cpu_task_executor_from_environment,
+  )
+
+  executor = build_cpu_task_executor_from_environment()
+  try:
+      results = await executor.map_ordered(pure_python_fn, items)
+  finally:
+      shutdown = getattr(executor, "shutdown", None)
+      if shutdown is not None:
+          shutdown()
+  ```
+
+  `EPISODIC_USE_INTERPRETER_POOL=1` enables `InterpreterPoolCpuTaskExecutor`
+  when the Python runtime supports it, and
+  `EPISODIC_INTERPRETER_POOL_MAX_WORKERS` caps its worker count. Keep
+  `EPISODIC_INTERPRETER_POOL_MIN_ITEMS` as task-level fan-out policy, not
+  Celery pool configuration. The task-level owner is responsible for executor
+  lifetime and cleanup; inline executors do not need shutdown, while
+  interpreter-pool executors must be shut down when their fan-out operation or
+  explicit worker-scoped owner is finished.
 
 ## Database migrations
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -230,7 +230,7 @@ When adding new worker tasks:
   ```
 
   `EPISODIC_USE_INTERPRETER_POOL=1` enables `InterpreterPoolCpuTaskExecutor`
-  when the injected capability detector reports support, and
+  when the injected capability check reports support, and
   `EPISODIC_INTERPRETER_POOL_MAX_WORKERS` caps its worker count. Keep
   `EPISODIC_INTERPRETER_POOL_MIN_ITEMS` as task-level fan-out policy, not
   Celery pool configuration. The task-level owner is responsible for executor

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -214,11 +214,13 @@ When adding new worker tasks:
   into independent items, build the task-level executor from the environment:
 
   ```python
+  import os
+
   from episodic.concurrent_interpreters import (
       build_cpu_task_executor_from_environment,
   )
 
-  executor = build_cpu_task_executor_from_environment()
+  executor = build_cpu_task_executor_from_environment(os.environ)
   try:
       results = await executor.map_ordered(pure_python_fn, items)
   finally:
@@ -228,7 +230,7 @@ When adding new worker tasks:
   ```
 
   `EPISODIC_USE_INTERPRETER_POOL=1` enables `InterpreterPoolCpuTaskExecutor`
-  when the Python runtime supports it, and
+  when the injected capability detector reports support, and
   `EPISODIC_INTERPRETER_POOL_MAX_WORKERS` caps its worker count. Keep
   `EPISODIC_INTERPRETER_POOL_MIN_ITEMS` as task-level fan-out policy, not
   Celery pool configuration. The task-level owner is responsible for executor

--- a/docs/episodic-podcast-generation-system-design.md
+++ b/docs/episodic-podcast-generation-system-design.md
@@ -417,13 +417,13 @@ The following rules are normative for LangGraph nodes and Celery tasks:
 
 #### Speech synthesis contracts
 
-The speech synthesis boundary separates authorial data from provider
-parameters. `TTSPort` remains the single-speaker segment renderer used for
-ordinary narration and partial regeneration. `DialogueSpeechPort` is a separate
-optional port for providers that render multiple speaker turns as one
-conversation-aware artefact. This split preserves editability for per-segment
-stems whilst allowing providers such as Inworld Realtime or ElevenLabs
-text-to-dialogue to use conversational context when the series profile opts in.
+The speech synthesis boundary separates authorial data from provider parameters.
+`TTSPort` remains the single-speaker segment renderer used for ordinary
+narration and partial regeneration. `DialogueSpeechPort` is a separate optional
+port for providers that render multiple speaker turns as one conversation-aware
+artefact. This split preserves editability for per-segment stems whilst
+allowing providers such as Inworld Realtime or ElevenLabs text-to-dialogue to
+use conversational context when the series profile opts in.
 
 Every speech request is derived from canonical TEI P5:
 
@@ -491,11 +491,11 @@ per-segment stems for workflows that require surgical partial regeneration.
   provider calls so renders remain correlated end to end, with spans around
   pronunciation lookup and provider dispatch.
 - Classify failures as transport, provider, capability, pronunciation
-  resolution, validation, or post-render so dashboards and alerts remain
-  stable across vendors.
+  resolution, validation, or post-render so dashboards and alerts remain stable
+  across vendors.
 - Alert on synthesis failures and capability mismatches using aggregate
-  metrics: page when the failure rate exceeds 5 percent over 15 minutes or
-  five consecutive renders fail, warn when repeated unsupported-capability
+  metrics: page when the failure rate exceeds 5 percent over 15 minutes or five
+  consecutive renders fail, warn when repeated unsupported-capability
   diagnostics reach three in 30 minutes, and page when an approved
   pronunciation cannot be resolved.
 
@@ -549,10 +549,10 @@ erDiagram
   SPEECH_RENDER_REQUESTS ||--o{ SPEECH_RENDER_ARTIFACTS : produces
 ```
 
-_Caption: Speech synthesis entity relationships. Pronunciation entries have
-one or more realizations; voice personas and provider capabilities are selected
-for speech render requests; each speech render request produces one or more
-speech render artefacts._
+_Caption: Speech synthesis entity relationships. Pronunciation entries have one
+or more realizations; voice personas and provider capabilities are selected for
+speech render requests; each speech render request produces one or more speech
+render artefacts._
 
 #### Pronunciation repository
 
@@ -717,8 +717,8 @@ sequenceDiagram
     participant InlineCpuTaskExecutor
     participant InterpreterPoolCpuTaskExecutor
 
-    Caller->>DefaultWeightingStrategy: __init__(cpu_executor=None, min_parallel_items=None)
-    DefaultWeightingStrategy->>DefaultWeightingStrategy: build_cpu_task_executor_from_environment(os.environ)
+    Caller->>DefaultWeightingStrategy: __init__(cpu_executor=None, metrics=None, min_parallel_items=None)
+    DefaultWeightingStrategy->>DefaultWeightingStrategy: build_cpu_task_executor_from_environment(os.environ, metrics=metrics)
     DefaultWeightingStrategy-->>CpuTaskExecutor: selected executor instance
 
     Caller->>DefaultWeightingStrategy: compute_weights(sources, series_configuration)
@@ -874,8 +874,8 @@ ports, including optional
 adapters that expose tool catalogues. Skill-based tool loading narrows the
 available tool set per workflow, reducing context size and guiding model choice.
 
-Roadmap item `2.4.1` now ships the first narrow implementation of that design
-in `episodic/orchestration/`. `StructuredGenerationPlanner` calls `LLMPort` once
+Roadmap item `2.4.1` now ships the first narrow implementation of that design in
+`episodic/orchestration/`. `StructuredGenerationPlanner` calls `LLMPort` once
 to obtain strict JSON, parses it into a typed `ExecutionPlan`, and records the
 planning model separately from the execution model selected in
 `GenerationOrchestrationConfig`. `StructuredPlanningOrchestrator` then executes
@@ -1456,7 +1456,7 @@ Agentic workflow behaviour is configurable per series profile:
   reusable reference document, including hashes and author metadata.
 - `reference_document_bindings` links pinned reference revisions to a target
   context (series profile, episode template, or ingestion run), with an optional
-   `effective_from_episode_id` anchor for forward-only applicability.
+  `effective_from_episode_id` anchor for forward-only applicability.
 - `uploads` records file upload metadata, content hashes, content type, size
   limits, storage location, and idempotency keys before uploaded material is
   attached to ingestion jobs.
@@ -1542,7 +1542,7 @@ profile guidance changes mid-series, editors will add a new revision and will
 create a binding with `effective_from_episode_id`; that revision will apply
 from the anchor episode onwards until superseded. Ingestion workflows will
 resolve these bindings and will snapshot selected revisions into ingestion-bound
- `source_documents`, preserving reproducible TEI provenance while allowing
+`source_documents`, preserving reproducible TEI provenance while allowing
 independent document reuse across jobs.
 
 TEI header payloads include an `episodic_provenance` extension with

--- a/docs/episodic-podcast-generation-system-design.md
+++ b/docs/episodic-podcast-generation-system-design.md
@@ -718,7 +718,7 @@ sequenceDiagram
     participant InterpreterPoolCpuTaskExecutor
 
     Caller->>DefaultWeightingStrategy: __init__(cpu_executor=None, min_parallel_items=None)
-    DefaultWeightingStrategy->>DefaultWeightingStrategy: build_cpu_task_executor_from_environment()
+    DefaultWeightingStrategy->>DefaultWeightingStrategy: build_cpu_task_executor_from_environment(os.environ)
     DefaultWeightingStrategy-->>CpuTaskExecutor: selected executor instance
 
     Caller->>DefaultWeightingStrategy: compute_weights(sources, series_configuration)

--- a/docs/execplans/upgrade-python-to-3-14-adopt-concurrent-interpreters.md
+++ b/docs/execplans/upgrade-python-to-3-14-adopt-concurrent-interpreters.md
@@ -123,6 +123,10 @@ Delivered artefacts:
   `EPISODIC_INTERPRETER_POOL_MIN_ITEMS`.
 - Benchmark CLI added at `episodic/benchmarks/interpreters.py`.
 - User and architecture docs updated with feature-flag guidance.
+- PR `#99` resolved the Celery integration gap called out in `Surprises &
+  discoveries` for issue `#66`: CPU-bound Celery tasks now have documented
+  task-level guidance and tests showing how to call
+  `build_cpu_task_executor_from_environment()` from within an eager task body.
 
 Validation evidence:
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -282,6 +282,11 @@ Optional interpreter-pool flags:
 - `EPISODIC_INTERPRETER_POOL_MAX_WORKERS` caps the interpreter-pool worker
   count when that path is enabled.
 
+CPU-task executor metrics are exported through the shared
+`CpuTaskExecutorMetricsPort`. Deployments that wire a metrics backend through
+that port can collect executor selection, interpreter-pool lifecycle, map item
+count, and shutdown-latency signals with bounded labels.
+
 Current queue model:
 
 - `episodic.tasks` topic exchange

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -175,7 +175,7 @@ Reusable reference-document workflows currently support:
   Stale updates return `409 Conflict`.
 - Creating and listing immutable document revisions at
   `POST /v1/series-profiles/{profile_id}/reference-documents/{document_id}/revisions`
-   and
+  and
   `GET /v1/series-profiles/{profile_id}/reference-documents/{document_id}/revisions`.
 - Creating, listing, and fetching target bindings at
   `POST /v1/reference-bindings`, `GET /v1/reference-bindings`, and
@@ -283,9 +283,13 @@ Optional interpreter-pool flags:
   count when that path is enabled.
 
 CPU-task executor metrics are exported through the shared
-`CpuTaskExecutorMetricsPort`. Deployments that wire a metrics backend through
+`CpuTaskExecutorMetricsPort`, which extends `BoundedValueMetricsPort` in
+`episodic/metrics_ports.py`. Deployments that wire a metrics backend through
 that port can collect executor selection, interpreter-pool lifecycle, map item
-count, and shutdown-latency signals with bounded labels.
+count, and shutdown-latency signals with bounded labels. In ingestion
+pipelines, pass the same metrics sink to
+`DefaultWeightingStrategy(metrics=...)` so weighting fan-out records executor
+observability in production.
 
 Current queue model:
 

--- a/episodic/canonical/adapters/weighting.py
+++ b/episodic/canonical/adapters/weighting.py
@@ -129,7 +129,7 @@ class DefaultWeightingStrategy:
         self._cpu_executor = (
             cpu_executor
             if cpu_executor is not None
-            else build_cpu_task_executor_from_environment()
+            else build_cpu_task_executor_from_environment(os.environ)
         )
         if min_parallel_items is None:
             self._min_parallel_items = _parse_min_parallel_items(

--- a/episodic/canonical/adapters/weighting.py
+++ b/episodic/canonical/adapters/weighting.py
@@ -22,6 +22,7 @@ from episodic.canonical.adapters._coercion import coerce_float
 from episodic.canonical.ingestion import NormalizedSource, WeightingResult
 from episodic.concurrent_interpreters import (
     CpuTaskExecutor,
+    CpuTaskExecutorMetricsPort,
     build_cpu_task_executor_from_environment,
 )
 
@@ -118,6 +119,11 @@ class DefaultWeightingStrategy:
     Coefficients are read from the series configuration under the
     ``"weighting"`` key, falling back to defaults (quality=0.5, freshness=0.3,
     reliability=0.2) when absent. Results are clamped to [0, 1].
+
+    When ``cpu_executor`` is omitted, the strategy builds one from the process
+    environment and forwards optional ``metrics`` to
+    ``build_cpu_task_executor_from_environment`` so production deployments can
+    collect interpreter-pool observability at the composition root.
     """
 
     def __init__(
@@ -125,11 +131,29 @@ class DefaultWeightingStrategy:
         *,
         cpu_executor: CpuTaskExecutor | None = None,
         min_parallel_items: int | None = None,
+        metrics: CpuTaskExecutorMetricsPort | None = None,
     ) -> None:
+        """Initialise the weighting strategy.
+
+        Parameters
+        ----------
+        cpu_executor : CpuTaskExecutor | None
+            Optional executor override. When omitted, the strategy selects one
+            from the process environment.
+        min_parallel_items : int | None
+            Minimum source count before interpreter-backed dispatch is attempted.
+            ``None`` reads ``EPISODIC_INTERPRETER_POOL_MIN_ITEMS``.
+        metrics : CpuTaskExecutorMetricsPort | None
+            Metrics sink forwarded to the environment-built executor. Ignored
+            when ``cpu_executor`` is supplied explicitly.
+        """
         self._cpu_executor = (
             cpu_executor
             if cpu_executor is not None
-            else build_cpu_task_executor_from_environment(os.environ)
+            else build_cpu_task_executor_from_environment(
+                os.environ,
+                metrics=metrics,
+            )
         )
         if min_parallel_items is None:
             self._min_parallel_items = _parse_min_parallel_items(

--- a/episodic/concurrent_interpreters.py
+++ b/episodic/concurrent_interpreters.py
@@ -98,6 +98,15 @@ class InterpreterPoolCpuTaskExecutor(CpuTaskExecutor):
     ----------
     max_workers : int | None
         Optional explicit worker count for interpreter pool creation.
+
+    Notes
+    -----
+    Each instance owns its interpreter pool. Create the executor at the
+    boundary that owns the CPU fan-out operation, reuse it for the related
+    ``map_ordered()`` calls, and call ``shutdown()`` when that operation or
+    worker-scoped owner is finished. Lazy pool creation is protected by a
+    lock, but callers should still avoid sharing one executor as mutable global
+    state across unrelated task flows.
     """
 
     def __init__(
@@ -142,7 +151,14 @@ class InterpreterPoolCpuTaskExecutor(CpuTaskExecutor):
 
 
 def build_cpu_task_executor_from_environment() -> CpuTaskExecutor:
-    """Select CPU-task adapter based on feature flag and runtime capability."""
+    """Select CPU-task adapter based on feature flag and runtime capability.
+
+    The returned object is owned by the caller. Inline executors have no
+    resources to release; interpreter-pool executors should be shut down by the
+    task-level owner after the fan-out work completes, commonly with
+    ``try/finally`` and ``getattr(executor, "shutdown", None)`` so the same
+    code works for both adapters.
+    """
     if not _flag_enabled(os.getenv(_INTERPRETER_POOL_FEATURE_FLAG)):
         return InlineCpuTaskExecutor()
     if not interpreter_pool_supported():

--- a/episodic/concurrent_interpreters.py
+++ b/episodic/concurrent_interpreters.py
@@ -10,8 +10,11 @@ from __future__ import annotations
 import asyncio
 import collections.abc as cabc
 import concurrent.futures as cf
+import dataclasses as dc
+import logging
 import os
 import threading
+import time
 import typing as typ
 
 _InputT = typ.TypeVar("_InputT")
@@ -20,7 +23,72 @@ InterpreterPoolCapability = cabc.Callable[[], bool]
 
 _INTERPRETER_POOL_FEATURE_FLAG = "EPISODIC_USE_INTERPRETER_POOL"
 _INTERPRETER_POOL_MAX_WORKERS_ENV = "EPISODIC_INTERPRETER_POOL_MAX_WORKERS"
+_METRIC_MAP_CALLS = "interpreter_pool.map.calls"
+_METRIC_MAP_ITEMS = "interpreter_pool.map.items"
+_METRIC_SHUTDOWN_LATENCY_MS = "interpreter_pool.shutdown.latency_ms"
 _TRUTHY_VALUES = frozenset({"1", "on", "true", "yes"})
+_log = logging.getLogger(__name__)
+
+
+class CpuTaskExecutorMetricsPort(typ.Protocol):
+    """Bounded-cardinality metrics sink for CPU task executors."""
+
+    def increment_counter(
+        self,
+        name: str,
+        *,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Increment a bounded-cardinality counter."""
+
+    def observe_latency_ms(
+        self,
+        name: str,
+        value: float,
+        *,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Observe a latency or gauge-like measurement in milliseconds."""
+
+
+class CpuTaskExecutorClockPort(typ.Protocol):
+    """Monotonic clock used to measure executor lifecycle timings."""
+
+    def monotonic_seconds(self) -> float:
+        """Return a monotonic timestamp in seconds."""
+
+
+@dc.dataclass(frozen=True, slots=True)
+class _NoopCpuTaskExecutorMetrics:
+    """Default metrics sink used when no backend is wired."""
+
+    def increment_counter(
+        self,
+        name: str,
+        *,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Ignore counter increments."""
+
+    def observe_latency_ms(
+        self,
+        name: str,
+        value: float,
+        *,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Ignore latency observations."""
+
+
+@dc.dataclass(frozen=True, slots=True)
+class _PerfCounterCpuTaskExecutorClock:
+    """Production executor clock backed by Python's monotonic perf counter."""
+
+    read_seconds: cabc.Callable[[], float] = time.perf_counter
+
+    def monotonic_seconds(self) -> float:
+        """Return the current monotonic timestamp in seconds."""
+        return self.read_seconds()
 
 
 class CpuTaskExecutor(typ.Protocol):
@@ -112,11 +180,17 @@ class InterpreterPoolCpuTaskExecutor(CpuTaskExecutor):
         self,
         *,
         max_workers: int | None = None,
+        metrics: CpuTaskExecutorMetricsPort | None = None,
+        clock: CpuTaskExecutorClockPort | None = None,
     ) -> None:
         self._max_workers = max_workers
         self._executor: cf.Executor | None = None
         self._executor_lock = threading.RLock()
         self._is_shutdown = False
+        self._metrics = (
+            metrics if metrics is not None else _NoopCpuTaskExecutorMetrics()
+        )
+        self._clock = clock if clock is not None else _PerfCounterCpuTaskExecutorClock()
 
     def _get_executor(self) -> cf.Executor:
         """Return the interpreter pool, creating it on first use."""
@@ -125,17 +199,50 @@ class InterpreterPoolCpuTaskExecutor(CpuTaskExecutor):
                 msg = "InterpreterPoolCpuTaskExecutor has been shut down."
                 raise RuntimeError(msg)
             if self._executor is None:
-                self._executor = _create_interpreter_pool_executor(self._max_workers)
+                try:
+                    self._executor = _create_interpreter_pool_executor(
+                        self._max_workers,
+                    )
+                except Exception:
+                    _log.exception(
+                        "Failed to create interpreter-pool executor",
+                        extra={"max_workers": self._max_workers},
+                    )
+                    raise
+                _log.info(
+                    "Created interpreter-pool executor",
+                    extra={"max_workers": self._max_workers},
+                )
             return self._executor
 
     def shutdown(self) -> None:
         """Shut down the interpreter pool atomically."""
         with self._executor_lock:
+            started = self._clock.monotonic_seconds()
             self._is_shutdown = True
             executor = self._executor
             self._executor = None
             if executor is not None:
-                executor.shutdown(wait=True)
+                outcome = "success"
+                try:
+                    executor.shutdown(wait=True)
+                except Exception:
+                    outcome = "error"
+                    _log.exception(
+                        "Interpreter-pool executor shutdown failed",
+                        extra={"max_workers": self._max_workers},
+                    )
+                    raise
+                finally:
+                    self._metrics.observe_latency_ms(
+                        _METRIC_SHUTDOWN_LATENCY_MS,
+                        (self._clock.monotonic_seconds() - started) * 1000,
+                        labels={"outcome": outcome},
+                    )
+                _log.info(
+                    "Shut down interpreter-pool executor",
+                    extra={"max_workers": self._max_workers},
+                )
 
     @typ.override
     async def map_ordered(
@@ -154,7 +261,31 @@ class InterpreterPoolCpuTaskExecutor(CpuTaskExecutor):
         def map_ordered_sync() -> list[_OutputT]:
             with self._executor_lock:
                 executor = self._get_executor()
-                return list(executor.map(task, items))
+                try:
+                    result = list(executor.map(task, items))
+                except Exception:
+                    self._metrics.increment_counter(
+                        _METRIC_MAP_CALLS,
+                        labels={"outcome": "error"},
+                    )
+                    _log.exception(
+                        "Interpreter-pool executor map failed",
+                        extra={
+                            "item_count": len(items),
+                            "max_workers": self._max_workers,
+                        },
+                    )
+                    raise
+                self._metrics.increment_counter(
+                    _METRIC_MAP_CALLS,
+                    labels={"outcome": "success"},
+                )
+                self._metrics.observe_latency_ms(
+                    _METRIC_MAP_ITEMS,
+                    float(len(items)),
+                    labels={"outcome": "success"},
+                )
+                return result
 
         return await asyncio.to_thread(map_ordered_sync)
 
@@ -184,17 +315,31 @@ def build_cpu_task_executor_from_environment(
     """
     environ_ = os.environ if environ is None else environ
     if not _flag_enabled(environ_.get(_INTERPRETER_POOL_FEATURE_FLAG)):
+        _log.info(
+            "Using inline CPU task executor",
+            extra={"reason": "feature_flag_disabled"},
+        )
         return InlineCpuTaskExecutor()
     if not capability_check():
+        _log.info(
+            "Using inline CPU task executor",
+            extra={"reason": "interpreter_pool_unavailable"},
+        )
         return InlineCpuTaskExecutor()
     max_workers = _parse_optional_positive_int(
         environ_.get(_INTERPRETER_POOL_MAX_WORKERS_ENV),
+    )
+    _log.info(
+        "Using interpreter-pool CPU task executor",
+        extra={"max_workers": max_workers},
     )
     return InterpreterPoolCpuTaskExecutor(max_workers=max_workers)
 
 
 __all__ = [
     "CpuTaskExecutor",
+    "CpuTaskExecutorClockPort",
+    "CpuTaskExecutorMetricsPort",
     "InlineCpuTaskExecutor",
     "InterpreterPoolCpuTaskExecutor",
     "build_cpu_task_executor_from_environment",

--- a/episodic/concurrent_interpreters.py
+++ b/episodic/concurrent_interpreters.py
@@ -19,7 +19,7 @@ import typing as typ
 
 _InputT = typ.TypeVar("_InputT")
 _OutputT = typ.TypeVar("_OutputT")
-type InterpreterPoolCapability = cabc.Callable[[], bool]
+type _InterpreterPoolCapability = cabc.Callable[[], bool]
 
 _INTERPRETER_POOL_FEATURE_FLAG = "EPISODIC_USE_INTERPRETER_POOL"
 _INTERPRETER_POOL_MAX_WORKERS_ENV = "EPISODIC_INTERPRETER_POOL_MAX_WORKERS"
@@ -62,7 +62,7 @@ class CpuTaskExecutorMetricsPort(typ.Protocol):
         """Observe a non-latency numeric measurement."""
 
 
-class CpuTaskExecutorClockPort(typ.Protocol):
+class _CpuTaskExecutorClockPort(typ.Protocol):
     """Monotonic clock used to measure executor lifecycle timings."""
 
     def monotonic_seconds(self) -> float:
@@ -204,7 +204,7 @@ class InterpreterPoolCpuTaskExecutor(CpuTaskExecutor):
         *,
         max_workers: int | None = None,
         metrics: CpuTaskExecutorMetricsPort | None = None,
-        clock: CpuTaskExecutorClockPort | None = None,
+        clock: _CpuTaskExecutorClockPort | None = None,
     ) -> None:
         self._max_workers = max_workers
         self._executor: cf.Executor | None = None
@@ -323,8 +323,8 @@ class InterpreterPoolCpuTaskExecutor(CpuTaskExecutor):
 def build_cpu_task_executor_from_environment(
     environ: cabc.Mapping[str, str] | None = None,
     *,
-    capability_check: InterpreterPoolCapability = interpreter_pool_supported,
     metrics: CpuTaskExecutorMetricsPort | None = None,
+    _capability_check: _InterpreterPoolCapability = interpreter_pool_supported,
 ) -> CpuTaskExecutor:
     """Select CPU-task adapter based on feature flag and runtime capability.
 
@@ -333,10 +333,6 @@ def build_cpu_task_executor_from_environment(
     environ : collections.abc.Mapping[str, str] | None
         Environment mapping to inspect. ``None`` falls back to ``os.environ``
         for backwards-compatible composition-root usage.
-    capability_check : collections.abc.Callable[[], bool]
-        Runtime capability probe for interpreter-pool support. Tests and
-        composition roots can inject this instead of monkeypatching module
-        state.
     metrics : CpuTaskExecutorMetricsPort | None
         Metrics sink for executor selection and interpreter-pool lifecycle
         observations. ``None`` uses the module default no-op sink.
@@ -359,7 +355,7 @@ def build_cpu_task_executor_from_environment(
             extra={"reason": "feature_flag_disabled"},
         )
         return InlineCpuTaskExecutor()
-    if not capability_check():
+    if not _capability_check():
         metrics_.increment_counter(
             _METRIC_EXECUTOR_SELECTIONS,
             labels={"executor": "inline", "reason": "interpreter_pool_unavailable"},
@@ -385,10 +381,8 @@ def build_cpu_task_executor_from_environment(
 
 __all__ = [
     "CpuTaskExecutor",
-    "CpuTaskExecutorClockPort",
     "CpuTaskExecutorMetricsPort",
     "InlineCpuTaskExecutor",
-    "InterpreterPoolCapability",
     "InterpreterPoolCpuTaskExecutor",
     "build_cpu_task_executor_from_environment",
     "interpreter_pool_supported",

--- a/episodic/concurrent_interpreters.py
+++ b/episodic/concurrent_interpreters.py
@@ -27,7 +27,6 @@ _METRIC_EXECUTOR_SELECTIONS = "cpu_task_executor.selections"
 _METRIC_POOL_CREATIONS = "interpreter_pool.creations"
 _METRIC_MAP_CALLS = "interpreter_pool.map.calls"
 _METRIC_MAP_ITEMS = "interpreter_pool.map.items"
-_METRIC_POOL_UTILIZATION = "interpreter_pool.utilization"
 _METRIC_SHUTDOWN_LATENCY_MS = "interpreter_pool.shutdown.latency_ms"
 _TRUTHY_VALUES = frozenset({"1", "on", "true", "yes"})
 _log = logging.getLogger(__name__)
@@ -316,11 +315,6 @@ class InterpreterPoolCpuTaskExecutor(CpuTaskExecutor):
                     float(len(items)),
                     labels={"outcome": "success"},
                 )
-                self._metrics.observe_value(
-                    _METRIC_POOL_UTILIZATION,
-                    float(len(items)),
-                    labels={"outcome": "success"},
-                )
                 return result
 
         return await asyncio.to_thread(map_ordered_sync)
@@ -330,6 +324,7 @@ def build_cpu_task_executor_from_environment(
     environ: cabc.Mapping[str, str] | None = None,
     *,
     capability_check: InterpreterPoolCapability = interpreter_pool_supported,
+    metrics: CpuTaskExecutorMetricsPort | None = None,
 ) -> CpuTaskExecutor:
     """Select CPU-task adapter based on feature flag and runtime capability.
 
@@ -342,6 +337,9 @@ def build_cpu_task_executor_from_environment(
         Runtime capability probe for interpreter-pool support. Tests and
         composition roots can inject this instead of monkeypatching module
         state.
+    metrics : CpuTaskExecutorMetricsPort | None
+        Metrics sink for executor selection and interpreter-pool lifecycle
+        observations. ``None`` uses the module default no-op sink.
 
     The returned object is owned by the caller. Inline executors have no
     resources to release; interpreter-pool executors should be shut down by the
@@ -350,8 +348,9 @@ def build_cpu_task_executor_from_environment(
     code works for both adapters.
     """
     environ_ = os.environ if environ is None else environ
+    metrics_ = metrics if metrics is not None else _CPU_TASK_EXECUTOR_METRICS
     if not _flag_enabled(environ_.get(_INTERPRETER_POOL_FEATURE_FLAG)):
-        _CPU_TASK_EXECUTOR_METRICS.increment_counter(
+        metrics_.increment_counter(
             _METRIC_EXECUTOR_SELECTIONS,
             labels={"executor": "inline", "reason": "feature_flag_disabled"},
         )
@@ -361,7 +360,7 @@ def build_cpu_task_executor_from_environment(
         )
         return InlineCpuTaskExecutor()
     if not capability_check():
-        _CPU_TASK_EXECUTOR_METRICS.increment_counter(
+        metrics_.increment_counter(
             _METRIC_EXECUTOR_SELECTIONS,
             labels={"executor": "inline", "reason": "interpreter_pool_unavailable"},
         )
@@ -373,7 +372,7 @@ def build_cpu_task_executor_from_environment(
     max_workers = _parse_optional_positive_int(
         environ_.get(_INTERPRETER_POOL_MAX_WORKERS_ENV),
     )
-    _CPU_TASK_EXECUTOR_METRICS.increment_counter(
+    metrics_.increment_counter(
         _METRIC_EXECUTOR_SELECTIONS,
         labels={"executor": "interpreter_pool", "reason": "enabled"},
     )
@@ -381,7 +380,7 @@ def build_cpu_task_executor_from_environment(
         "Using interpreter-pool CPU task executor",
         extra={"max_workers": max_workers},
     )
-    return InterpreterPoolCpuTaskExecutor(max_workers=max_workers)
+    return InterpreterPoolCpuTaskExecutor(max_workers=max_workers, metrics=metrics_)
 
 
 __all__ = [

--- a/episodic/concurrent_interpreters.py
+++ b/episodic/concurrent_interpreters.py
@@ -51,7 +51,16 @@ class CpuTaskExecutorMetricsPort(typ.Protocol):
         *,
         labels: cabc.Mapping[str, str],
     ) -> None:
-        """Observe a latency or gauge-like measurement in milliseconds."""
+        """Observe a latency measurement in milliseconds."""
+
+    def observe_value(
+        self,
+        name: str,
+        value: float,
+        *,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Observe a non-latency numeric measurement."""
 
 
 class CpuTaskExecutorClockPort(typ.Protocol):
@@ -81,6 +90,15 @@ class _NoopCpuTaskExecutorMetrics:
         labels: cabc.Mapping[str, str],
     ) -> None:
         """Ignore latency observations."""
+
+    def observe_value(
+        self,
+        name: str,
+        value: float,
+        *,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Ignore non-latency observations."""
 
 
 @dc.dataclass(frozen=True, slots=True)
@@ -293,12 +311,12 @@ class InterpreterPoolCpuTaskExecutor(CpuTaskExecutor):
                     _METRIC_MAP_CALLS,
                     labels={"outcome": "success"},
                 )
-                self._metrics.observe_latency_ms(
+                self._metrics.observe_value(
                     _METRIC_MAP_ITEMS,
                     float(len(items)),
                     labels={"outcome": "success"},
                 )
-                self._metrics.observe_latency_ms(
+                self._metrics.observe_value(
                     _METRIC_POOL_UTILIZATION,
                     float(len(items)),
                     labels={"outcome": "success"},

--- a/episodic/concurrent_interpreters.py
+++ b/episodic/concurrent_interpreters.py
@@ -19,7 +19,7 @@ import typing as typ
 
 _InputT = typ.TypeVar("_InputT")
 _OutputT = typ.TypeVar("_OutputT")
-InterpreterPoolCapability = cabc.Callable[[], bool]
+type InterpreterPoolCapability = cabc.Callable[[], bool]
 
 _INTERPRETER_POOL_FEATURE_FLAG = "EPISODIC_USE_INTERPRETER_POOL"
 _INTERPRETER_POOL_MAX_WORKERS_ENV = "EPISODIC_INTERPRETER_POOL_MAX_WORKERS"
@@ -388,6 +388,7 @@ __all__ = [
     "CpuTaskExecutorClockPort",
     "CpuTaskExecutorMetricsPort",
     "InlineCpuTaskExecutor",
+    "InterpreterPoolCapability",
     "InterpreterPoolCpuTaskExecutor",
     "build_cpu_task_executor_from_environment",
     "interpreter_pool_supported",

--- a/episodic/concurrent_interpreters.py
+++ b/episodic/concurrent_interpreters.py
@@ -17,6 +17,11 @@ import threading
 import time
 import typing as typ
 
+from episodic.metrics_ports import (
+    BoundedValueMetricsPort,
+    NoopBoundedValueMetrics,
+)
+
 _InputT = typ.TypeVar("_InputT")
 _OutputT = typ.TypeVar("_OutputT")
 type _InterpreterPoolCapability = cabc.Callable[[], bool]
@@ -32,34 +37,8 @@ _TRUTHY_VALUES = frozenset({"1", "on", "true", "yes"})
 _log = logging.getLogger(__name__)
 
 
-class CpuTaskExecutorMetricsPort(typ.Protocol):
+class CpuTaskExecutorMetricsPort(BoundedValueMetricsPort, typ.Protocol):
     """Bounded-cardinality metrics sink for CPU task executors."""
-
-    def increment_counter(
-        self,
-        name: str,
-        *,
-        labels: cabc.Mapping[str, str],
-    ) -> None:
-        """Increment a bounded-cardinality counter."""
-
-    def observe_latency_ms(
-        self,
-        name: str,
-        value: float,
-        *,
-        labels: cabc.Mapping[str, str],
-    ) -> None:
-        """Observe a latency measurement in milliseconds."""
-
-    def observe_value(
-        self,
-        name: str,
-        value: float,
-        *,
-        labels: cabc.Mapping[str, str],
-    ) -> None:
-        """Observe a non-latency numeric measurement."""
 
 
 class _CpuTaskExecutorClockPort(typ.Protocol):
@@ -70,34 +49,8 @@ class _CpuTaskExecutorClockPort(typ.Protocol):
 
 
 @dc.dataclass(frozen=True, slots=True)
-class _NoopCpuTaskExecutorMetrics:
+class _NoopCpuTaskExecutorMetrics(NoopBoundedValueMetrics):
     """Default metrics sink used when no backend is wired."""
-
-    def increment_counter(
-        self,
-        name: str,
-        *,
-        labels: cabc.Mapping[str, str],
-    ) -> None:
-        """Ignore counter increments."""
-
-    def observe_latency_ms(
-        self,
-        name: str,
-        value: float,
-        *,
-        labels: cabc.Mapping[str, str],
-    ) -> None:
-        """Ignore latency observations."""
-
-    def observe_value(
-        self,
-        name: str,
-        value: float,
-        *,
-        labels: cabc.Mapping[str, str],
-    ) -> None:
-        """Ignore non-latency observations."""
 
 
 @dc.dataclass(frozen=True, slots=True)

--- a/episodic/concurrent_interpreters.py
+++ b/episodic/concurrent_interpreters.py
@@ -8,16 +8,14 @@ feature-flagged and capability-gated so callers can opt in safely.
 from __future__ import annotations
 
 import asyncio
+import collections.abc as cabc
 import concurrent.futures as cf
-import os
 import threading
 import typing as typ
 
-if typ.TYPE_CHECKING:
-    import collections.abc as cabc
-
 _InputT = typ.TypeVar("_InputT")
 _OutputT = typ.TypeVar("_OutputT")
+InterpreterPoolCapability = cabc.Callable[[], bool]
 
 _INTERPRETER_POOL_FEATURE_FLAG = "EPISODIC_USE_INTERPRETER_POOL"
 _INTERPRETER_POOL_MAX_WORKERS_ENV = "EPISODIC_INTERPRETER_POOL_MAX_WORKERS"
@@ -116,7 +114,7 @@ class InterpreterPoolCpuTaskExecutor(CpuTaskExecutor):
     ) -> None:
         self._max_workers = max_workers
         self._executor: cf.Executor | None = None
-        self._executor_lock = threading.Lock()
+        self._executor_lock = threading.RLock()
 
     def _get_executor(self) -> cf.Executor:
         """Create the interpreter pool lazily and reuse it for subsequent calls."""
@@ -130,8 +128,8 @@ class InterpreterPoolCpuTaskExecutor(CpuTaskExecutor):
         with self._executor_lock:
             executor = self._executor
             self._executor = None
-        if executor is not None:
-            executor.shutdown(wait=True)
+            if executor is not None:
+                executor.shutdown(wait=True)
 
     @typ.override
     async def map_ordered(
@@ -142,16 +140,25 @@ class InterpreterPoolCpuTaskExecutor(CpuTaskExecutor):
         """Dispatch ``task`` across interpreter workers and preserve order."""
         if not items:
             return []
-        executor = self._get_executor()
 
         def map_ordered_sync() -> list[_OutputT]:
-            return list(executor.map(task, items))
+            with self._executor_lock:
+                executor = self._get_executor()
+                return list(executor.map(task, items))
 
         return await asyncio.to_thread(map_ordered_sync)
 
 
-def build_cpu_task_executor_from_environment() -> CpuTaskExecutor:
+def build_cpu_task_executor_from_environment(
+    environ: cabc.Mapping[str, str],
+    *,
+    capability_detector: InterpreterPoolCapability = interpreter_pool_supported,
+) -> CpuTaskExecutor:
     """Select CPU-task adapter based on feature flag and runtime capability.
+
+    ``environ`` is supplied by the caller so environment access stays at the
+    composition boundary. ``capability_detector`` is injectable for tests and
+    runtimes that need to make interpreter-pool support explicit.
 
     The returned object is owned by the caller. Inline executors have no
     resources to release; interpreter-pool executors should be shut down by the
@@ -159,12 +166,12 @@ def build_cpu_task_executor_from_environment() -> CpuTaskExecutor:
     ``try/finally`` and ``getattr(executor, "shutdown", None)`` so the same
     code works for both adapters.
     """
-    if not _flag_enabled(os.getenv(_INTERPRETER_POOL_FEATURE_FLAG)):
+    if not _flag_enabled(environ.get(_INTERPRETER_POOL_FEATURE_FLAG)):
         return InlineCpuTaskExecutor()
-    if not interpreter_pool_supported():
+    if not capability_detector():
         return InlineCpuTaskExecutor()
     max_workers = _parse_optional_positive_int(
-        os.getenv(_INTERPRETER_POOL_MAX_WORKERS_ENV),
+        environ.get(_INTERPRETER_POOL_MAX_WORKERS_ENV),
     )
     return InterpreterPoolCpuTaskExecutor(max_workers=max_workers)
 

--- a/episodic/concurrent_interpreters.py
+++ b/episodic/concurrent_interpreters.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import collections.abc as cabc
 import concurrent.futures as cf
+import os
 import threading
 import typing as typ
 
@@ -115,17 +116,22 @@ class InterpreterPoolCpuTaskExecutor(CpuTaskExecutor):
         self._max_workers = max_workers
         self._executor: cf.Executor | None = None
         self._executor_lock = threading.RLock()
+        self._is_shutdown = False
 
     def _get_executor(self) -> cf.Executor:
-        """Create the interpreter pool lazily and reuse it for subsequent calls."""
+        """Return the interpreter pool, creating it on first use."""
         with self._executor_lock:
+            if self._is_shutdown:
+                msg = "InterpreterPoolCpuTaskExecutor has been shut down."
+                raise RuntimeError(msg)
             if self._executor is None:
                 self._executor = _create_interpreter_pool_executor(self._max_workers)
             return self._executor
 
     def shutdown(self) -> None:
-        """Shut down the interpreter pool if it has been created."""
+        """Shut down the interpreter pool atomically."""
         with self._executor_lock:
+            self._is_shutdown = True
             executor = self._executor
             self._executor = None
             if executor is not None:
@@ -138,8 +144,12 @@ class InterpreterPoolCpuTaskExecutor(CpuTaskExecutor):
         items: tuple[_InputT, ...],
     ) -> list[_OutputT]:
         """Dispatch ``task`` across interpreter workers and preserve order."""
-        if not items:
-            return []
+        with self._executor_lock:
+            if self._is_shutdown:
+                msg = "InterpreterPoolCpuTaskExecutor has been shut down."
+                raise RuntimeError(msg)
+            if not items:
+                return []
 
         def map_ordered_sync() -> list[_OutputT]:
             with self._executor_lock:
@@ -150,15 +160,21 @@ class InterpreterPoolCpuTaskExecutor(CpuTaskExecutor):
 
 
 def build_cpu_task_executor_from_environment(
-    environ: cabc.Mapping[str, str],
+    environ: cabc.Mapping[str, str] | None = None,
     *,
-    capability_detector: InterpreterPoolCapability = interpreter_pool_supported,
+    capability_check: InterpreterPoolCapability = interpreter_pool_supported,
 ) -> CpuTaskExecutor:
     """Select CPU-task adapter based on feature flag and runtime capability.
 
-    ``environ`` is supplied by the caller so environment access stays at the
-    composition boundary. ``capability_detector`` is injectable for tests and
-    runtimes that need to make interpreter-pool support explicit.
+    Parameters
+    ----------
+    environ : collections.abc.Mapping[str, str] | None
+        Environment mapping to inspect. ``None`` falls back to ``os.environ``
+        for backwards-compatible composition-root usage.
+    capability_check : collections.abc.Callable[[], bool]
+        Runtime capability probe for interpreter-pool support. Tests and
+        composition roots can inject this instead of monkeypatching module
+        state.
 
     The returned object is owned by the caller. Inline executors have no
     resources to release; interpreter-pool executors should be shut down by the
@@ -166,12 +182,13 @@ def build_cpu_task_executor_from_environment(
     ``try/finally`` and ``getattr(executor, "shutdown", None)`` so the same
     code works for both adapters.
     """
-    if not _flag_enabled(environ.get(_INTERPRETER_POOL_FEATURE_FLAG)):
+    environ_ = os.environ if environ is None else environ
+    if not _flag_enabled(environ_.get(_INTERPRETER_POOL_FEATURE_FLAG)):
         return InlineCpuTaskExecutor()
-    if not capability_detector():
+    if not capability_check():
         return InlineCpuTaskExecutor()
     max_workers = _parse_optional_positive_int(
-        environ.get(_INTERPRETER_POOL_MAX_WORKERS_ENV),
+        environ_.get(_INTERPRETER_POOL_MAX_WORKERS_ENV),
     )
     return InterpreterPoolCpuTaskExecutor(max_workers=max_workers)
 

--- a/episodic/concurrent_interpreters.py
+++ b/episodic/concurrent_interpreters.py
@@ -5,8 +5,6 @@ inline execution and interpreter-pool execution. The interpreter adapter is
 feature-flagged and capability-gated so callers can opt in safely.
 """
 
-from __future__ import annotations
-
 import asyncio
 import collections.abc as cabc
 import concurrent.futures as cf

--- a/episodic/concurrent_interpreters.py
+++ b/episodic/concurrent_interpreters.py
@@ -23,8 +23,11 @@ InterpreterPoolCapability = cabc.Callable[[], bool]
 
 _INTERPRETER_POOL_FEATURE_FLAG = "EPISODIC_USE_INTERPRETER_POOL"
 _INTERPRETER_POOL_MAX_WORKERS_ENV = "EPISODIC_INTERPRETER_POOL_MAX_WORKERS"
+_METRIC_EXECUTOR_SELECTIONS = "cpu_task_executor.selections"
+_METRIC_POOL_CREATIONS = "interpreter_pool.creations"
 _METRIC_MAP_CALLS = "interpreter_pool.map.calls"
 _METRIC_MAP_ITEMS = "interpreter_pool.map.items"
+_METRIC_POOL_UTILIZATION = "interpreter_pool.utilization"
 _METRIC_SHUTDOWN_LATENCY_MS = "interpreter_pool.shutdown.latency_ms"
 _TRUTHY_VALUES = frozenset({"1", "on", "true", "yes"})
 _log = logging.getLogger(__name__)
@@ -89,6 +92,9 @@ class _PerfCounterCpuTaskExecutorClock:
     def monotonic_seconds(self) -> float:
         """Return the current monotonic timestamp in seconds."""
         return self.read_seconds()
+
+
+_CPU_TASK_EXECUTOR_METRICS = _NoopCpuTaskExecutorMetrics()
 
 
 class CpuTaskExecutor(typ.Protocol):
@@ -199,16 +205,23 @@ class InterpreterPoolCpuTaskExecutor(CpuTaskExecutor):
                 msg = "InterpreterPoolCpuTaskExecutor has been shut down."
                 raise RuntimeError(msg)
             if self._executor is None:
+                outcome = "success"
                 try:
                     self._executor = _create_interpreter_pool_executor(
                         self._max_workers,
                     )
                 except Exception:
+                    outcome = "error"
                     _log.exception(
                         "Failed to create interpreter-pool executor",
                         extra={"max_workers": self._max_workers},
                     )
                     raise
+                finally:
+                    self._metrics.increment_counter(
+                        _METRIC_POOL_CREATIONS,
+                        labels={"outcome": outcome},
+                    )
                 _log.info(
                     "Created interpreter-pool executor",
                     extra={"max_workers": self._max_workers},
@@ -285,6 +298,11 @@ class InterpreterPoolCpuTaskExecutor(CpuTaskExecutor):
                     float(len(items)),
                     labels={"outcome": "success"},
                 )
+                self._metrics.observe_latency_ms(
+                    _METRIC_POOL_UTILIZATION,
+                    float(len(items)),
+                    labels={"outcome": "success"},
+                )
                 return result
 
         return await asyncio.to_thread(map_ordered_sync)
@@ -315,12 +333,20 @@ def build_cpu_task_executor_from_environment(
     """
     environ_ = os.environ if environ is None else environ
     if not _flag_enabled(environ_.get(_INTERPRETER_POOL_FEATURE_FLAG)):
+        _CPU_TASK_EXECUTOR_METRICS.increment_counter(
+            _METRIC_EXECUTOR_SELECTIONS,
+            labels={"executor": "inline", "reason": "feature_flag_disabled"},
+        )
         _log.info(
             "Using inline CPU task executor",
             extra={"reason": "feature_flag_disabled"},
         )
         return InlineCpuTaskExecutor()
     if not capability_check():
+        _CPU_TASK_EXECUTOR_METRICS.increment_counter(
+            _METRIC_EXECUTOR_SELECTIONS,
+            labels={"executor": "inline", "reason": "interpreter_pool_unavailable"},
+        )
         _log.info(
             "Using inline CPU task executor",
             extra={"reason": "interpreter_pool_unavailable"},
@@ -328,6 +354,10 @@ def build_cpu_task_executor_from_environment(
         return InlineCpuTaskExecutor()
     max_workers = _parse_optional_positive_int(
         environ_.get(_INTERPRETER_POOL_MAX_WORKERS_ENV),
+    )
+    _CPU_TASK_EXECUTOR_METRICS.increment_counter(
+        _METRIC_EXECUTOR_SELECTIONS,
+        labels={"executor": "interpreter_pool", "reason": "enabled"},
     )
     _log.info(
         "Using interpreter-pool CPU task executor",

--- a/episodic/concurrent_interpreters.py
+++ b/episodic/concurrent_interpreters.py
@@ -320,11 +320,51 @@ class InterpreterPoolCpuTaskExecutor(CpuTaskExecutor):
         return await asyncio.to_thread(map_ordered_sync)
 
 
+def _build_cpu_task_executor_from_environment(
+    environ: cabc.Mapping[str, str],
+    *,
+    metrics: CpuTaskExecutorMetricsPort,
+    _capability_check: _InterpreterPoolCapability,
+) -> CpuTaskExecutor:
+    """Build CPU-task adapter from environment with an injectable capability check."""
+    if not _flag_enabled(environ.get(_INTERPRETER_POOL_FEATURE_FLAG)):
+        metrics.increment_counter(
+            _METRIC_EXECUTOR_SELECTIONS,
+            labels={"executor": "inline", "reason": "feature_flag_disabled"},
+        )
+        _log.info(
+            "Using inline CPU task executor",
+            extra={"reason": "feature_flag_disabled"},
+        )
+        return InlineCpuTaskExecutor()
+    if not _capability_check():
+        metrics.increment_counter(
+            _METRIC_EXECUTOR_SELECTIONS,
+            labels={"executor": "inline", "reason": "interpreter_pool_unavailable"},
+        )
+        _log.info(
+            "Using inline CPU task executor",
+            extra={"reason": "interpreter_pool_unavailable"},
+        )
+        return InlineCpuTaskExecutor()
+    max_workers = _parse_optional_positive_int(
+        environ.get(_INTERPRETER_POOL_MAX_WORKERS_ENV),
+    )
+    metrics.increment_counter(
+        _METRIC_EXECUTOR_SELECTIONS,
+        labels={"executor": "interpreter_pool", "reason": "enabled"},
+    )
+    _log.info(
+        "Using interpreter-pool CPU task executor",
+        extra={"max_workers": max_workers},
+    )
+    return InterpreterPoolCpuTaskExecutor(max_workers=max_workers, metrics=metrics)
+
+
 def build_cpu_task_executor_from_environment(
     environ: cabc.Mapping[str, str] | None = None,
     *,
     metrics: CpuTaskExecutorMetricsPort | None = None,
-    _capability_check: _InterpreterPoolCapability = interpreter_pool_supported,
 ) -> CpuTaskExecutor:
     """Select CPU-task adapter based on feature flag and runtime capability.
 
@@ -345,38 +385,11 @@ def build_cpu_task_executor_from_environment(
     """
     environ_ = os.environ if environ is None else environ
     metrics_ = metrics if metrics is not None else _CPU_TASK_EXECUTOR_METRICS
-    if not _flag_enabled(environ_.get(_INTERPRETER_POOL_FEATURE_FLAG)):
-        metrics_.increment_counter(
-            _METRIC_EXECUTOR_SELECTIONS,
-            labels={"executor": "inline", "reason": "feature_flag_disabled"},
-        )
-        _log.info(
-            "Using inline CPU task executor",
-            extra={"reason": "feature_flag_disabled"},
-        )
-        return InlineCpuTaskExecutor()
-    if not _capability_check():
-        metrics_.increment_counter(
-            _METRIC_EXECUTOR_SELECTIONS,
-            labels={"executor": "inline", "reason": "interpreter_pool_unavailable"},
-        )
-        _log.info(
-            "Using inline CPU task executor",
-            extra={"reason": "interpreter_pool_unavailable"},
-        )
-        return InlineCpuTaskExecutor()
-    max_workers = _parse_optional_positive_int(
-        environ_.get(_INTERPRETER_POOL_MAX_WORKERS_ENV),
+    return _build_cpu_task_executor_from_environment(
+        environ_,
+        metrics=metrics_,
+        _capability_check=interpreter_pool_supported,
     )
-    metrics_.increment_counter(
-        _METRIC_EXECUTOR_SELECTIONS,
-        labels={"executor": "interpreter_pool", "reason": "enabled"},
-    )
-    _log.info(
-        "Using interpreter-pool CPU task executor",
-        extra={"max_workers": max_workers},
-    )
-    return InterpreterPoolCpuTaskExecutor(max_workers=max_workers, metrics=metrics_)
 
 
 __all__ = [

--- a/episodic/metrics_ports.py
+++ b/episodic/metrics_ports.py
@@ -1,0 +1,93 @@
+"""Shared bounded-cardinality metrics ports for operational adapters.
+
+These protocols centralise counter, latency, and scalar observation contracts
+so feature-specific ports such as ``ChronoMetricsPort`` and
+``CpuTaskExecutorMetricsPort`` reuse one implementation strategy instead of
+duplicating identical method signatures.
+"""
+
+from __future__ import annotations
+
+import dataclasses as dc
+import typing as typ
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+
+
+class BoundedMetricsPort(typ.Protocol):
+    """Bounded-cardinality metrics sink for counters and latency observations."""
+
+    def increment_counter(
+        self,
+        name: str,
+        *,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Increment a bounded-cardinality counter."""
+
+    def observe_latency_ms(
+        self,
+        name: str,
+        value: float,
+        *,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Observe a latency measurement in milliseconds."""
+
+
+class BoundedValueMetricsPort(BoundedMetricsPort, typ.Protocol):
+    """Bounded-cardinality metrics sink that also records scalar values."""
+
+    def observe_value(
+        self,
+        name: str,
+        value: float,
+        *,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Observe a non-latency numeric measurement."""
+
+
+@dc.dataclass(frozen=True, slots=True)
+class NoopBoundedMetrics:
+    """Default metrics sink used when no backend is wired."""
+
+    def increment_counter(
+        self,
+        name: str,
+        *,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Ignore counter increments."""
+
+    def observe_latency_ms(
+        self,
+        name: str,
+        value: float,
+        *,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Ignore latency observations."""
+
+
+@dc.dataclass(frozen=True, slots=True)
+class NoopBoundedValueMetrics(NoopBoundedMetrics):
+    """Default value-metrics sink used when no backend is wired."""
+
+    def observe_value(
+        self,
+        name: str,
+        value: float,
+        *,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Ignore non-latency observations."""
+
+
+__all__ = [
+    "BoundedMetricsPort",
+    "BoundedValueMetricsPort",
+    "NoopBoundedMetrics",
+    "NoopBoundedValueMetrics",
+]

--- a/episodic/metrics_ports.py
+++ b/episodic/metrics_ports.py
@@ -6,13 +6,8 @@ so feature-specific ports such as ``ChronoMetricsPort`` and
 duplicating identical method signatures.
 """
 
-from __future__ import annotations
-
 import dataclasses as dc
 import typing as typ
-
-if typ.TYPE_CHECKING:
-    import collections.abc as cabc
 
 
 class BoundedMetricsPort(typ.Protocol):
@@ -22,7 +17,7 @@ class BoundedMetricsPort(typ.Protocol):
         self,
         name: str,
         *,
-        labels: cabc.Mapping[str, str],
+        labels: dict[str, str],
     ) -> None:
         """Increment a bounded-cardinality counter."""
 
@@ -31,7 +26,7 @@ class BoundedMetricsPort(typ.Protocol):
         name: str,
         value: float,
         *,
-        labels: cabc.Mapping[str, str],
+        labels: dict[str, str],
     ) -> None:
         """Observe a latency measurement in milliseconds."""
 
@@ -44,7 +39,7 @@ class BoundedValueMetricsPort(BoundedMetricsPort, typ.Protocol):
         name: str,
         value: float,
         *,
-        labels: cabc.Mapping[str, str],
+        labels: dict[str, str],
     ) -> None:
         """Observe a non-latency numeric measurement."""
 
@@ -57,7 +52,7 @@ class NoopBoundedMetrics:
         self,
         name: str,
         *,
-        labels: cabc.Mapping[str, str],
+        labels: dict[str, str],
     ) -> None:
         """Ignore counter increments."""
 
@@ -66,7 +61,7 @@ class NoopBoundedMetrics:
         name: str,
         value: float,
         *,
-        labels: cabc.Mapping[str, str],
+        labels: dict[str, str],
     ) -> None:
         """Ignore latency observations."""
 
@@ -80,7 +75,7 @@ class NoopBoundedValueMetrics(NoopBoundedMetrics):
         name: str,
         value: float,
         *,
-        labels: cabc.Mapping[str, str],
+        labels: dict[str, str],
     ) -> None:
         """Ignore non-latency observations."""
 

--- a/episodic/qa/chrono.py
+++ b/episodic/qa/chrono.py
@@ -37,6 +37,8 @@ import typing as typ
 
 import tei_rapporteur as _tei
 
+from episodic.metrics_ports import BoundedMetricsPort, NoopBoundedMetrics
+
 if typ.TYPE_CHECKING:
     from collections import abc as cabc
 
@@ -50,25 +52,8 @@ _METRIC_EVALUATIONS = "chrono.runtime_estimator.evaluations"
 _METRIC_LATENCY_MS = "chrono.runtime_estimator.latency_ms"
 
 
-class ChronoMetricsPort(typ.Protocol):
+class ChronoMetricsPort(BoundedMetricsPort, typ.Protocol):
     """Bounded-cardinality metrics sink for Chrono runtime estimation."""
-
-    def increment_counter(
-        self,
-        name: str,
-        *,
-        labels: cabc.Mapping[str, str],
-    ) -> None:
-        """Increment a bounded-cardinality counter."""
-
-    def observe_latency_ms(
-        self,
-        name: str,
-        value: float,
-        *,
-        labels: cabc.Mapping[str, str],
-    ) -> None:
-        """Observe a latency measurement in milliseconds."""
 
 
 class ChronoClockPort(typ.Protocol):
@@ -79,25 +64,8 @@ class ChronoClockPort(typ.Protocol):
 
 
 @dc.dataclass(frozen=True, slots=True)
-class _NoopChronoMetrics:
+class _NoopChronoMetrics(NoopBoundedMetrics):
     """Default metrics sink used when no backend is wired."""
-
-    def increment_counter(
-        self,
-        name: str,
-        *,
-        labels: cabc.Mapping[str, str],
-    ) -> None:
-        """Ignore counter increments."""
-
-    def observe_latency_ms(
-        self,
-        name: str,
-        value: float,
-        *,
-        labels: cabc.Mapping[str, str],
-    ) -> None:
-        """Ignore latency observations."""
 
 
 @dc.dataclass(frozen=True, slots=True)

--- a/episodic/worker/runtime.py
+++ b/episodic/worker/runtime.py
@@ -100,10 +100,7 @@ def _parse_positive_int(
     key: str,
     default: int,
 ) -> int:
-    """Parse a positive-integer environment variable.
-
-    Raise RuntimeError if the configured value is invalid.
-    """
+    """Parse a positive-integer environment variable."""
     value = environ.get(key)
     if value is None or not value.strip():
         return default

--- a/episodic/worker/runtime.py
+++ b/episodic/worker/runtime.py
@@ -81,6 +81,7 @@ class WorkerLaunchProfile:
 
 
 def _parse_bool(environ: cabc.Mapping[str, str], *, key: str, default: bool) -> bool:
+    """Parse a boolean environment variable, raising RuntimeError if invalid."""
     value = environ.get(key)
     if value is None:
         return default
@@ -99,6 +100,10 @@ def _parse_positive_int(
     key: str,
     default: int,
 ) -> int:
+    """Parse a positive-integer environment variable.
+
+    Raise RuntimeError if the configured value is invalid.
+    """
     value = environ.get(key)
     if value is None or not value.strip():
         return default
@@ -119,6 +124,7 @@ def _parse_pool(
     key: str,
     default: WorkerPool,
 ) -> WorkerPool:
+    """Parse a WorkerPool environment variable, raising RuntimeError if invalid."""
     value = environ.get(key)
     if value is None or not value.strip():
         return default

--- a/episodic/worker/runtime.py
+++ b/episodic/worker/runtime.py
@@ -100,7 +100,7 @@ def _parse_positive_int(
     key: str,
     default: int,
 ) -> int:
-    """Parse a positive-integer environment variable."""
+    """Parse a positive integer, raising RuntimeError if invalid."""
     value = environ.get(key)
     if value is None or not value.strip():
         return default

--- a/episodic/worker/runtime.py
+++ b/episodic/worker/runtime.py
@@ -26,7 +26,23 @@ class WorkerPool(enum.StrEnum):
 
 @dc.dataclass(frozen=True, slots=True)
 class WorkerRuntimeConfig:
-    """Runtime configuration required to boot the Celery worker scaffold."""
+    """Runtime configuration required to boot the Celery worker scaffold.
+
+    Notes
+    -----
+    This configuration governs Celery-level dispatch concerns: broker
+    connection settings, result backend configuration, worker pool selection,
+    and per-pool concurrency.
+
+    `EPISODIC_USE_INTERPRETER_POOL`,
+    `EPISODIC_INTERPRETER_POOL_MIN_ITEMS`, and
+    `EPISODIC_INTERPRETER_POOL_MAX_WORKERS` are task-level companion variables
+    consumed by CPU-bound task implementations and related fan-out policy.
+    Task code should use `build_cpu_task_executor_from_environment()` for the
+    executor adapter. These variables are intentionally not surfaced here
+    because they control intra-task parallelism inside a prefork worker
+    process, not inter-task dispatch across Celery worker pools.
+    """
 
     broker_url: str
     result_backend: str | None = None

--- a/episodic/worker/runtime.py
+++ b/episodic/worker/runtime.py
@@ -38,10 +38,11 @@ class WorkerRuntimeConfig:
     `EPISODIC_INTERPRETER_POOL_MIN_ITEMS`, and
     `EPISODIC_INTERPRETER_POOL_MAX_WORKERS` are task-level companion variables
     consumed by CPU-bound task implementations and related fan-out policy.
-    Task code should use `build_cpu_task_executor_from_environment()` for the
-    executor adapter. These variables are intentionally not surfaced here
-    because they control intra-task parallelism inside a prefork worker
-    process, not inter-task dispatch across Celery worker pools.
+    Task code should pass its environment mapping to
+    `build_cpu_task_executor_from_environment()` for the executor adapter.
+    These variables are intentionally not surfaced here because they control
+    intra-task parallelism inside a prefork worker process, not inter-task
+    dispatch across Celery worker pools.
     """
 
     broker_url: str

--- a/episodic/worker/tasks.py
+++ b/episodic/worker/tasks.py
@@ -5,11 +5,13 @@ processes. Tasks whose inner work can be split into pure-Python items may also
 fan out inside one worker process through the optional interpreter-pool adapter:
 
 ```python
+import os
+
 from episodic.concurrent_interpreters import (
     build_cpu_task_executor_from_environment,
 )
 
-executor = build_cpu_task_executor_from_environment()
+executor = build_cpu_task_executor_from_environment(os.environ)
 try:
     results = await executor.map_ordered(pure_python_fn, items)
 finally:

--- a/episodic/worker/tasks.py
+++ b/episodic/worker/tasks.py
@@ -10,7 +10,12 @@ from episodic.concurrent_interpreters import (
 )
 
 executor = build_cpu_task_executor_from_environment()
-results = await executor.map_ordered(pure_python_fn, items)
+try:
+    results = await executor.map_ordered(pure_python_fn, items)
+finally:
+    shutdown = getattr(executor, "shutdown", None)
+    if shutdown is not None:
+        shutdown()
 ```
 
 Set `EPISODIC_USE_INTERPRETER_POOL=1` to enable subinterpreter parallelism for
@@ -19,6 +24,9 @@ that inner fan-out path, with the implementation and
 `episodic/concurrent_interpreters.py`. Callers that gate fan-out by batch size
 should keep that threshold as task-level policy, as
 `DefaultWeightingStrategy` does with `EPISODIC_INTERPRETER_POOL_MIN_ITEMS`.
+Treat the executor as owned by the task-level fan-out operation or an explicit
+worker-scoped owner; do not hide a long-lived interpreter pool in unrelated
+global task state.
 """
 
 import collections.abc as cabc

--- a/episodic/worker/tasks.py
+++ b/episodic/worker/tasks.py
@@ -1,4 +1,25 @@
-"""Representative Celery task seams for the worker scaffold."""
+"""Representative Celery task seams for the worker scaffold.
+
+CPU-bound tasks run on the `episodic.cpu` queue in Celery `prefork` worker
+processes. Tasks whose inner work can be split into pure-Python items may also
+fan out inside one worker process through the optional interpreter-pool adapter:
+
+```python
+from episodic.concurrent_interpreters import (
+    build_cpu_task_executor_from_environment,
+)
+
+executor = build_cpu_task_executor_from_environment()
+results = await executor.map_ordered(pure_python_fn, items)
+```
+
+Set `EPISODIC_USE_INTERPRETER_POOL=1` to enable subinterpreter parallelism for
+that inner fan-out path, with the implementation and
+`EPISODIC_INTERPRETER_POOL_MAX_WORKERS` tuning knob documented in
+`episodic/concurrent_interpreters.py`. Callers that gate fan-out by batch size
+should keep that threshold as task-level policy, as
+`DefaultWeightingStrategy` does with `EPISODIC_INTERPRETER_POOL_MIN_ITEMS`.
+"""
 
 import collections.abc as cabc
 import dataclasses as dc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -462,6 +462,7 @@ prefixes = [
     "episodic.canonical.reference_protocols",
     "episodic.canonical.unit_of_work_protocols",
     "episodic.llm.ports",
+    "episodic.metrics_ports",
 ]
 allowed = ["domain_ports"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import asyncio
 import concurrent.futures as cf
 import dataclasses as dc
 import os
+import threading
 import typing as typ
 
 import pytest
@@ -77,6 +78,45 @@ class FakeCpuDiagnostic:
 def double_worker_value(value: int) -> int:
     """Double an integer for worker fan-out tests."""
     return value * 2
+
+
+def square_executor_value(value: int) -> int:
+    """Return the square of a generated executor input."""
+    return value * value
+
+
+class BlockingMapExecutor(cf.Executor):
+    """Executor test double that exposes map/shutdown ordering."""
+
+    def __init__(self) -> None:
+        self.map_started = threading.Event()
+        self.release_map = threading.Event()
+        self.shutdown_called = threading.Event()
+
+    def map(
+        self,
+        fn: cabc.Callable[..., int],
+        *iterables: cabc.Iterable[typ.Any],
+        **kwargs: object,
+    ) -> cabc.Iterator[int]:
+        """Block mapped work until the test releases it."""
+        del kwargs
+        items = tuple(typ.cast("cabc.Iterable[int]", iterables[0]))
+        self.map_started.set()
+        if not self.release_map.wait(timeout=5):
+            msg = "Timed out waiting for test to release executor.map()."
+            raise TimeoutError(msg)
+        return iter(fn(item) for item in items)
+
+    def shutdown(
+        self,
+        wait: bool = True,  # noqa: FBT001, FBT002
+        *,
+        cancel_futures: bool = False,
+    ) -> None:
+        """Record that shutdown reached the underlying executor."""
+        del wait, cancel_futures
+        self.shutdown_called.set()
 
 
 async def cpu_task_inner_fan_out(items: tuple[int, ...]) -> list[int]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,14 @@
 """Root pytest configuration: plugin registration and cross-cutting fixtures."""
 
 import asyncio
+import concurrent.futures as cf
+import dataclasses as dc
 import os
 import typing as typ
 
 import pytest
+
+import episodic.concurrent_interpreters as ci
 
 # psycopg-binary currently segfaults against py-pglite in this test harness.
 os.environ.setdefault("PSYCOPG_IMPL", "python")
@@ -19,6 +23,12 @@ if typ.TYPE_CHECKING:
 
     from episodic.canonical.domain import EpisodeTemplate
     from episodic.canonical.unit_of_work_protocols import CanonicalUnitOfWork
+    from episodic.worker import (
+        CpuDiagnosticRequest,
+        CpuDiagnosticResult,
+        IoDiagnosticRequest,
+        IoDiagnosticResult,
+    )
 pytest_plugins: list[str] = [
     "tests.fixtures.database",
     "tests.fixtures.llm",
@@ -26,6 +36,89 @@ pytest_plugins: list[str] = [
     "tests.fixtures.ingestion",
     "tests.fixtures.binding",
 ]
+
+
+@dc.dataclass(slots=True)
+class FakeIoDiagnostic:
+    """Record an I/O-bound diagnostic request and return a canned response."""
+
+    seen_messages: list[str]
+
+    def __call__(self, request: IoDiagnosticRequest) -> IoDiagnosticResult:
+        """Record the request and return a diagnostic I/O result payload."""
+        from episodic.worker import IoDiagnosticResult
+
+        self.seen_messages.append(request.message)
+        return IoDiagnosticResult(
+            message=request.message,
+            correlation_id=request.correlation_id,
+            worker_kind="io-bound",
+        )
+
+
+@dc.dataclass(slots=True)
+class FakeCpuDiagnostic:
+    """Record a CPU-bound diagnostic request and return a canned response."""
+
+    seen_iterations: list[int]
+
+    def __call__(self, request: CpuDiagnosticRequest) -> CpuDiagnosticResult:
+        """Record the request and return a diagnostic CPU result payload."""
+        from episodic.worker import CpuDiagnosticResult
+
+        self.seen_iterations.append(request.iterations)
+        return CpuDiagnosticResult(
+            digest=f"digest-{request.iterations}",
+            iterations=request.iterations,
+            worker_kind="cpu-bound",
+        )
+
+
+def double_worker_value(value: int) -> int:
+    """Double an integer for worker fan-out tests."""
+    return value * 2
+
+
+async def cpu_task_inner_fan_out(items: tuple[int, ...]) -> list[int]:
+    """Mirror the documented CPU task interpreter-pool integration pattern."""
+    executor = ci.build_cpu_task_executor_from_environment()
+    try:
+        return await executor.map_ordered(double_worker_value, items)
+    finally:
+        shutdown = getattr(executor, "shutdown", None)
+        if shutdown is not None:
+            shutdown()
+
+
+@pytest.fixture
+def runtime_environ() -> dict[str, str]:
+    """Return the minimal eager Celery worker environment for tests."""
+    return {
+        "EPISODIC_CELERY_BROKER_URL": "amqp://guest:guest@localhost:5672//",
+        "EPISODIC_CELERY_ALWAYS_EAGER": "true",
+    }
+
+
+@pytest.fixture
+def captured_interpreter_pool_workers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[int | None]:
+    """Enable interpreter-pool dispatch and record requested worker counts."""
+    captured_max_workers: list[int | None] = []
+
+    def fake_create_interpreter_pool_executor(max_workers: int | None) -> cf.Executor:
+        captured_max_workers.append(max_workers)
+        return cf.ThreadPoolExecutor(max_workers=max_workers)
+
+    monkeypatch.setenv("EPISODIC_USE_INTERPRETER_POOL", "1")
+    monkeypatch.setenv("EPISODIC_INTERPRETER_POOL_MAX_WORKERS", "2")
+    monkeypatch.setattr(ci, "interpreter_pool_supported", lambda: True)
+    monkeypatch.setattr(
+        ci,
+        "_create_interpreter_pool_executor",
+        fake_create_interpreter_pool_executor,
+    )
+    return captured_max_workers
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,6 +110,7 @@ class BlockingMapExecutor(cf.Executor):
 
     def shutdown(
         self,
+        # Suppression matches concurrent.futures.Executor.shutdown.
         wait: bool = True,  # noqa: FBT001, FBT002
         *,
         cancel_futures: bool = False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,7 +81,7 @@ def double_worker_value(value: int) -> int:
 
 async def cpu_task_inner_fan_out(items: tuple[int, ...]) -> list[int]:
     """Mirror the documented CPU task interpreter-pool integration pattern."""
-    executor = ci.build_cpu_task_executor_from_environment()
+    executor = ci.build_cpu_task_executor_from_environment(os.environ)
     try:
         return await executor.map_ordered(double_worker_value, items)
     finally:

--- a/tests/test_ingestion_weighting.py
+++ b/tests/test_ingestion_weighting.py
@@ -1,5 +1,6 @@
 """Unit tests for weighting strategy adapters."""
 
+import dataclasses as dc
 import typing as typ
 
 import pytest
@@ -30,6 +31,40 @@ class RecordingCpuTaskExecutor:
         """Map inputs and record invocation count for assertions."""
         self.map_calls += 1
         return [task(item) for item in items]
+
+
+@dc.dataclass(slots=True)
+class _RecordingCpuTaskExecutorMetrics:
+    """Capture executor selection metrics for composition-root wiring tests."""
+
+    counters: list[tuple[str, dict[str, str]]] = dc.field(default_factory=list)
+
+    def increment_counter(
+        self,
+        name: str,
+        *,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Record a counter increment."""
+        self.counters.append((name, dict(labels)))
+
+    def observe_latency_ms(
+        self,
+        name: str,
+        value: float,
+        *,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Record a latency observation."""
+
+    def observe_value(
+        self,
+        name: str,
+        value: float,
+        *,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Record a scalar observation."""
 
 
 @pytest.fixture
@@ -163,3 +198,30 @@ async def test_weighting_strategy_threshold_dispatch(
     assert [result.computed_weight for result in results] == pytest.approx(
         expected_weights,
     ), "Expected deterministic computed weights for both dispatch paths."
+
+
+def test_default_weighting_strategy_forwards_metrics_to_executor_builder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Composition roots can wire executor metrics through the strategy."""
+    metrics = _RecordingCpuTaskExecutorMetrics()
+    captured: dict[str, object] = {}
+
+    def fake_build_cpu_task_executor_from_environment(
+        environ: cabc.Mapping[str, str],
+        *,
+        metrics: object = None,
+    ) -> RecordingCpuTaskExecutor:
+        captured["metrics"] = metrics
+        return RecordingCpuTaskExecutor()
+
+    monkeypatch.setattr(
+        "episodic.canonical.adapters.weighting.build_cpu_task_executor_from_environment",
+        fake_build_cpu_task_executor_from_environment,
+    )
+
+    DefaultWeightingStrategy(metrics=metrics)
+
+    assert captured["metrics"] is metrics, (
+        "Expected strategy construction to forward metrics to the executor builder."
+    )

--- a/tests/test_interpreter_executor.py
+++ b/tests/test_interpreter_executor.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures as cf
 import operator
-import threading
 import typing as typ
 from unittest import mock
 
@@ -14,14 +13,11 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 import episodic.concurrent_interpreters as ci
+from tests.conftest import BlockingMapExecutor as _BlockingMapExecutor
+from tests.conftest import square_executor_value as _square
 
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
-
-
-def _square(value: int) -> int:
-    """Return the square of a generated executor input."""
-    return value * value
 
 
 def _explode_on_three(value: int) -> int:
@@ -42,40 +38,6 @@ _ORDERED_MAP_TASKS: dict[str, cabc.Callable[[int], int]] = {
     "negate": typ.cast("cabc.Callable[[int], int]", operator.neg),
     "square": _square,
 }
-
-
-class _BlockingMapExecutor(cf.Executor):
-    """Executor test double that exposes map/shutdown ordering."""
-
-    def __init__(self) -> None:
-        self.map_started = threading.Event()
-        self.release_map = threading.Event()
-        self.shutdown_called = threading.Event()
-
-    def map(
-        self,
-        fn: cabc.Callable[..., int],
-        *iterables: cabc.Iterable[typ.Any],
-        **kwargs: object,
-    ) -> cabc.Iterator[int]:
-        """Block mapped work until the test releases it."""
-        del kwargs
-        items = tuple(typ.cast("cabc.Iterable[int]", iterables[0]))
-        self.map_started.set()
-        if not self.release_map.wait(timeout=5):
-            msg = "Timed out waiting for test to release executor.map()."
-            raise TimeoutError(msg)
-        return iter(fn(item) for item in items)
-
-    def shutdown(
-        self,
-        wait: bool = True,  # noqa: FBT001, FBT002
-        *,
-        cancel_futures: bool = False,
-    ) -> None:
-        """Record that shutdown reached the underlying executor."""
-        del wait, cancel_futures
-        self.shutdown_called.set()
 
 
 @pytest.mark.asyncio
@@ -245,6 +207,7 @@ def test_interpreter_executor_shutdown_is_idempotent() -> None:
 
     executor.shutdown()
     executor.shutdown()
+    assert executor._is_shutdown is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_interpreter_executor.py
+++ b/tests/test_interpreter_executor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures as cf
 import operator
+import threading
 import typing as typ
 from unittest import mock
 
@@ -19,10 +20,12 @@ if typ.TYPE_CHECKING:
 
 
 def _square(value: int) -> int:
+    """Return the square of a generated executor input."""
     return value * value
 
 
 def _explode_on_three(value: int) -> int:
+    """Raise on a sentinel value to prove executor errors propagate."""
     if value == 3:
         msg = "bad value: 3"
         raise ValueError(msg)
@@ -30,6 +33,7 @@ def _explode_on_three(value: int) -> int:
 
 
 def _affine(value: int) -> int:
+    """Apply a non-symmetric transform for ordering property tests."""
     return (value * 3) - 7
 
 
@@ -38,6 +42,40 @@ _ORDERED_MAP_TASKS: dict[str, cabc.Callable[[int], int]] = {
     "negate": typ.cast("cabc.Callable[[int], int]", operator.neg),
     "square": _square,
 }
+
+
+class _BlockingMapExecutor(cf.Executor):
+    """Executor test double that exposes map/shutdown ordering."""
+
+    def __init__(self) -> None:
+        self.map_started = threading.Event()
+        self.release_map = threading.Event()
+        self.shutdown_called = threading.Event()
+
+    def map(
+        self,
+        fn: cabc.Callable[..., int],
+        *iterables: cabc.Iterable[typ.Any],
+        **kwargs: object,
+    ) -> cabc.Iterator[int]:
+        """Block mapped work until the test releases it."""
+        del kwargs
+        items = tuple(typ.cast("cabc.Iterable[int]", iterables[0]))
+        self.map_started.set()
+        if not self.release_map.wait(timeout=5):
+            msg = "Timed out waiting for test to release executor.map()."
+            raise TimeoutError(msg)
+        return iter(fn(item) for item in items)
+
+    def shutdown(
+        self,
+        wait: bool = True,  # noqa: FBT001, FBT002
+        *,
+        cancel_futures: bool = False,
+    ) -> None:
+        """Record that shutdown reached the underlying executor."""
+        del wait, cancel_futures
+        self.shutdown_called.set()
 
 
 @pytest.mark.asyncio
@@ -141,6 +179,70 @@ async def test_interpreter_executor_propagates_worker_exception(
 
 
 @pytest.mark.asyncio
+async def test_interpreter_executor_shutdown_waits_for_active_map(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent shutdown waits until an active map operation releases the pool."""
+    blocking_executor = _BlockingMapExecutor()
+    monkeypatch.setattr(
+        ci,
+        "_create_interpreter_pool_executor",
+        lambda max_workers: blocking_executor,
+    )
+    executor = ci.InterpreterPoolCpuTaskExecutor()
+    map_task = asyncio.create_task(executor.map_ordered(_square, (2, 4)))
+
+    map_started = await asyncio.to_thread(blocking_executor.map_started.wait, 5)
+    assert map_started, "Expected map_ordered() to reach the underlying executor."
+
+    shutdown_task = asyncio.create_task(asyncio.to_thread(executor.shutdown))
+    await asyncio.sleep(0.05)
+    assert not blocking_executor.shutdown_called.is_set(), (
+        "Expected shutdown() to wait for the active map_ordered() call."
+    )
+
+    blocking_executor.release_map.set()
+    assert await map_task == [4, 16]
+    await shutdown_task
+    assert blocking_executor.shutdown_called.is_set(), (
+        "Expected shutdown() to reach the pool after map_ordered() completes."
+    )
+
+
+@pytest.mark.asyncio
+async def test_interpreter_executor_map_after_shutdown_creates_new_pool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Calling shutdown before later fan-out does not poison the executor."""
+    created_pools: list[cf.ThreadPoolExecutor] = []
+
+    def fake_create_interpreter_pool_executor(
+        max_workers: int | None,
+    ) -> cf.ThreadPoolExecutor:
+        pool = cf.ThreadPoolExecutor(max_workers=max_workers)
+        created_pools.append(pool)
+        return pool
+
+    monkeypatch.setattr(
+        ci,
+        "_create_interpreter_pool_executor",
+        fake_create_interpreter_pool_executor,
+    )
+    executor = ci.InterpreterPoolCpuTaskExecutor(max_workers=1)
+    executor.shutdown()
+
+    try:
+        results = await executor.map_ordered(_square, (3,))
+    finally:
+        executor.shutdown()
+
+    assert results == [9]
+    assert len(created_pools) == 1, (
+        "Expected post-shutdown mapping to create exactly one new pool."
+    )
+
+
+@pytest.mark.asyncio
 async def test_inline_executor_handles_empty_input() -> None:
     """Inline adapter returns an empty list for empty workloads."""
     executor = ci.InlineCpuTaskExecutor()
@@ -205,17 +307,22 @@ async def test_interpreter_executor_handles_empty_input(
     ],
 )
 def test_builder_selects_executor_based_on_environment(
-    monkeypatch: pytest.MonkeyPatch,
     env_flag: str,
     mock_support: bool | None,  # noqa: FBT001
     expected_type: type[object],
 ) -> None:
     """Builder picks the expected executor for each environment combination."""
-    monkeypatch.setenv("EPISODIC_USE_INTERPRETER_POOL", env_flag)
+    environ = {"EPISODIC_USE_INTERPRETER_POOL": env_flag}
+    capability_detector = ci.interpreter_pool_supported
     if mock_support is not None:
-        monkeypatch.setattr(ci, "interpreter_pool_supported", lambda: mock_support)
 
-    executor = ci.build_cpu_task_executor_from_environment()
+        def capability_detector() -> bool:
+            return mock_support
+
+    executor = ci.build_cpu_task_executor_from_environment(
+        environ,
+        capability_detector=capability_detector,
+    )
 
     assert isinstance(executor, expected_type), (
         f"Expected {expected_type.__name__} based on environment configuration."
@@ -244,16 +351,20 @@ async def test_builder_parses_max_workers_from_environment(
         captured["max_workers"] = max_workers
         return cf.ThreadPoolExecutor(max_workers=1)
 
-    monkeypatch.setenv("EPISODIC_USE_INTERPRETER_POOL", "1")
-    monkeypatch.setenv("EPISODIC_INTERPRETER_POOL_MAX_WORKERS", env_value)
-    monkeypatch.setattr(ci, "interpreter_pool_supported", lambda: True)
     monkeypatch.setattr(
         ci,
         "_create_interpreter_pool_executor",
         fake_create_interpreter_pool_executor,
     )
+    environ = {
+        "EPISODIC_USE_INTERPRETER_POOL": "1",
+        "EPISODIC_INTERPRETER_POOL_MAX_WORKERS": env_value,
+    }
 
-    executor = ci.build_cpu_task_executor_from_environment()
+    executor = ci.build_cpu_task_executor_from_environment(
+        environ,
+        capability_detector=lambda: True,
+    )
     assert isinstance(executor, ci.InterpreterPoolCpuTaskExecutor)
 
     try:

--- a/tests/test_interpreter_executor.py
+++ b/tests/test_interpreter_executor.py
@@ -289,7 +289,7 @@ def test_builder_selects_executor_based_on_environment(
 
     executor = ci.build_cpu_task_executor_from_environment(
         environ,
-        capability_check=capability_check,
+        _capability_check=capability_check,
     )
 
     assert isinstance(executor, expected_type), (
@@ -331,7 +331,7 @@ async def test_builder_parses_max_workers_from_environment(
 
     executor = ci.build_cpu_task_executor_from_environment(
         environ,
-        capability_check=lambda: True,
+        _capability_check=lambda: True,
     )
     assert isinstance(executor, ci.InterpreterPoolCpuTaskExecutor)
 

--- a/tests/test_interpreter_executor.py
+++ b/tests/test_interpreter_executor.py
@@ -287,8 +287,9 @@ def test_builder_selects_executor_based_on_environment(
         def capability_check() -> bool:
             return mock_support
 
-    executor = ci.build_cpu_task_executor_from_environment(
+    executor = ci._build_cpu_task_executor_from_environment(
         environ,
+        metrics=ci._CPU_TASK_EXECUTOR_METRICS,
         _capability_check=capability_check,
     )
 
@@ -329,8 +330,9 @@ async def test_builder_parses_max_workers_from_environment(
         "EPISODIC_INTERPRETER_POOL_MAX_WORKERS": env_value,
     }
 
-    executor = ci.build_cpu_task_executor_from_environment(
+    executor = ci._build_cpu_task_executor_from_environment(
         environ,
+        metrics=ci._CPU_TASK_EXECUTOR_METRICS,
         _capability_check=lambda: True,
     )
     assert isinstance(executor, ci.InterpreterPoolCpuTaskExecutor)

--- a/tests/test_interpreter_executor.py
+++ b/tests/test_interpreter_executor.py
@@ -210,10 +210,10 @@ async def test_interpreter_executor_shutdown_waits_for_active_map(
 
 
 @pytest.mark.asyncio
-async def test_interpreter_executor_map_after_shutdown_creates_new_pool(
+async def test_interpreter_executor_map_after_shutdown_raises(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Calling shutdown before later fan-out does not poison the executor."""
+    """Calling map_ordered after shutdown raises instead of creating a pool."""
     created_pools: list[cf.ThreadPoolExecutor] = []
 
     def fake_create_interpreter_pool_executor(
@@ -231,15 +231,20 @@ async def test_interpreter_executor_map_after_shutdown_creates_new_pool(
     executor = ci.InterpreterPoolCpuTaskExecutor(max_workers=1)
     executor.shutdown()
 
-    try:
-        results = await executor.map_ordered(_square, (3,))
-    finally:
-        executor.shutdown()
+    with pytest.raises(RuntimeError, match="has been shut down"):
+        await executor.map_ordered(_square, (3,))
 
-    assert results == [9]
-    assert len(created_pools) == 1, (
-        "Expected post-shutdown mapping to create exactly one new pool."
+    assert not created_pools, (
+        "Expected post-shutdown mapping to avoid creating a new pool."
     )
+
+
+def test_interpreter_executor_shutdown_is_idempotent() -> None:
+    """Calling shutdown twice is a no-op after the first shutdown."""
+    executor = ci.InterpreterPoolCpuTaskExecutor()
+
+    executor.shutdown()
+    executor.shutdown()
 
 
 @pytest.mark.asyncio
@@ -313,15 +318,15 @@ def test_builder_selects_executor_based_on_environment(
 ) -> None:
     """Builder picks the expected executor for each environment combination."""
     environ = {"EPISODIC_USE_INTERPRETER_POOL": env_flag}
-    capability_detector = ci.interpreter_pool_supported
+    capability_check = ci.interpreter_pool_supported
     if mock_support is not None:
 
-        def capability_detector() -> bool:
+        def capability_check() -> bool:
             return mock_support
 
     executor = ci.build_cpu_task_executor_from_environment(
         environ,
-        capability_detector=capability_detector,
+        capability_check=capability_check,
     )
 
     assert isinstance(executor, expected_type), (
@@ -363,7 +368,7 @@ async def test_builder_parses_max_workers_from_environment(
 
     executor = ci.build_cpu_task_executor_from_environment(
         environ,
-        capability_detector=lambda: True,
+        capability_check=lambda: True,
     )
     assert isinstance(executor, ci.InterpreterPoolCpuTaskExecutor)
 

--- a/tests/test_interpreter_executor.py
+++ b/tests/test_interpreter_executor.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
+import asyncio
 import concurrent.futures as cf
+import operator
+import typing as typ
+from unittest import mock
 
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 
 import episodic.concurrent_interpreters as ci
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
 
 
 def _square(value: int) -> int:
@@ -20,6 +29,17 @@ def _explode_on_three(value: int) -> int:
     return value
 
 
+def _affine(value: int) -> int:
+    return (value * 3) - 7
+
+
+_ORDERED_MAP_TASKS: dict[str, cabc.Callable[[int], int]] = {
+    "affine": _affine,
+    "negate": typ.cast("cabc.Callable[[int], int]", operator.neg),
+    "square": _square,
+}
+
+
 @pytest.mark.asyncio
 async def test_inline_executor_maps_values_in_order() -> None:
     """Inline execution preserves deterministic input ordering."""
@@ -29,6 +49,25 @@ async def test_inline_executor_maps_values_in_order() -> None:
 
     assert results == [4, 1, 9], (
         "Expected inline executor to keep map output aligned with input order."
+    )
+
+
+@given(
+    items=st.lists(st.integers(min_value=-100, max_value=100), max_size=25),
+    task_name=st.sampled_from(sorted(_ORDERED_MAP_TASKS)),
+)
+def test_inline_executor_preserves_order_for_arbitrary_inputs(
+    items: list[int],
+    task_name: str,
+) -> None:
+    """Inline execution preserves map ordering for generated inputs."""
+    task = _ORDERED_MAP_TASKS[task_name]
+    executor = ci.InlineCpuTaskExecutor()
+
+    results = asyncio.run(executor.map_ordered(task, tuple(items)))
+
+    assert results == [task(item) for item in items], (
+        "Expected inline executor output to align with generated input order."
     )
 
 
@@ -51,6 +90,34 @@ async def test_interpreter_executor_maps_values_in_order(
 
     assert results == [4, 1, 9], (
         "Expected interpreter-backed executor to keep output aligned with input order."
+    )
+
+
+@given(
+    items=st.lists(st.integers(min_value=-100, max_value=100), max_size=25),
+    task_name=st.sampled_from(sorted(_ORDERED_MAP_TASKS)),
+)
+def test_interpreter_executor_preserves_order_for_arbitrary_inputs(
+    items: list[int],
+    task_name: str,
+) -> None:
+    """Interpreter-backed execution preserves map ordering for generated inputs."""
+    create_executor = mock.patch.object(
+        ci,
+        "_create_interpreter_pool_executor",
+        side_effect=lambda max_workers: cf.ThreadPoolExecutor(max_workers=max_workers),
+    )
+    task = _ORDERED_MAP_TASKS[task_name]
+    with create_executor:
+        executor = ci.InterpreterPoolCpuTaskExecutor(max_workers=3)
+
+        try:
+            results = asyncio.run(executor.map_ordered(task, tuple(items)))
+        finally:
+            executor.shutdown()
+
+    assert results == [task(item) for item in items], (
+        "Expected interpreter-backed executor output to align with input order."
     )
 
 

--- a/tests/test_interpreter_executor_lifecycle.py
+++ b/tests/test_interpreter_executor_lifecycle.py
@@ -1,10 +1,9 @@
-"""Lifecycle and observability tests for interpreter CPU task executors."""
+"""Lifecycle tests for interpreter CPU task executors."""
 
 from __future__ import annotations
 
 import asyncio
 import concurrent.futures as cf
-import dataclasses as dc
 import threading
 import typing as typ
 from unittest import mock
@@ -22,6 +21,14 @@ if typ.TYPE_CHECKING:
 def _square(value: int) -> int:
     """Return the square of a generated executor input."""
     return value * value
+
+
+def _raise_on_negative(value: int) -> int:
+    """Raise on negative values for generated failure-state tests."""
+    if value < 0:
+        msg = "negative values are rejected"
+        raise ValueError(msg)
+    return value
 
 
 class _BlockingMapExecutor(cf.Executor):
@@ -56,63 +63,6 @@ class _BlockingMapExecutor(cf.Executor):
         """Record that shutdown reached the underlying executor."""
         del wait, cancel_futures
         self.shutdown_called.set()
-
-
-@dc.dataclass(slots=True)
-class _FakeCpuTaskExecutorMetrics:
-    """Capture executor metrics for observability assertions."""
-
-    counters: list[tuple[str, dict[str, str]]] = dc.field(default_factory=list)
-    observations: list[tuple[str, float, dict[str, str]]] = dc.field(
-        default_factory=list,
-    )
-
-    def increment_counter(
-        self,
-        name: str,
-        *,
-        labels: cabc.Mapping[str, str],
-    ) -> None:
-        """Record a counter increment."""
-        self.counters.append((name, dict(labels)))
-
-    def observe_latency_ms(
-        self,
-        name: str,
-        value: float,
-        *,
-        labels: cabc.Mapping[str, str],
-    ) -> None:
-        """Record an observed measurement."""
-        self.observations.append((name, value, dict(labels)))
-
-
-@dc.dataclass(slots=True)
-class _FakeCpuTaskExecutorClock:
-    """Return deterministic monotonic timestamps for executor tests."""
-
-    timestamps: list[float]
-
-    def monotonic_seconds(self) -> float:
-        """Return the next configured timestamp."""
-        return self.timestamps.pop(0)
-
-
-@dc.dataclass(slots=True)
-class _FakeLogger:
-    """Capture logger calls without depending on process-wide logging config."""
-
-    messages: list[str] = dc.field(default_factory=list)
-
-    def info(self, message: str, **kwargs: object) -> None:
-        """Record an info-level message."""
-        del kwargs
-        self.messages.append(message)
-
-    def exception(self, message: str, **kwargs: object) -> None:
-        """Record an exception-level message."""
-        del kwargs
-        self.messages.append(message)
 
 
 @settings(max_examples=25, deadline=None)
@@ -217,45 +167,98 @@ def test_interpreter_executor_lifecycle_state_sequences(
     assert created_pools == expected_created_pools
 
 
-@pytest.mark.asyncio
-async def test_interpreter_executor_records_lifecycle_observability(
-    monkeypatch: pytest.MonkeyPatch,
+@settings(max_examples=20, deadline=None)
+@given(
+    first_count=st.integers(min_value=1, max_value=4),
+    second_count=st.integers(min_value=1, max_value=4),
+    release_order=st.sampled_from(["first", "second"]),
+)
+def test_interpreter_executor_concurrent_maps_then_shutdown_are_terminal(
+    first_count: int,
+    second_count: int,
+    release_order: str,
 ) -> None:
-    """Interpreter-pool creation, map utilisation, and shutdown emit signals."""
-    metrics = _FakeCpuTaskExecutorMetrics()
-    clock = _FakeCpuTaskExecutorClock(timestamps=[1.0, 1.025])
-    logger = _FakeLogger()
-    monkeypatch.setattr(
+    """Generated multi-map interleavings serialise before terminal shutdown."""
+
+    async def exercise_interleaving() -> None:
+        create_executor = mock.patch.object(
+            ci,
+            "_create_interpreter_pool_executor",
+            side_effect=lambda max_workers: cf.ThreadPoolExecutor(
+                max_workers=max_workers,
+            ),
+        )
+        with create_executor:
+            executor = ci.InterpreterPoolCpuTaskExecutor(max_workers=2)
+            first_items = tuple(range(first_count))
+            second_items = tuple(range(second_count))
+            first_task = asyncio.create_task(executor.map_ordered(_square, first_items))
+            second_task = asyncio.create_task(
+                executor.map_ordered(_square, second_items),
+            )
+
+            if release_order == "second":
+                second_result, first_result = await asyncio.gather(
+                    second_task,
+                    first_task,
+                )
+            else:
+                first_result, second_result = await asyncio.gather(
+                    first_task,
+                    second_task,
+                )
+
+            assert first_result == [_square(item) for item in first_items]
+            assert second_result == [_square(item) for item in second_items]
+
+            executor.shutdown()
+            with pytest.raises(RuntimeError, match="has been shut down"):
+                await executor.map_ordered(_square, first_items)
+
+    asyncio.run(exercise_interleaving())
+
+
+@settings(max_examples=30, deadline=None)
+@given(
+    operations=st.lists(
+        st.sampled_from(["map_success", "map_error", "shutdown"]),
+        min_size=1,
+        max_size=6,
+    ),
+)
+def test_interpreter_executor_failure_sequences_remain_terminal(
+    operations: list[str],
+) -> None:
+    """Generated map-failure sequences preserve shutdown as terminal state."""
+    create_executor = mock.patch.object(
         ci,
         "_create_interpreter_pool_executor",
-        lambda max_workers: cf.ThreadPoolExecutor(max_workers=max_workers),
+        side_effect=lambda max_workers: cf.ThreadPoolExecutor(max_workers=max_workers),
     )
-    monkeypatch.setattr(ci, "_log", logger)
-    executor = ci.InterpreterPoolCpuTaskExecutor(
-        max_workers=1,
-        metrics=metrics,
-        clock=clock,
-    )
+    with create_executor:
+        executor = ci.InterpreterPoolCpuTaskExecutor(max_workers=2)
+        is_shutdown = False
 
-    try:
-        results = await executor.map_ordered(_square, (2, 3))
-    finally:
+        for operation in operations:
+            if operation == "shutdown":
+                executor.shutdown()
+                is_shutdown = True
+                continue
+
+            items = (-1,) if operation == "map_error" else (1, 2)
+            if is_shutdown:
+                with pytest.raises(RuntimeError, match="has been shut down"):
+                    asyncio.run(executor.map_ordered(_raise_on_negative, items))
+                continue
+            if operation == "map_error":
+                with pytest.raises(ValueError, match="negative values are rejected"):
+                    asyncio.run(executor.map_ordered(_raise_on_negative, items))
+            else:
+                assert asyncio.run(executor.map_ordered(_raise_on_negative, items)) == [
+                    1,
+                    2,
+                ]
+
         executor.shutdown()
-
-    assert results == [4, 9]
-    assert (
-        "interpreter_pool.map.calls",
-        {"outcome": "success"},
-    ) in metrics.counters
-    assert (
-        "interpreter_pool.map.items",
-        2.0,
-        {"outcome": "success"},
-    ) in metrics.observations
-    assert (
-        "interpreter_pool.shutdown.latency_ms",
-        pytest.approx(25.0),
-        {"outcome": "success"},
-    ) in metrics.observations
-    assert "Created interpreter-pool executor" in logger.messages
-    assert "Shut down interpreter-pool executor" in logger.messages
+        with pytest.raises(RuntimeError, match="has been shut down"):
+            asyncio.run(executor.map_ordered(_raise_on_negative, (1,)))

--- a/tests/test_interpreter_executor_lifecycle.py
+++ b/tests/test_interpreter_executor_lifecycle.py
@@ -1,0 +1,261 @@
+"""Lifecycle and observability tests for interpreter CPU task executors."""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures as cf
+import dataclasses as dc
+import threading
+import typing as typ
+from unittest import mock
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+import episodic.concurrent_interpreters as ci
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+
+
+def _square(value: int) -> int:
+    """Return the square of a generated executor input."""
+    return value * value
+
+
+class _BlockingMapExecutor(cf.Executor):
+    """Executor test double that exposes map/shutdown ordering."""
+
+    def __init__(self) -> None:
+        self.map_started = threading.Event()
+        self.release_map = threading.Event()
+        self.shutdown_called = threading.Event()
+
+    def map(
+        self,
+        fn: cabc.Callable[..., int],
+        *iterables: cabc.Iterable[typ.Any],
+        **kwargs: object,
+    ) -> cabc.Iterator[int]:
+        """Block mapped work until the test releases it."""
+        del kwargs
+        items = tuple(typ.cast("cabc.Iterable[int]", iterables[0]))
+        self.map_started.set()
+        if not self.release_map.wait(timeout=5):
+            msg = "Timed out waiting for test to release executor.map()."
+            raise TimeoutError(msg)
+        return iter(fn(item) for item in items)
+
+    def shutdown(
+        self,
+        wait: bool = True,  # noqa: FBT001, FBT002
+        *,
+        cancel_futures: bool = False,
+    ) -> None:
+        """Record that shutdown reached the underlying executor."""
+        del wait, cancel_futures
+        self.shutdown_called.set()
+
+
+@dc.dataclass(slots=True)
+class _FakeCpuTaskExecutorMetrics:
+    """Capture executor metrics for observability assertions."""
+
+    counters: list[tuple[str, dict[str, str]]] = dc.field(default_factory=list)
+    observations: list[tuple[str, float, dict[str, str]]] = dc.field(
+        default_factory=list,
+    )
+
+    def increment_counter(
+        self,
+        name: str,
+        *,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Record a counter increment."""
+        self.counters.append((name, dict(labels)))
+
+    def observe_latency_ms(
+        self,
+        name: str,
+        value: float,
+        *,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Record an observed measurement."""
+        self.observations.append((name, value, dict(labels)))
+
+
+@dc.dataclass(slots=True)
+class _FakeCpuTaskExecutorClock:
+    """Return deterministic monotonic timestamps for executor tests."""
+
+    timestamps: list[float]
+
+    def monotonic_seconds(self) -> float:
+        """Return the next configured timestamp."""
+        return self.timestamps.pop(0)
+
+
+@dc.dataclass(slots=True)
+class _FakeLogger:
+    """Capture logger calls without depending on process-wide logging config."""
+
+    messages: list[str] = dc.field(default_factory=list)
+
+    def info(self, message: str, **kwargs: object) -> None:
+        """Record an info-level message."""
+        del kwargs
+        self.messages.append(message)
+
+    def exception(self, message: str, **kwargs: object) -> None:
+        """Record an exception-level message."""
+        del kwargs
+        self.messages.append(message)
+
+
+@settings(max_examples=25, deadline=None)
+@given(
+    item_count=st.integers(min_value=1, max_value=5),
+    release_before_shutdown=st.booleans(),
+)
+def test_interpreter_executor_shutdown_race_preserves_state(
+    item_count: int,
+    release_before_shutdown: bool,  # noqa: FBT001
+) -> None:
+    """Generated map/shutdown races leave the executor terminal after shutdown."""
+
+    async def exercise_race() -> None:
+        blocking_executor = _BlockingMapExecutor()
+        create_executor = mock.patch.object(
+            ci,
+            "_create_interpreter_pool_executor",
+            side_effect=lambda max_workers: blocking_executor,
+        )
+        with create_executor:
+            executor = ci.InterpreterPoolCpuTaskExecutor()
+            items = tuple(range(item_count))
+            map_task = asyncio.create_task(executor.map_ordered(_square, items))
+
+            map_started = await asyncio.to_thread(
+                blocking_executor.map_started.wait,
+                5,
+            )
+            assert map_started, "Expected map_ordered() to reach executor.map()."
+
+            if release_before_shutdown:
+                blocking_executor.release_map.set()
+                assert await map_task == [_square(item) for item in items]
+                executor.shutdown()
+            else:
+                shutdown_task = asyncio.create_task(
+                    asyncio.to_thread(executor.shutdown),
+                )
+                await asyncio.sleep(0)
+                assert not blocking_executor.shutdown_called.is_set()
+                blocking_executor.release_map.set()
+                assert await map_task == [_square(item) for item in items]
+                await shutdown_task
+
+            assert blocking_executor.shutdown_called.is_set()
+            with pytest.raises(RuntimeError, match="has been shut down"):
+                await executor.map_ordered(_square, items)
+
+    asyncio.run(exercise_race())
+
+
+@settings(max_examples=40, deadline=None)
+@given(
+    operations=st.lists(
+        st.sampled_from(["map_empty", "map_values", "shutdown"]),
+        min_size=1,
+        max_size=8,
+    ),
+    item_count=st.integers(min_value=1, max_value=5),
+)
+def test_interpreter_executor_lifecycle_state_sequences(
+    operations: list[str],
+    item_count: int,
+) -> None:
+    """Generated lifecycle sequences enforce terminal shutdown semantics."""
+    created_pools = 0
+
+    def fake_create_interpreter_pool_executor(max_workers: int | None) -> cf.Executor:
+        nonlocal created_pools
+        created_pools += 1
+        return cf.ThreadPoolExecutor(max_workers=max_workers)
+
+    create_executor = mock.patch.object(
+        ci,
+        "_create_interpreter_pool_executor",
+        side_effect=fake_create_interpreter_pool_executor,
+    )
+    with create_executor:
+        executor = ci.InterpreterPoolCpuTaskExecutor(max_workers=2)
+        is_shutdown = False
+        expected_created_pools = 0
+
+        for operation in operations:
+            if operation == "shutdown":
+                executor.shutdown()
+                is_shutdown = True
+                continue
+
+            items = () if operation == "map_empty" else tuple(range(item_count))
+            if is_shutdown:
+                with pytest.raises(RuntimeError, match="has been shut down"):
+                    asyncio.run(executor.map_ordered(_square, items))
+                continue
+
+            results = asyncio.run(executor.map_ordered(_square, items))
+            assert results == [_square(item) for item in items]
+            if items and expected_created_pools == 0:
+                expected_created_pools = 1
+
+        executor.shutdown()
+    assert created_pools == expected_created_pools
+
+
+@pytest.mark.asyncio
+async def test_interpreter_executor_records_lifecycle_observability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Interpreter-pool creation, map utilisation, and shutdown emit signals."""
+    metrics = _FakeCpuTaskExecutorMetrics()
+    clock = _FakeCpuTaskExecutorClock(timestamps=[1.0, 1.025])
+    logger = _FakeLogger()
+    monkeypatch.setattr(
+        ci,
+        "_create_interpreter_pool_executor",
+        lambda max_workers: cf.ThreadPoolExecutor(max_workers=max_workers),
+    )
+    monkeypatch.setattr(ci, "_log", logger)
+    executor = ci.InterpreterPoolCpuTaskExecutor(
+        max_workers=1,
+        metrics=metrics,
+        clock=clock,
+    )
+
+    try:
+        results = await executor.map_ordered(_square, (2, 3))
+    finally:
+        executor.shutdown()
+
+    assert results == [4, 9]
+    assert (
+        "interpreter_pool.map.calls",
+        {"outcome": "success"},
+    ) in metrics.counters
+    assert (
+        "interpreter_pool.map.items",
+        2.0,
+        {"outcome": "success"},
+    ) in metrics.observations
+    assert (
+        "interpreter_pool.shutdown.latency_ms",
+        pytest.approx(25.0),
+        {"outcome": "success"},
+    ) in metrics.observations
+    assert "Created interpreter-pool executor" in logger.messages
+    assert "Shut down interpreter-pool executor" in logger.messages

--- a/tests/test_interpreter_executor_lifecycle.py
+++ b/tests/test_interpreter_executor_lifecycle.py
@@ -1,7 +1,5 @@
 """Lifecycle tests for interpreter CPU task executors."""
 
-from __future__ import annotations
-
 import asyncio
 import concurrent.futures as cf
 from unittest import mock

--- a/tests/test_interpreter_executor_lifecycle.py
+++ b/tests/test_interpreter_executor_lifecycle.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures as cf
-import threading
-import typing as typ
 from unittest import mock
 
 import pytest
@@ -13,14 +11,8 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 import episodic.concurrent_interpreters as ci
-
-if typ.TYPE_CHECKING:
-    import collections.abc as cabc
-
-
-def _square(value: int) -> int:
-    """Return the square of a generated executor input."""
-    return value * value
+from tests.conftest import BlockingMapExecutor as _BlockingMapExecutor
+from tests.conftest import square_executor_value as _square
 
 
 def _raise_on_negative(value: int) -> int:
@@ -29,40 +21,6 @@ def _raise_on_negative(value: int) -> int:
         msg = "negative values are rejected"
         raise ValueError(msg)
     return value
-
-
-class _BlockingMapExecutor(cf.Executor):
-    """Executor test double that exposes map/shutdown ordering."""
-
-    def __init__(self) -> None:
-        self.map_started = threading.Event()
-        self.release_map = threading.Event()
-        self.shutdown_called = threading.Event()
-
-    def map(
-        self,
-        fn: cabc.Callable[..., int],
-        *iterables: cabc.Iterable[typ.Any],
-        **kwargs: object,
-    ) -> cabc.Iterator[int]:
-        """Block mapped work until the test releases it."""
-        del kwargs
-        items = tuple(typ.cast("cabc.Iterable[int]", iterables[0]))
-        self.map_started.set()
-        if not self.release_map.wait(timeout=5):
-            msg = "Timed out waiting for test to release executor.map()."
-            raise TimeoutError(msg)
-        return iter(fn(item) for item in items)
-
-    def shutdown(
-        self,
-        wait: bool = True,  # noqa: FBT001, FBT002
-        *,
-        cancel_futures: bool = False,
-    ) -> None:
-        """Record that shutdown reached the underlying executor."""
-        del wait, cancel_futures
-        self.shutdown_called.set()
 
 
 @settings(max_examples=25, deadline=None)

--- a/tests/test_interpreter_executor_observability.py
+++ b/tests/test_interpreter_executor_observability.py
@@ -149,13 +149,13 @@ def test_builder_records_executor_selection_metrics(
     )
     unsupported_executor = ci.build_cpu_task_executor_from_environment(
         {"EPISODIC_USE_INTERPRETER_POOL": "1"},
-        capability_check=lambda: False,
         metrics=metrics,
+        _capability_check=lambda: False,
     )
     executor = ci.build_cpu_task_executor_from_environment(
         {"EPISODIC_USE_INTERPRETER_POOL": "1"},
-        capability_check=lambda: True,
         metrics=metrics,
+        _capability_check=lambda: True,
     )
     assert isinstance(executor, ci.InterpreterPoolCpuTaskExecutor)
 
@@ -189,8 +189,8 @@ async def test_builder_passes_metrics_to_interpreter_executor(
     )
     executor = ci.build_cpu_task_executor_from_environment(
         {"EPISODIC_USE_INTERPRETER_POOL": "1"},
-        capability_check=lambda: True,
         metrics=metrics,
+        _capability_check=lambda: True,
     )
     assert isinstance(executor, ci.InterpreterPoolCpuTaskExecutor)
 

--- a/tests/test_interpreter_executor_observability.py
+++ b/tests/test_interpreter_executor_observability.py
@@ -147,12 +147,12 @@ def test_builder_records_executor_selection_metrics(
         {},
         metrics=metrics,
     )
-    unsupported_executor = ci.build_cpu_task_executor_from_environment(
+    unsupported_executor = ci._build_cpu_task_executor_from_environment(
         {"EPISODIC_USE_INTERPRETER_POOL": "1"},
         metrics=metrics,
         _capability_check=lambda: False,
     )
-    executor = ci.build_cpu_task_executor_from_environment(
+    executor = ci._build_cpu_task_executor_from_environment(
         {"EPISODIC_USE_INTERPRETER_POOL": "1"},
         metrics=metrics,
         _capability_check=lambda: True,
@@ -187,7 +187,7 @@ async def test_builder_passes_metrics_to_interpreter_executor(
         "_create_interpreter_pool_executor",
         lambda max_workers: cf.ThreadPoolExecutor(max_workers=max_workers),
     )
-    executor = ci.build_cpu_task_executor_from_environment(
+    executor = ci._build_cpu_task_executor_from_environment(
         {"EPISODIC_USE_INTERPRETER_POOL": "1"},
         metrics=metrics,
         _capability_check=lambda: True,

--- a/tests/test_interpreter_executor_observability.py
+++ b/tests/test_interpreter_executor_observability.py
@@ -15,6 +15,13 @@ if typ.TYPE_CHECKING:
     import collections.abc as cabc
 
 
+def _shutdown_if_supported(executor: ci.CpuTaskExecutor) -> None:
+    """Shut down executor implementations that own runtime resources."""
+    shutdown = getattr(executor, "shutdown", None)
+    if shutdown is not None:
+        shutdown()
+
+
 @dc.dataclass(slots=True)
 class _FakeCpuTaskExecutorMetrics:
     """Capture executor metrics for observability assertions."""
@@ -136,8 +143,11 @@ def test_builder_records_executor_selection_metrics(
     """Builder fallback and pool selections increment bounded counters."""
     metrics = _FakeCpuTaskExecutorMetrics()
 
-    ci.build_cpu_task_executor_from_environment({}, metrics=metrics)
-    ci.build_cpu_task_executor_from_environment(
+    disabled_executor = ci.build_cpu_task_executor_from_environment(
+        {},
+        metrics=metrics,
+    )
+    unsupported_executor = ci.build_cpu_task_executor_from_environment(
         {"EPISODIC_USE_INTERPRETER_POOL": "1"},
         capability_check=lambda: False,
         metrics=metrics,
@@ -161,6 +171,8 @@ def test_builder_records_executor_selection_metrics(
         "cpu_task_executor.selections",
         {"executor": "interpreter_pool", "reason": "enabled"},
     ) in metrics.counters
+    _shutdown_if_supported(disabled_executor)
+    _shutdown_if_supported(unsupported_executor)
     executor.shutdown()
 
 

--- a/tests/test_interpreter_executor_observability.py
+++ b/tests/test_interpreter_executor_observability.py
@@ -1,7 +1,5 @@
 """Observability tests for interpreter CPU task executors."""
 
-from __future__ import annotations
-
 import concurrent.futures as cf
 import dataclasses as dc
 import typing as typ

--- a/tests/test_interpreter_executor_observability.py
+++ b/tests/test_interpreter_executor_observability.py
@@ -9,14 +9,10 @@ import typing as typ
 import pytest
 
 import episodic.concurrent_interpreters as ci
+from tests.conftest import square_executor_value as _square
 
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
-
-
-def _square(value: int) -> int:
-    """Return the square of an executor input."""
-    return value * value
 
 
 @dc.dataclass(slots=True)
@@ -126,11 +122,6 @@ async def test_interpreter_executor_records_lifecycle_observability(
         {"outcome": "success"},
     ) in metrics.counters
     assert (
-        "interpreter_pool.utilization",
-        2.0,
-        {"outcome": "success"},
-    ) in metrics.observations
-    assert (
         "interpreter_pool.shutdown.latency_ms",
         pytest.approx(25.0),
         {"outcome": "success"},
@@ -144,16 +135,17 @@ def test_builder_records_executor_selection_metrics(
 ) -> None:
     """Builder fallback and pool selections increment bounded counters."""
     metrics = _FakeCpuTaskExecutorMetrics()
-    monkeypatch.setattr(ci, "_CPU_TASK_EXECUTOR_METRICS", metrics)
 
-    ci.build_cpu_task_executor_from_environment({})
+    ci.build_cpu_task_executor_from_environment({}, metrics=metrics)
     ci.build_cpu_task_executor_from_environment(
         {"EPISODIC_USE_INTERPRETER_POOL": "1"},
         capability_check=lambda: False,
+        metrics=metrics,
     )
     executor = ci.build_cpu_task_executor_from_environment(
         {"EPISODIC_USE_INTERPRETER_POOL": "1"},
         capability_check=lambda: True,
+        metrics=metrics,
     )
     assert isinstance(executor, ci.InterpreterPoolCpuTaskExecutor)
 
@@ -170,3 +162,33 @@ def test_builder_records_executor_selection_metrics(
         {"executor": "interpreter_pool", "reason": "enabled"},
     ) in metrics.counters
     executor.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_builder_passes_metrics_to_interpreter_executor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Builder-provided metrics receive interpreter executor lifecycle signals."""
+    metrics = _FakeCpuTaskExecutorMetrics()
+    monkeypatch.setattr(
+        ci,
+        "_create_interpreter_pool_executor",
+        lambda max_workers: cf.ThreadPoolExecutor(max_workers=max_workers),
+    )
+    executor = ci.build_cpu_task_executor_from_environment(
+        {"EPISODIC_USE_INTERPRETER_POOL": "1"},
+        capability_check=lambda: True,
+        metrics=metrics,
+    )
+    assert isinstance(executor, ci.InterpreterPoolCpuTaskExecutor)
+
+    try:
+        assert await executor.map_ordered(_square, (2,)) == [4]
+    finally:
+        executor.shutdown()
+
+    assert (
+        "interpreter_pool.map.items",
+        1.0,
+        {"outcome": "success"},
+    ) in metrics.observations

--- a/tests/test_interpreter_executor_observability.py
+++ b/tests/test_interpreter_executor_observability.py
@@ -44,7 +44,17 @@ class _FakeCpuTaskExecutorMetrics:
         *,
         labels: cabc.Mapping[str, str],
     ) -> None:
-        """Record an observed measurement."""
+        """Record an observed latency measurement."""
+        self.observations.append((name, value, dict(labels)))
+
+    def observe_value(
+        self,
+        name: str,
+        value: float,
+        *,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Record an observed non-latency measurement."""
         self.observations.append((name, value, dict(labels)))
 
 

--- a/tests/test_interpreter_executor_observability.py
+++ b/tests/test_interpreter_executor_observability.py
@@ -1,0 +1,162 @@
+"""Observability tests for interpreter CPU task executors."""
+
+from __future__ import annotations
+
+import concurrent.futures as cf
+import dataclasses as dc
+import typing as typ
+
+import pytest
+
+import episodic.concurrent_interpreters as ci
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+
+
+def _square(value: int) -> int:
+    """Return the square of an executor input."""
+    return value * value
+
+
+@dc.dataclass(slots=True)
+class _FakeCpuTaskExecutorMetrics:
+    """Capture executor metrics for observability assertions."""
+
+    counters: list[tuple[str, dict[str, str]]] = dc.field(default_factory=list)
+    observations: list[tuple[str, float, dict[str, str]]] = dc.field(
+        default_factory=list,
+    )
+
+    def increment_counter(
+        self,
+        name: str,
+        *,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Record a counter increment."""
+        self.counters.append((name, dict(labels)))
+
+    def observe_latency_ms(
+        self,
+        name: str,
+        value: float,
+        *,
+        labels: cabc.Mapping[str, str],
+    ) -> None:
+        """Record an observed measurement."""
+        self.observations.append((name, value, dict(labels)))
+
+
+@dc.dataclass(slots=True)
+class _FakeCpuTaskExecutorClock:
+    """Return deterministic monotonic timestamps for executor tests."""
+
+    timestamps: list[float]
+
+    def monotonic_seconds(self) -> float:
+        """Return the next configured timestamp."""
+        return self.timestamps.pop(0)
+
+
+@dc.dataclass(slots=True)
+class _FakeLogger:
+    """Capture logger calls without depending on process-wide logging config."""
+
+    messages: list[str] = dc.field(default_factory=list)
+
+    def info(self, message: str, **kwargs: object) -> None:
+        """Record an info-level message."""
+        del kwargs
+        self.messages.append(message)
+
+    def exception(self, message: str, **kwargs: object) -> None:
+        """Record an exception-level message."""
+        del kwargs
+        self.messages.append(message)
+
+
+@pytest.mark.asyncio
+async def test_interpreter_executor_records_lifecycle_observability(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Interpreter-pool creation, map utilisation, and shutdown emit signals."""
+    metrics = _FakeCpuTaskExecutorMetrics()
+    clock = _FakeCpuTaskExecutorClock(timestamps=[1.0, 1.025])
+    logger = _FakeLogger()
+    monkeypatch.setattr(
+        ci,
+        "_create_interpreter_pool_executor",
+        lambda max_workers: cf.ThreadPoolExecutor(max_workers=max_workers),
+    )
+    monkeypatch.setattr(ci, "_log", logger)
+    executor = ci.InterpreterPoolCpuTaskExecutor(
+        max_workers=1,
+        metrics=metrics,
+        clock=clock,
+    )
+
+    try:
+        results = await executor.map_ordered(_square, (2, 3))
+    finally:
+        executor.shutdown()
+
+    assert results == [4, 9]
+    assert (
+        "interpreter_pool.map.calls",
+        {"outcome": "success"},
+    ) in metrics.counters
+    assert (
+        "interpreter_pool.map.items",
+        2.0,
+        {"outcome": "success"},
+    ) in metrics.observations
+    assert (
+        "interpreter_pool.creations",
+        {"outcome": "success"},
+    ) in metrics.counters
+    assert (
+        "interpreter_pool.utilization",
+        2.0,
+        {"outcome": "success"},
+    ) in metrics.observations
+    assert (
+        "interpreter_pool.shutdown.latency_ms",
+        pytest.approx(25.0),
+        {"outcome": "success"},
+    ) in metrics.observations
+    assert "Created interpreter-pool executor" in logger.messages
+    assert "Shut down interpreter-pool executor" in logger.messages
+
+
+def test_builder_records_executor_selection_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Builder fallback and pool selections increment bounded counters."""
+    metrics = _FakeCpuTaskExecutorMetrics()
+    monkeypatch.setattr(ci, "_CPU_TASK_EXECUTOR_METRICS", metrics)
+
+    ci.build_cpu_task_executor_from_environment({})
+    ci.build_cpu_task_executor_from_environment(
+        {"EPISODIC_USE_INTERPRETER_POOL": "1"},
+        capability_check=lambda: False,
+    )
+    executor = ci.build_cpu_task_executor_from_environment(
+        {"EPISODIC_USE_INTERPRETER_POOL": "1"},
+        capability_check=lambda: True,
+    )
+    assert isinstance(executor, ci.InterpreterPoolCpuTaskExecutor)
+
+    assert (
+        "cpu_task_executor.selections",
+        {"executor": "inline", "reason": "feature_flag_disabled"},
+    ) in metrics.counters
+    assert (
+        "cpu_task_executor.selections",
+        {"executor": "inline", "reason": "interpreter_pool_unavailable"},
+    ) in metrics.counters
+    assert (
+        "cpu_task_executor.selections",
+        {"executor": "interpreter_pool", "reason": "enabled"},
+    ) in metrics.counters
+    executor.shutdown()

--- a/tests/test_worker_interpreter_task_integration.py
+++ b/tests/test_worker_interpreter_task_integration.py
@@ -6,7 +6,6 @@ import asyncio
 import typing as typ
 
 import episodic.concurrent_interpreters as ci
-from tests.conftest import double_worker_value
 
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
@@ -37,7 +36,7 @@ def test_eager_cpu_task_body_uses_environment_executor_pattern(
         executor = ci.build_cpu_task_executor_from_environment()
         try:
             results = asyncio.run(
-                executor.map_ordered(double_worker_value, validated_items),
+                executor.map_ordered(abs, validated_items),
             )
         finally:
             shutdown = getattr(executor, "shutdown", None)
@@ -46,10 +45,10 @@ def test_eager_cpu_task_body_uses_environment_executor_pattern(
         return {"results": results}
 
     task_result = app.tasks["tests.worker.cpu_fanout_probe"].delay({
-        "items": [1, 3, 5],
+        "items": [-1, 3, -5],
     })
 
-    assert task_result.get() == {"results": [2, 6, 10]}
+    assert task_result.get() == {"results": [1, 3, 5]}
     assert captured_interpreter_pool_workers == [2], (
         "Expected eager Celery task body to honour interpreter-pool env."
     )

--- a/tests/test_worker_interpreter_task_integration.py
+++ b/tests/test_worker_interpreter_task_integration.py
@@ -1,7 +1,5 @@
 """Celery task-boundary tests for interpreter-backed CPU fan-out."""
 
-from __future__ import annotations
-
 import asyncio
 import os
 import typing as typ

--- a/tests/test_worker_interpreter_task_integration.py
+++ b/tests/test_worker_interpreter_task_integration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import typing as typ
 
 import episodic.concurrent_interpreters as ci
@@ -33,7 +34,7 @@ def test_eager_cpu_task_body_uses_environment_executor_pattern(
                 raise TypeError(msg)
             items.append(item)
         validated_items = tuple(items)
-        executor = ci.build_cpu_task_executor_from_environment()
+        executor = ci.build_cpu_task_executor_from_environment(os.environ)
         try:
             results = asyncio.run(
                 executor.map_ordered(abs, validated_items),

--- a/tests/test_worker_interpreter_task_integration.py
+++ b/tests/test_worker_interpreter_task_integration.py
@@ -1,0 +1,55 @@
+"""Celery task-boundary tests for interpreter-backed CPU fan-out."""
+
+from __future__ import annotations
+
+import asyncio
+import typing as typ
+
+import episodic.concurrent_interpreters as ci
+from tests.conftest import double_worker_value
+
+if typ.TYPE_CHECKING:
+    import collections.abc as cabc
+
+
+def test_eager_cpu_task_body_uses_environment_executor_pattern(
+    captured_interpreter_pool_workers: list[int | None],
+    runtime_environ: dict[str, str],
+) -> None:
+    """Exercise interpreter-pool fan-out from inside an eager Celery task body."""
+    from episodic.worker import create_celery_app, load_runtime_config
+
+    app = create_celery_app(load_runtime_config(runtime_environ))
+
+    @app.task(name="tests.worker.cpu_fanout_probe")
+    def run_cpu_fanout_probe(payload: cabc.Mapping[str, object]) -> dict[str, object]:
+        raw_items = payload["items"]
+        if not isinstance(raw_items, list):
+            msg = "items must be a JSON list."
+            raise TypeError(msg)
+        items: list[int] = []
+        for item in raw_items:
+            if not isinstance(item, int):
+                msg = "items must contain only integers."
+                raise TypeError(msg)
+            items.append(item)
+        validated_items = tuple(items)
+        executor = ci.build_cpu_task_executor_from_environment()
+        try:
+            results = asyncio.run(
+                executor.map_ordered(double_worker_value, validated_items),
+            )
+        finally:
+            shutdown = getattr(executor, "shutdown", None)
+            if shutdown is not None:
+                shutdown()
+        return {"results": results}
+
+    task_result = app.tasks["tests.worker.cpu_fanout_probe"].delay({
+        "items": [1, 3, 5],
+    })
+
+    assert task_result.get() == {"results": [2, 6, 10]}
+    assert captured_interpreter_pool_workers == [2], (
+        "Expected eager Celery task body to honour interpreter-pool env."
+    )

--- a/tests/test_worker_service_scaffold.py
+++ b/tests/test_worker_service_scaffold.py
@@ -1,9 +1,12 @@
 """Tests for the Celery worker scaffold."""
 
+import concurrent.futures as cf
 import dataclasses as dc
 import typing as typ
 
 import pytest
+
+import episodic.concurrent_interpreters as ci
 
 if typ.TYPE_CHECKING:
     from kombu import Queue
@@ -55,6 +58,21 @@ def _runtime_environ() -> dict[str, str]:
         "EPISODIC_CELERY_BROKER_URL": "amqp://guest:guest@localhost:5672//",
         "EPISODIC_CELERY_ALWAYS_EAGER": "true",
     }
+
+
+def _double(value: int) -> int:
+    return value * 2
+
+
+async def _cpu_task_inner_fan_out(items: tuple[int, ...]) -> list[int]:
+    """Mirror the documented CPU task interpreter-pool integration pattern."""
+    executor = ci.build_cpu_task_executor_from_environment()
+    try:
+        return await executor.map_ordered(_double, items)
+    finally:
+        shutdown = getattr(executor, "shutdown", None)
+        if shutdown is not None:
+            shutdown()
 
 
 def test_worker_topology_defines_io_and_cpu_queues() -> None:
@@ -237,6 +255,57 @@ def test_build_worker_launch_profiles_maps_workloads_to_distinct_pools() -> None
     assert profiles[WorkloadClass.CPU_BOUND].pool is WorkerPool.PREFORK
     assert profiles[WorkloadClass.CPU_BOUND].concurrency == 6
     assert profiles[WorkloadClass.CPU_BOUND].queue_name == "episodic.cpu"
+
+
+@pytest.mark.asyncio
+async def test_cpu_task_inner_fan_out_uses_environment_executor_pattern(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exercise the documented CPU task interpreter-pool integration seam."""
+    monkeypatch.setenv("EPISODIC_USE_INTERPRETER_POOL", "1")
+    monkeypatch.setenv("EPISODIC_INTERPRETER_POOL_MAX_WORKERS", "2")
+    monkeypatch.setattr(ci, "interpreter_pool_supported", lambda: True)
+
+    captured_max_workers: list[int | None] = []
+
+    def fake_create_interpreter_pool_executor(max_workers: int | None) -> cf.Executor:
+        captured_max_workers.append(max_workers)
+        return cf.ThreadPoolExecutor(max_workers=max_workers)
+
+    monkeypatch.setattr(
+        ci,
+        "_create_interpreter_pool_executor",
+        fake_create_interpreter_pool_executor,
+    )
+
+    results = await _cpu_task_inner_fan_out((1, 3, 5))
+
+    assert results == [2, 6, 10], (
+        "Expected task-level executor fan-out to preserve input ordering."
+    )
+    assert captured_max_workers == [2], (
+        "Expected task-level executor creation to honour interpreter-pool env."
+    )
+
+
+@pytest.mark.asyncio
+async def test_cpu_task_inner_fan_out_falls_back_when_flag_is_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keep CPU task fan-out runnable when interpreter-pool dispatch is off."""
+    monkeypatch.delenv("EPISODIC_USE_INTERPRETER_POOL", raising=False)
+    monkeypatch.setattr(ci, "interpreter_pool_supported", lambda: True)
+    monkeypatch.setattr(
+        ci,
+        "_create_interpreter_pool_executor",
+        pytest.fail,
+    )
+
+    results = await _cpu_task_inner_fan_out((2, 4))
+
+    assert results == [4, 8], (
+        "Expected documented task-level pattern to fall back to inline execution."
+    )
 
 
 def test_create_celery_app_registers_task_routes_and_queues() -> None:

--- a/tests/test_worker_service_scaffold.py
+++ b/tests/test_worker_service_scaffold.py
@@ -1,78 +1,14 @@
 """Tests for the Celery worker scaffold."""
 
-import concurrent.futures as cf
-import dataclasses as dc
 import typing as typ
 
 import pytest
 
 import episodic.concurrent_interpreters as ci
+from tests.conftest import FakeCpuDiagnostic, FakeIoDiagnostic, cpu_task_inner_fan_out
 
 if typ.TYPE_CHECKING:
     from kombu import Queue
-
-    from episodic.worker import (
-        CpuDiagnosticRequest,
-        CpuDiagnosticResult,
-        IoDiagnosticRequest,
-        IoDiagnosticResult,
-    )
-
-
-@dc.dataclass(slots=True)
-class _FakeIoDiagnostic:
-    """Record an I/O-bound diagnostic request and return a canned response."""
-
-    seen_messages: list[str]
-
-    def __call__(self, request: IoDiagnosticRequest) -> IoDiagnosticResult:
-        from episodic.worker import IoDiagnosticResult
-
-        self.seen_messages.append(request.message)
-        return IoDiagnosticResult(
-            message=request.message,
-            correlation_id=request.correlation_id,
-            worker_kind="io-bound",
-        )
-
-
-@dc.dataclass(slots=True)
-class _FakeCpuDiagnostic:
-    """Record a CPU-bound diagnostic request and return a canned response."""
-
-    seen_iterations: list[int]
-
-    def __call__(self, request: CpuDiagnosticRequest) -> CpuDiagnosticResult:
-        from episodic.worker import CpuDiagnosticResult
-
-        self.seen_iterations.append(request.iterations)
-        return CpuDiagnosticResult(
-            digest=f"digest-{request.iterations}",
-            iterations=request.iterations,
-            worker_kind="cpu-bound",
-        )
-
-
-def _runtime_environ() -> dict[str, str]:
-    return {
-        "EPISODIC_CELERY_BROKER_URL": "amqp://guest:guest@localhost:5672//",
-        "EPISODIC_CELERY_ALWAYS_EAGER": "true",
-    }
-
-
-def _double(value: int) -> int:
-    return value * 2
-
-
-async def _cpu_task_inner_fan_out(items: tuple[int, ...]) -> list[int]:
-    """Mirror the documented CPU task interpreter-pool integration pattern."""
-    executor = ci.build_cpu_task_executor_from_environment()
-    try:
-        return await executor.map_ordered(_double, items)
-    finally:
-        shutdown = getattr(executor, "shutdown", None)
-        if shutdown is not None:
-            shutdown()
 
 
 def test_worker_topology_defines_io_and_cpu_queues() -> None:
@@ -220,18 +156,21 @@ def test_load_runtime_config_rejects_invalid_env_values(
     env_key: str,
     env_value: str,
     expected_message: str,
+    runtime_environ: dict[str, str],
 ) -> None:
     """Reject invalid environment values through runtime configuration."""
     from episodic.worker import load_runtime_config
 
     with pytest.raises(RuntimeError, match=expected_message):
         load_runtime_config({
-            **_runtime_environ(),
+            **runtime_environ,
             env_key: env_value,
         })
 
 
-def test_build_worker_launch_profiles_maps_workloads_to_distinct_pools() -> None:
+def test_build_worker_launch_profiles_maps_workloads_to_distinct_pools(
+    runtime_environ: dict[str, str],
+) -> None:
     """Capture the documented pool split between I/O and CPU workloads."""
     from episodic.worker import (
         WorkerPool,
@@ -241,7 +180,7 @@ def test_build_worker_launch_profiles_maps_workloads_to_distinct_pools() -> None
     )
 
     config = load_runtime_config({
-        **_runtime_environ(),
+        **runtime_environ,
         "EPISODIC_CELERY_IO_POOL": "eventlet",
         "EPISODIC_CELERY_IO_CONCURRENCY": "128",
         "EPISODIC_CELERY_CPU_CONCURRENCY": "6",
@@ -259,31 +198,15 @@ def test_build_worker_launch_profiles_maps_workloads_to_distinct_pools() -> None
 
 @pytest.mark.asyncio
 async def test_cpu_task_inner_fan_out_uses_environment_executor_pattern(
-    monkeypatch: pytest.MonkeyPatch,
+    captured_interpreter_pool_workers: list[int | None],
 ) -> None:
     """Exercise the documented CPU task interpreter-pool integration seam."""
-    monkeypatch.setenv("EPISODIC_USE_INTERPRETER_POOL", "1")
-    monkeypatch.setenv("EPISODIC_INTERPRETER_POOL_MAX_WORKERS", "2")
-    monkeypatch.setattr(ci, "interpreter_pool_supported", lambda: True)
-
-    captured_max_workers: list[int | None] = []
-
-    def fake_create_interpreter_pool_executor(max_workers: int | None) -> cf.Executor:
-        captured_max_workers.append(max_workers)
-        return cf.ThreadPoolExecutor(max_workers=max_workers)
-
-    monkeypatch.setattr(
-        ci,
-        "_create_interpreter_pool_executor",
-        fake_create_interpreter_pool_executor,
-    )
-
-    results = await _cpu_task_inner_fan_out((1, 3, 5))
+    results = await cpu_task_inner_fan_out((1, 3, 5))
 
     assert results == [2, 6, 10], (
         "Expected task-level executor fan-out to preserve input ordering."
     )
-    assert captured_max_workers == [2], (
+    assert captured_interpreter_pool_workers == [2], (
         "Expected task-level executor creation to honour interpreter-pool env."
     )
 
@@ -301,14 +224,16 @@ async def test_cpu_task_inner_fan_out_falls_back_when_flag_is_disabled(
         pytest.fail,
     )
 
-    results = await _cpu_task_inner_fan_out((2, 4))
+    results = await cpu_task_inner_fan_out((2, 4))
 
     assert results == [4, 8], (
         "Expected documented task-level pattern to fall back to inline execution."
     )
 
 
-def test_create_celery_app_registers_task_routes_and_queues() -> None:
+def test_create_celery_app_registers_task_routes_and_queues(
+    runtime_environ: dict[str, str],
+) -> None:
     """Configure the documented queue topology on the Celery app."""
     from episodic.worker import (
         CPU_DIAGNOSTIC_TASK_NAME,
@@ -318,7 +243,7 @@ def test_create_celery_app_registers_task_routes_and_queues() -> None:
         load_runtime_config,
     )
 
-    app = create_celery_app(load_runtime_config(_runtime_environ()))
+    app = create_celery_app(load_runtime_config(runtime_environ))
     queues = typ.cast("tuple[Queue, ...]", app.conf.task_queues)
 
     assert app.conf.task_default_exchange == DEFAULT_WORKER_TOPOLOGY.exchange_name
@@ -352,7 +277,9 @@ def test_create_celery_app_registers_task_routes_and_queues() -> None:
     assert CPU_DIAGNOSTIC_TASK_NAME in app.tasks
 
 
-def test_create_celery_app_executes_representative_tasks_through_dependencies() -> None:
+def test_create_celery_app_executes_representative_tasks_through_dependencies(
+    runtime_environ: dict[str, str],
+) -> None:
     """Run eager tasks and prove that the task bodies depend on typed seams."""
     from episodic.worker import (
         CPU_DIAGNOSTIC_TASK_NAME,
@@ -362,10 +289,10 @@ def test_create_celery_app_executes_representative_tasks_through_dependencies() 
         load_runtime_config,
     )
 
-    io_handler = _FakeIoDiagnostic(seen_messages=[])
-    cpu_handler = _FakeCpuDiagnostic(seen_iterations=[])
+    io_handler = FakeIoDiagnostic(seen_messages=[])
+    cpu_handler = FakeCpuDiagnostic(seen_iterations=[])
     app = create_celery_app(
-        load_runtime_config(_runtime_environ()),
+        load_runtime_config(runtime_environ),
         WorkerDependencies(
             io_diagnostic=io_handler,
             cpu_diagnostic=cpu_handler,


### PR DESCRIPTION
## Summary

This branch documents the coupling point between the Celery worker scaffold and the Python 3.14 interpreter-pool executor so future CPU-bound task authors can find the intended intra-task fan-out path.

Closes #66.

## Review walkthrough

- Start with [episodic/worker/tasks.py](https://github.com/leynos/episodic/blob/issue-66-reconcile-celery-worker-scaffold-with-subinterpreter/episodic/worker/tasks.py) to see the task-author pattern for `build_cpu_task_executor_from_environment()` and `map_ordered(...)`.
- Then review [episodic/worker/runtime.py](https://github.com/leynos/episodic/blob/issue-66-reconcile-celery-worker-scaffold-with-subinterpreter/episodic/worker/runtime.py) for the boundary between Celery pool configuration and task-level interpreter-pool knobs.
- Finish with [docs/adr/adr-003-celery-worker-scaffold.md](https://github.com/leynos/episodic/blob/issue-66-reconcile-celery-worker-scaffold-with-subinterpreter/docs/adr/adr-003-celery-worker-scaffold.md) for the architectural cross-reference to the Python 3.14 concurrent-interpreter decision.

## Validation

- `make fmt`: passed.
- `make check-fmt`: passed.
- `make markdownlint`: passed.
- `make nixie`: passed.
- `make lint`: passed.
- `make typecheck`: passed.
- `make test`: final rerun passed, reporting 477 passed and 3 skipped.

## Notes

- Earlier full `make test` attempts hit transient `pytest-timeout` setup errors in py-pglite-backed async fixtures. The affected tests passed when rerun directly before the final full-suite pass.

## Summary by Sourcery

Clarify how Celery worker runtime configuration relates to CPU-bound task interpreter-pool settings and document the intended task-level fan-out path via concurrent interpreters.

Documentation:
- Expand WorkerRuntimeConfig docstring to describe Celery-level dispatch concerns and explicitly distinguish task-level interpreter-pool environment variables and their executor adapter.
- Update the Celery worker scaffold ADR to document optional interpreter-pool fan-out for CPU-bound tasks and cross-reference the Python 3.14 concurrent-interpreters decision and related modules.