### PR TITLE
Add CrossHair contracts for Chrono arithmetic (#102)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ nixie: ## Validate Mermaid diagrams
 	$(call ensure_tool,nixie)
 	$(NIXIE) --no-sandbox
 
-test: build $(VENV_TOOLS) ## Run tests
+test: build crosshair $(VENV_TOOLS) ## Run tests
 	$(UV_ENV) $(UV) run pytest -v -n $(PYTEST_XDIST_WORKERS)
 
 check-migrations: build $(VENV_TOOLS) ## Check for schema drift between models and migrations

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ PYLINT_PYPY_SHIM = git+https://github.com/leynos/pylint-pypy-shim.git@$(PYLINT_P
 PYLINT = $(UV_ENV) $(UV) tool run --python $(PYLINT_PYTHON) --from '$(PYLINT_PYPY_SHIM)' pylint-pypy
 
 .PHONY: help all clean build build-release lint fmt check-fmt \
-        markdownlint nixie test typecheck check-migrations $(TOOLS) $(VENV_TOOLS)
+        markdownlint nixie test typecheck crosshair check-migrations $(TOOLS) $(VENV_TOOLS)
 
 .DEFAULT_GOAL := all
 
@@ -80,6 +80,9 @@ check-architecture: build ## Check hexagonal architecture import boundaries
 typecheck: build ## Run typechecking
 	$(UV_ENV) $(UV) tool run ty==0.0.32 --version
 	$(UV_ENV) $(UV) tool run ty==0.0.32 check
+
+crosshair: build ## Verify CrossHair PEP 316 contracts
+	$(UV_ENV) $(UV) run crosshair check --analysis_kind=PEP316 episodic/qa/chrono.py
 
 markdownlint: ## Lint Markdown files
 	env -u NO_COLOR $(MDLINT) '**/*.md'

--- a/docs/adr/adr-006-chrono-spoken-text-semantics.md
+++ b/docs/adr/adr-006-chrono-spoken-text-semantics.md
@@ -202,8 +202,8 @@ contracts around the pure `_compute_estimated_seconds(...)` helper. CrossHair
 symbolically checks the same safety boundary that matters for the estimator:
 valid inputs have a non-negative word count and positive words-per-minute
 setting, zero words produce zero seconds, and positive word counts use the
-documented ceiling formula. The surrounding dataclass guards enforce the same
-input preconditions at Chrono's runtime boundaries.
+documented integer-only ceiling formula. The surrounding dataclass guards
+enforce the same input preconditions at Chrono's runtime boundaries.
 
 ## Consequences
 
@@ -218,9 +218,8 @@ input preconditions at Chrono's runtime boundaries.
 - Nested inline segmentation can no longer inflate runtime estimates by
   double-counting child text.
 - Chrono now has a Python-native symbolic verification gate for the
-  deterministic
-  duration arithmetic without adding a Rust verification toolchain to this
-  repository.
+  deterministic duration arithmetic without adding a Rust verification
+  toolchain to this repository.
 
 ### Negative
 

--- a/docs/adr/adr-006-chrono-spoken-text-semantics.md
+++ b/docs/adr/adr-006-chrono-spoken-text-semantics.md
@@ -195,6 +195,16 @@ baseline estimator, not a linguistic model. Keeping the token pattern versioned
 and visible makes later improvements comparable rather than silently changing
 historical runtime estimates.
 
+Chrono is Python application code, so Kani and Verus are out of scope for its
+numeric arithmetic. Those tools verify Rust code and cannot be applied directly
+to `episodic/qa/chrono.py`. Chrono instead uses CrossHair with Python PEP 316
+contracts around the pure `_compute_estimated_seconds(...)` helper. CrossHair
+symbolically checks the same safety boundary that matters for the estimator:
+valid inputs have a non-negative word count and positive words-per-minute
+setting, zero words produce zero seconds, and positive word counts use the
+documented ceiling formula. The surrounding dataclass guards enforce the same
+input preconditions at Chrono's runtime boundaries.
+
 ## Consequences
 
 ### Positive
@@ -207,6 +217,10 @@ historical runtime estimates.
   Chrono and any future spoken-script consumer.
 - Nested inline segmentation can no longer inflate runtime estimates by
   double-counting child text.
+- Chrono now has a Python-native symbolic verification gate for the
+  deterministic
+  duration arithmetic without adding a Rust verification toolchain to this
+  repository.
 
 ### Negative
 
@@ -216,6 +230,9 @@ historical runtime estimates.
   with valid TEI P5 fixtures.
 - Non-Latin scripts and pure numeric speech are undercounted by the first naive
   estimator unless a later version broadens tokenisation.
+- CrossHair covers the pure numeric helper only. It does not replace the
+  behavioural, property, or TEI-validation tests that exercise Chrono's parser
+  boundary and orchestration side effects.
 
 ### Neutral
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -606,9 +606,8 @@ Pedante and Chrono are implemented in the `episodic/qa/` package.
   `tests/features/chrono.feature` with steps in
   `tests/steps/test_chrono_steps.py`.
 - Chrono contract tests live in `tests/test_chrono_contracts.py`. They pin the
-  direct helper behaviour for `_ceil_seconds(...)`,
-  `_seconds_contract_holds(...)`, and `_compute_estimated_seconds(...)` so the
-  CrossHair gate has ordinary unit and property-test coverage beside symbolic
+  direct helper behaviour for `_compute_estimated_seconds(...)` so the CrossHair
+  gate has ordinary unit and property-test coverage beside symbolic
   verification. The same module includes the `pytest.mark.crosshair` subprocess
   gate for `crosshair check --analysis_kind=PEP316 episodic/qa/chrono.py`.
 - Chrono behavioural tests do not launch Vidai Mock because Chrono has no

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -585,10 +585,10 @@ Pedante and Chrono are implemented in the `episodic/qa/` package.
   effects belong at the estimator orchestration boundary.
 - Keep Chrono's numeric duration arithmetic in small pure helpers. The
   `_compute_estimated_seconds(...)` helper carries Python Enhancement Proposal
-  (PEP) 316 contracts verified by CrossHair. Run
-  `crosshair check --analysis_kind=PEP316 episodic/qa/chrono.py` after changing
-  the word-count, words-per-minute, or ceiling-rounding policy. Kani and Verus
-  are Rust verification tools and are not applicable to this Python module.
+  (PEP) 316 contracts verified by CrossHair. Run `make crosshair` after
+  changing the word-count, words-per-minute, or ceiling-rounding policy. Kani
+  and Verus are Rust verification tools and are not applicable to this Python
+  module.
 
 ### Testing the evaluator
 
@@ -609,7 +609,8 @@ Pedante and Chrono are implemented in the `episodic/qa/` package.
   direct helper behaviour for `_ceil_seconds(...)`,
   `_seconds_contract_holds(...)`, and `_compute_estimated_seconds(...)` so the
   CrossHair gate has ordinary unit and property-test coverage beside symbolic
-  verification.
+  verification. The same module includes the `pytest.mark.crosshair` subprocess
+  gate for `crosshair check --analysis_kind=PEP316 episodic/qa/chrono.py`.
 - Chrono behavioural tests do not launch Vidai Mock because Chrono has no
   inference-service boundary in roadmap item `2.2.6`.
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -11,6 +11,7 @@ Accepted design decisions relevant to current implementation work:
 - [`adr-003-celery-worker-scaffold.md`](adr/adr-003-celery-worker-scaffold.md)
 - [`adr-004-show-notes-tei-representation.md`](adr/adr-004-show-notes-tei-representation.md)
 - [`adr-005-structured-planning-and-tool-execution.md`](adr/adr-005-structured-planning-and-tool-execution.md)
+- [`adr-006-chrono-spoken-text-semantics.md`](adr/adr-006-chrono-spoken-text-semantics.md)
 - [`episodic-podcast-generation-system-design.md`](episodic-podcast-generation-system-design.md)
 
 ## Local development
@@ -606,10 +607,10 @@ Pedante and Chrono are implemented in the `episodic/qa/` package.
   `tests/features/chrono.feature` with steps in
   `tests/steps/test_chrono_steps.py`.
 - Chrono contract tests live in `tests/test_chrono_contracts.py`. They pin the
-  direct helper behaviour for `_compute_estimated_seconds(...)` so the CrossHair
-  gate has ordinary unit and property-test coverage beside symbolic
-  verification. The same module includes the `pytest.mark.crosshair` subprocess
-  gate for `crosshair check --analysis_kind=PEP316 episodic/qa/chrono.py`.
+  public estimator behaviour backed by `_compute_estimated_seconds(...)` so the
+  CrossHair gate has property-test coverage beside symbolic verification. The
+  same module includes the `pytest.mark.crosshair` subprocess gate for
+  `crosshair check --analysis_kind=PEP316 episodic/qa/chrono.py`.
 - Chrono behavioural tests do not launch Vidai Mock because Chrono has no
   inference-service boundary in roadmap item `2.2.6`.
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -583,6 +583,12 @@ Pedante and Chrono are implemented in the `episodic/qa/` package.
   high-cardinality payload data. Keep the deterministic spoken-runtime
   calculation free of logging, metrics, and wall-clock reads; those side
   effects belong at the estimator orchestration boundary.
+- Keep Chrono's numeric duration arithmetic in small pure helpers. The
+  `_compute_estimated_seconds(...)` helper carries Python Enhancement Proposal
+  (PEP) 316 contracts verified by CrossHair. Run
+  `crosshair check --analysis_kind=PEP316 episodic/qa/chrono.py` after changing
+  the word-count, words-per-minute, or ceiling-rounding policy. Kani and Verus
+  are Rust verification tools and are not applicable to this Python module.
 
 ### Testing the evaluator
 
@@ -599,6 +605,11 @@ Pedante and Chrono are implemented in the `episodic/qa/` package.
   `tests/test_chrono_langgraph.py`, and its behavioural scenario lives in
   `tests/features/chrono.feature` with steps in
   `tests/steps/test_chrono_steps.py`.
+- Chrono contract tests live in `tests/test_chrono_contracts.py`. They pin the
+  direct helper behaviour for `_ceil_seconds(...)`,
+  `_seconds_contract_holds(...)`, and `_compute_estimated_seconds(...)` so the
+  CrossHair gate has ordinary unit and property-test coverage beside symbolic
+  verification.
 - Chrono behavioural tests do not launch Vidai Mock because Chrono has no
   inference-service boundary in roadmap item `2.2.6`.
 

--- a/docs/execplans/2-2-6-chrono-runtime-estimator.md
+++ b/docs/execplans/2-2-6-chrono-runtime-estimator.md
@@ -208,6 +208,9 @@ XML and unsupported TEI body markup.
   `_compute_estimated_seconds(...)` arithmetic helper, documented why Rust
   verification tools are out of scope for Chrono, and added direct helper tests
   for the CrossHair gate.
+- [x] (2026-05-17 00:00Z) Replaced Chrono's floating-point ceiling expression
+  with integer-only arithmetic, added an automated `pytest.mark.crosshair`
+  subprocess gate, and added `make crosshair` for CI and local verification.
 
 Follow-on roadmap entry: close ADR-006 by accepting or revising the spoken-text
 semantics, then update documentation if the accepted semantics change Chrono's
@@ -348,6 +351,13 @@ supported inputs.
   for the pure `_compute_estimated_seconds(...)` helper, and Chrono's dataclass
   guards enforce the same non-negative word-count and positive words-per-minute
   preconditions at runtime boundaries. Date/Author: 2026-05-17 / Codex.
+
+- Decision: compute Chrono's ceiling seconds with integer arithmetic and run
+  CrossHair through an automated pytest gate plus `make crosshair`. Rationale:
+  integer-only arithmetic avoids floating-point precision edge cases for large
+  generated word counts, and the verification command should be reproducible as
+  a normal gate rather than only documented as a manual instruction.
+  Date/Author: 2026-05-17 / Codex.
 
 ## Outcomes & Retrospective
 

--- a/docs/execplans/2-2-6-chrono-runtime-estimator.md
+++ b/docs/execplans/2-2-6-chrono-runtime-estimator.md
@@ -939,7 +939,7 @@ P5 is the enforced interchange format in Episodic. Raw-text fallback for
 malformed XML was invalid for the future contract and has since been removed;
 minimal TEI-shaped snippets are not acceptable fixtures unless they validate as
 TEI P5 documents, and Chrono should not own TEI spoken-dialogue semantics. That
-remaining work is gated by an ADR and by prioritized `tei-rapporteur` changes
+remaining work is gated by an ADR and by prioritised `tei-rapporteur` changes
 that provide the spoken-text extraction contract Chrono needs.
 
 The next 2026-05-10 revision adds proposed ADR-006 as the Stage I draft. The

--- a/docs/execplans/2-2-6-chrono-runtime-estimator.md
+++ b/docs/execplans/2-2-6-chrono-runtime-estimator.md
@@ -173,14 +173,14 @@ XML and unsupported TEI body markup.
   `2.2.6` completion gate. The extraction gap was closed later in Stage K;
   strict validation and ADR closure remain follow-on work.
 - [x] (2026-05-13 11:10Z) Updated `tei-rapporteur` to
-  `89fc86ef3952ecfde0bb7f653cde217e2651b895` and refreshed the vendored
-  users' guide from the same revision. The guide now documents
+  `89fc86ef3952ecfde0bb7f653cde217e2651b895` and refreshed the vendored users'
+  guide from the same revision. The guide now documents
   `spoken_text_segments(...)`, strict validation, and streaming events for
   spoken text.
 - [x] (2026-05-13 11:30Z) Resume Stage K by replacing Chrono's local
-  `ElementTree` traversal with the Chrono-ready `tei_rapporteur`
-  spoken-text extraction surface, keeping the naive word-count and metadata
-  policy inside Chrono.
+  `ElementTree` traversal with the Chrono-ready `tei_rapporteur` spoken-text
+  extraction surface, keeping the naive word-count and metadata policy inside
+  Chrono.
 - [x] (2026-05-13 12:15Z) Updated Chrono fixtures to valid TEI documents with
   headers and confirmed the focused Chrono suite passes with 29 tests.
 - [x] (2026-05-13 12:35Z) Ran repository gates after the migration:
@@ -204,10 +204,14 @@ XML and unsupported TEI body markup.
   Syrupy snapshots for estimator and graph artefacts, and distinct spoken-word
   counts in concurrent evaluator and graph fixtures. Validation reported
   `477 passed, 3 skipped`.
+- [x] (2026-05-17 00:00Z) Added CrossHair PEP 316 contracts to the pure Chrono
+  `_compute_estimated_seconds(...)` arithmetic helper, documented why Rust
+  verification tools are out of scope for Chrono, and added direct helper tests
+  for the CrossHair gate.
 
-Follow-on roadmap entry: close ADR-006 by accepting or revising the
-spoken-text semantics, then update documentation if the accepted semantics
-change Chrono's supported inputs.
+Follow-on roadmap entry: close ADR-006 by accepting or revising the spoken-text
+semantics, then update documentation if the accepted semantics change Chrono's
+supported inputs.
 
 ## Surprises & Discoveries
 
@@ -250,11 +254,11 @@ change Chrono's supported inputs.
 
 - Observation: the initial `tei-rapporteur` pin exposed `parse_xml`, `to_dict`,
   `to_msgpack`, and `iter_parse`, but not the Chrono-specific spoken-text
-  extraction contract. Evidence: the earlier `docs/tei-rapporteur-users-guide.md`
-  documented paragraph, utterance, and div events, plus inline tagged nodes,
-  but no runtime-estimation extraction API. Impact: Chrono could not safely own
-  local TEI semantics, so the required behaviour moved upstream into
-  `tei-rapporteur` before Stage K.
+  extraction contract. Evidence: the earlier
+  `docs/tei-rapporteur-users-guide.md` documented paragraph, utterance, and div
+  events, plus inline tagged nodes, but no runtime-estimation extraction API.
+  Impact: Chrono could not safely own local TEI semantics, so the required
+  behaviour moved upstream into `tei-rapporteur` before Stage K.
 
 - Observation: after updating `tei-rapporteur` to
   `89fc86ef3952ecfde0bb7f653cde217e2651b895`, `iter_parse(...)` returns
@@ -336,6 +340,14 @@ change Chrono's supported inputs.
   `ValueError` cases and never falls back to raw-text counting; Chrono should
   not create plausible runtime metadata from invalid scripts. Date/Author:
   2026-05-13 / User and Codex.
+
+- Decision: use CrossHair PEP 316 contracts for Chrono numeric arithmetic
+  instead of Kani or Verus. Rationale: Chrono is Python application code, while
+  Kani and Verus verify Rust code and cannot be applied directly to
+  `episodic/qa/chrono.py`. CrossHair provides a Python-native symbolic check
+  for the pure `_compute_estimated_seconds(...)` helper, and Chrono's dataclass
+  guards enforce the same non-negative word-count and positive words-per-minute
+  preconditions at runtime boundaries. Date/Author: 2026-05-17 / Codex.
 
 ## Outcomes & Retrospective
 
@@ -515,8 +527,8 @@ class ChronoRuntimeEstimate:
 Add `ChronoRuntimeEstimator` with an async `evaluate(...)` method or a
 synchronous `estimate(...)` method plus an async adapter method. Prefer the
 shape that best matches the QA graph port without adding fake asynchrony to the
-domain policy. Keep word counting as estimator-local policy, but delegate TEI P5
-parsing and spoken-text extraction to `tei-rapporteur`.
+domain policy. Keep word counting as estimator-local policy, but delegate TEI
+P5 parsing and spoken-text extraction to `tei-rapporteur`.
 
 The original initial heuristic used the Python standard library XML parser and
 raw-text fallback. Stage K replaced it with this `tei-rapporteur`-backed
@@ -779,8 +791,8 @@ spoken_text_segments(...). The remaining follow-on items are ADR-006 acceptance
 and strict contract enforcement.
 ```
 
-For the follow-on strict TEI P5 roadmap item, after ADR-006 is accepted, enforce
-the accepted strict contract and run focused validation:
+For the follow-on strict TEI P5 roadmap item, after ADR-006 is accepted,
+enforce the accepted strict contract and run focused validation:
 
 ```bash
 uv run pytest tests/test_chrono.py tests/test_chrono_properties.py
@@ -917,9 +929,8 @@ P5 is the enforced interchange format in Episodic. Raw-text fallback for
 malformed XML was invalid for the future contract and has since been removed;
 minimal TEI-shaped snippets are not acceptable fixtures unless they validate as
 TEI P5 documents, and Chrono should not own TEI spoken-dialogue semantics. That
-remaining work is
-gated by an ADR and by prioritized `tei-rapporteur` changes that provide the
-spoken-text extraction contract Chrono needs.
+remaining work is gated by an ADR and by prioritized `tei-rapporteur` changes
+that provide the spoken-text extraction contract Chrono needs.
 
 The next 2026-05-10 revision adds proposed ADR-006 as the Stage I draft. The
 ADR is intentionally not yet accepted, so strict TEI P5 validation remains
@@ -927,7 +938,6 @@ blocked until reviewers ratify or revise the proposed TEI P5 spoken-text
 semantics.
 
 The latest 2026-05-13 revision keeps `Status: COMPLETE` authoritative for
-roadmap item `2.2.6`. The deterministic local Chrono slice,
-`tei-rapporteur` spoken-text extraction migration, and validation-error
-propagation are complete, while ADR acceptance is tracked as separate follow-on
-roadmap work.
+roadmap item `2.2.6`. The deterministic local Chrono slice, `tei-rapporteur`
+spoken-text extraction migration, and validation-error propagation are
+complete, while ADR acceptance is tracked as separate follow-on roadmap work.

--- a/docs/execplans/2-2-6-chrono-runtime-estimator.md
+++ b/docs/execplans/2-2-6-chrono-runtime-estimator.md
@@ -939,7 +939,7 @@ P5 is the enforced interchange format in Episodic. Raw-text fallback for
 malformed XML was invalid for the future contract and has since been removed;
 minimal TEI-shaped snippets are not acceptable fixtures unless they validate as
 TEI P5 documents, and Chrono should not own TEI spoken-dialogue semantics. That
-remaining work is gated by an ADR and by prioritised `tei-rapporteur` changes
+remaining work is gated by an ADR and by prioritized `tei-rapporteur` changes
 that provide the spoken-text extraction contract Chrono needs.
 
 The next 2026-05-10 revision adds proposed ADR-006 as the Stage I draft. The

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -267,8 +267,8 @@ jobs.
 - Generated scripts can now receive an internal Chrono spoken-runtime estimate
   during QA. Chrono uses the canonical TEI script through `tei-rapporteur`,
   counts spoken words with a deterministic local heuristic, and records
-  estimator metadata for audit and future comparison. Chrono does not call a
-  Large Language Model (LLM) and does not add provider usage charges. Duration
+  estimator metadata for audit and future comparison. Chrono does not call an
+  LLM (Large Language Model) and does not add provider usage charges. Duration
   estimates round up to the next whole second using integer arithmetic, so any
   non-empty spoken script receives at least a one-second estimate even when a
   custom words-per-minute setting is extremely high.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -268,7 +268,10 @@ jobs.
   during QA. Chrono uses the canonical TEI script through `tei-rapporteur`,
   counts spoken words with a deterministic local heuristic, and records
   estimator metadata for audit and future comparison. Chrono does not call a
-  Large Language Model (LLM) and does not add provider usage charges.
+  Large Language Model (LLM) and does not add provider usage charges. Duration
+  estimates round up to the next whole second using integer arithmetic, so any
+  non-empty spoken script receives at least a one-second estimate even when a
+  custom words-per-minute setting is extremely high.
 - Using the editorial approval workflow
 - Reviewing approval states and audit history for canonical episodes
 - Reviewing and approving generated content

--- a/episodic/qa/chrono.py
+++ b/episodic/qa/chrono.py
@@ -31,7 +31,6 @@ runtime policy.
 
 import dataclasses as dc
 import logging
-import math
 import re
 import time
 import typing as typ
@@ -53,7 +52,7 @@ _METRIC_LATENCY_MS = "chrono.runtime_estimator.latency_ms"
 
 def _ceil_seconds(spoken_word_count: int, words_per_minute: int) -> int:
     """Compute the ceiling-formula estimate used by Chrono contracts."""
-    return math.ceil(spoken_word_count / words_per_minute * 60)
+    return (spoken_word_count * 60 + words_per_minute - 1) // words_per_minute
 
 
 def _seconds_contract_holds(
@@ -61,7 +60,7 @@ def _seconds_contract_holds(
     words_per_minute: int,
     estimated_seconds: int,
 ) -> bool:
-    """Return whether an estimate satisfies Chrono's numeric postconditions."""
+    """Return whether an estimate satisfies CrossHair contract postconditions."""
     return (
         estimated_seconds >= 0
         and (spoken_word_count == 0) == (estimated_seconds == 0)

--- a/episodic/qa/chrono.py
+++ b/episodic/qa/chrono.py
@@ -61,9 +61,14 @@ def _seconds_contract_holds(
     words_per_minute: int,
     estimated_seconds: int,
 ) -> bool:
-    """Return whether an estimate matches the Chrono ceiling formula."""
-    return spoken_word_count == 0 or estimated_seconds == _ceil_seconds(
-        spoken_word_count, words_per_minute
+    """Return whether an estimate satisfies Chrono's numeric postconditions."""
+    return (
+        estimated_seconds >= 0
+        and (spoken_word_count == 0) == (estimated_seconds == 0)
+        and (
+            spoken_word_count == 0
+            or estimated_seconds == _ceil_seconds(spoken_word_count, words_per_minute)
+        )
     )
 
 

--- a/episodic/qa/chrono.py
+++ b/episodic/qa/chrono.py
@@ -50,27 +50,6 @@ _METRIC_EVALUATIONS = "chrono.runtime_estimator.evaluations"
 _METRIC_LATENCY_MS = "chrono.runtime_estimator.latency_ms"
 
 
-def _ceil_seconds(spoken_word_count: int, words_per_minute: int) -> int:
-    """Compute the ceiling-formula estimate used by Chrono contracts."""
-    return (spoken_word_count * 60 + words_per_minute - 1) // words_per_minute
-
-
-def _seconds_contract_holds(
-    spoken_word_count: int,
-    words_per_minute: int,
-    estimated_seconds: int,
-) -> bool:
-    """Return whether an estimate satisfies CrossHair contract postconditions."""
-    return (
-        estimated_seconds >= 0
-        and (spoken_word_count == 0) == (estimated_seconds == 0)
-        and (
-            spoken_word_count == 0
-            or estimated_seconds == _ceil_seconds(spoken_word_count, words_per_minute)
-        )
-    )
-
-
 class ChronoMetricsPort(typ.Protocol):
     """Bounded-cardinality metrics sink for Chrono runtime estimation."""
 
@@ -262,11 +241,11 @@ def _compute_estimated_seconds(spoken_word_count: int, words_per_minute: int) ->
     pre: words_per_minute > 0
     post: __return__ >= 0
     post: (spoken_word_count == 0) == (__return__ == 0)
-    post: _seconds_contract_holds(spoken_word_count, words_per_minute, __return__)
+    post: spoken_word_count==0 or __return__==-(-spoken_word_count*60//words_per_minute)
     """
     if spoken_word_count == 0:
         return 0
-    return _ceil_seconds(spoken_word_count, words_per_minute)
+    return (spoken_word_count * 60 + words_per_minute - 1) // words_per_minute
 
 
 @dc.dataclass(frozen=True, slots=True)

--- a/episodic/qa/chrono.py
+++ b/episodic/qa/chrono.py
@@ -51,6 +51,22 @@ _METRIC_EVALUATIONS = "chrono.runtime_estimator.evaluations"
 _METRIC_LATENCY_MS = "chrono.runtime_estimator.latency_ms"
 
 
+def _ceil_seconds(spoken_word_count: int, words_per_minute: int) -> int:
+    """Compute the ceiling-formula estimate used by Chrono contracts."""
+    return math.ceil(spoken_word_count / words_per_minute * 60)
+
+
+def _seconds_contract_holds(
+    spoken_word_count: int,
+    words_per_minute: int,
+    estimated_seconds: int,
+) -> bool:
+    """Return whether an estimate matches the Chrono ceiling formula."""
+    return spoken_word_count == 0 or estimated_seconds == _ceil_seconds(
+        spoken_word_count, words_per_minute
+    )
+
+
 class ChronoMetricsPort(typ.Protocol):
     """Bounded-cardinality metrics sink for Chrono runtime estimation."""
 
@@ -218,9 +234,10 @@ def _estimate_runtime(
 ) -> ChronoRuntimeEstimate:
     """Build a deterministic Chrono estimate from extracted spoken text."""
     spoken_word_count = _count_spoken_words(spoken_text)
-    estimated_seconds = 0
-    if spoken_word_count > 0:
-        estimated_seconds = math.ceil(spoken_word_count / config.words_per_minute * 60)
+    estimated_seconds = _compute_estimated_seconds(
+        spoken_word_count,
+        config.words_per_minute,
+    )
     metadata = ChronoEstimatorMetadata(
         estimator_name=config.estimator_name,
         estimator_version=config.estimator_version,
@@ -232,6 +249,20 @@ def _estimate_runtime(
         estimated_seconds=estimated_seconds,
         metadata=metadata,
     )
+
+
+def _compute_estimated_seconds(spoken_word_count: int, words_per_minute: int) -> int:
+    """Compute estimated spoken duration in whole seconds.
+
+    pre: spoken_word_count >= 0
+    pre: words_per_minute > 0
+    post: __return__ >= 0
+    post: (spoken_word_count == 0) == (__return__ == 0)
+    post: _seconds_contract_holds(spoken_word_count, words_per_minute, __return__)
+    """
+    if spoken_word_count == 0:
+        return 0
+    return _ceil_seconds(spoken_word_count, words_per_minute)
 
 
 @dc.dataclass(frozen=True, slots=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,9 @@ stilyagi = "stilyagi.stilyagi:main"
 
 [dependency-groups]
 dev = [
-    "crosshair-tool",
+    "crosshair-tool>=0.0.104,<0.1",
     "hypothesis[asyncio]>=6,<7",
-    "mypy",
+    "mypy>=2.1,<3",
     "pytest>=9,<11",
     "pytest-bdd",
     "pytest-asyncio",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,9 @@ stilyagi = "stilyagi.stilyagi:main"
 
 [dependency-groups]
 dev = [
+    "crosshair-tool",
     "hypothesis[asyncio]>=6,<7",
+    "mypy",
     "pytest>=9,<11",
     "pytest-bdd",
     "pytest-asyncio",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -422,6 +422,7 @@ enable = [
 timeout = 60
 markers = [
     "act: integration tests that drive GitHub Actions via act",
+    "crosshair: symbolic contract verification using CrossHair",
     "slow: exercises that take longer or require heavyweight tooling",
 ]
 filterwarnings = [

--- a/tests/test_chrono_contracts.py
+++ b/tests/test_chrono_contracts.py
@@ -1,0 +1,19 @@
+"""CrossHair contract verification for Chrono numeric arithmetic.
+
+Run with:
+    crosshair check --analysis_kind=PEP316 episodic/qa/chrono.py
+
+This module documents the symbolic verification gate for
+_compute_estimated_seconds as a Python-native alternative to Kani/Verus bounded
+model-checking (which are Rust tools and cannot be applied to this codebase).
+
+Properties verified by CrossHair via SMT solving:
+- Non-negativity: estimated_seconds >= 0 for all valid (n, wpm) pairs.
+- Zero-case identity: n == 0 iff result == 0.
+- Formula correctness: result == ceil(n / wpm * 60) for n > 0.
+
+Preconditions that bound the input space (enforced by ChronoEstimatorConfig and
+ChronoEstimatorMetadata __post_init__ guards):
+- spoken_word_count >= 0
+- words_per_minute > 0
+"""

--- a/tests/test_chrono_contracts.py
+++ b/tests/test_chrono_contracts.py
@@ -64,7 +64,6 @@ class TestChronoContracts:
         ("word_count", "words_per_minute", "expected_seconds"),
         [
             (1, 10**400, 1),
-            (0, sys.maxsize, 0),
         ],
     )
     def test_estimate_matches_boundary_inputs(
@@ -119,30 +118,7 @@ class TestChronoContracts:
         spoken_word_count: int,
         words_per_minute: int,
     ) -> None:
-        """The public estimator should match Chrono's arithmetic formula."""
-        request = ChronoEvaluationRequest(
-            script_tei_xml=_script_with_word_count(spoken_word_count)
-        )
-        result = ChronoRuntimeEstimator(
-            config=ChronoEstimatorConfig(words_per_minute=words_per_minute)
-        ).estimate(request)
-
-        assert result.estimated_seconds == (
-            _integer_ceiling_seconds(spoken_word_count, words_per_minute)
-        )
-        assert result.metadata.spoken_word_count == spoken_word_count
-        assert result.metadata.words_per_minute == words_per_minute
-
-    @given(
-        spoken_word_count=_PUBLIC_API_WORD_COUNTS,
-        words_per_minute=_VALID_WORDS_PER_MINUTE,
-    )
-    def test_estimate_satisfies_postconditions(
-        self,
-        spoken_word_count: int,
-        words_per_minute: int,
-    ) -> None:
-        """Public estimates should satisfy the CrossHair postcondition predicate."""
+        """The public estimator should match Chrono's arithmetic contracts."""
         request = ChronoEvaluationRequest(
             script_tei_xml=_script_with_word_count(spoken_word_count)
         )
@@ -151,6 +127,11 @@ class TestChronoContracts:
         ).estimate(request)
         estimated_seconds = result.estimated_seconds
 
+        assert estimated_seconds == (
+            _integer_ceiling_seconds(spoken_word_count, words_per_minute)
+        )
+        assert result.metadata.spoken_word_count == spoken_word_count
+        assert result.metadata.words_per_minute == words_per_minute
         assert estimated_seconds >= 0
         assert (spoken_word_count == 0) == (estimated_seconds == 0)
         assert spoken_word_count == 0 or estimated_seconds == _integer_ceiling_seconds(

--- a/tests/test_chrono_contracts.py
+++ b/tests/test_chrono_contracts.py
@@ -28,10 +28,12 @@ import pytest
 from hypothesis import given
 
 from episodic.qa.chrono import (
-    _compute_estimated_seconds,
+    ChronoEstimatorConfig,
+    ChronoEvaluationRequest,
+    ChronoRuntimeEstimator,
 )
 
-_VALID_WORD_COUNTS = st.integers(min_value=0, max_value=sys.maxsize)
+_PUBLIC_API_WORD_COUNTS = st.integers(min_value=0, max_value=500)
 _VALID_WORDS_PER_MINUTE = st.integers(min_value=1, max_value=sys.maxsize)
 _REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 
@@ -41,24 +43,44 @@ def _integer_ceiling_seconds(spoken_word_count: int, words_per_minute: int) -> i
     return (spoken_word_count * 60 + words_per_minute - 1) // words_per_minute
 
 
+def _tei_document(body: str) -> str:
+    """Wrap a TEI body fixture with the required document header."""
+    return (
+        "<TEI><teiHeader><fileDesc><title>Chrono contract test</title></fileDesc>"
+        f"</teiHeader><text><body>{body}</body></text></TEI>"
+    )
+
+
+def _script_with_word_count(spoken_word_count: int) -> str:
+    """Build a valid TEI script with the requested spoken word count."""
+    spoken_text = " ".join(f"word{index}" for index in range(spoken_word_count))
+    return _tei_document(f"<sp><p>{spoken_text}</p></sp>")
+
+
 class TestChronoContracts:
     """Contract and property coverage for Chrono duration arithmetic."""
 
-    def test_compute_estimated_seconds_matches_boundary_inputs(self) -> None:
-        """The formula helper should match the documented ceiling calculation."""
-        assert _compute_estimated_seconds(1, 150) == 1
-        assert _compute_estimated_seconds(150, 150) == 60
-        assert _compute_estimated_seconds(sys.maxsize, sys.maxsize) == 60
-        assert _compute_estimated_seconds(1, 10**400) == 1
+    def test_estimate_matches_boundary_inputs(self) -> None:
+        """The public estimator should match the documented ceiling calculation."""
+        request = ChronoEvaluationRequest(script_tei_xml=_script_with_word_count(1))
+        result = ChronoRuntimeEstimator(
+            config=ChronoEstimatorConfig(words_per_minute=10**400)
+        ).estimate(request)
 
-    def test_compute_estimated_seconds_preserves_zero_identity(self) -> None:
+        assert result.estimated_seconds == 1
+        assert result.metadata.spoken_word_count == 1
+        assert result.metadata.words_per_minute == 10**400
+
+    def test_estimate_preserves_zero_identity(self) -> None:
         """Zero spoken words should produce a zero-second estimate."""
-        assert _compute_estimated_seconds(0, 1) == 0
-        assert _compute_estimated_seconds(0, sys.maxsize) == 0
+        request = ChronoEvaluationRequest(script_tei_xml=_script_with_word_count(0))
+        result = ChronoRuntimeEstimator(
+            config=ChronoEstimatorConfig(words_per_minute=sys.maxsize)
+        ).estimate(request)
 
-    def test_compute_estimated_seconds_avoids_float_underflow(self) -> None:
-        """Positive word counts should not round down under huge WPM configs."""
-        assert _compute_estimated_seconds(1, 10**400) == 1
+        assert result.estimated_seconds == 0
+        assert result.metadata.spoken_word_count == 0
+        assert result.metadata.words_per_minute == sys.maxsize
 
     @pytest.mark.crosshair
     def test_chrono_crosshair_contracts_pass(self) -> None:
@@ -86,41 +108,60 @@ class TestChronoContracts:
         )
 
     @given(
-        spoken_word_count=_VALID_WORD_COUNTS,
+        spoken_word_count=_PUBLIC_API_WORD_COUNTS,
         words_per_minute=_VALID_WORDS_PER_MINUTE,
     )
-    def test_compute_estimated_seconds_matches_ceiling_formula(
+    def test_estimate_matches_ceiling_formula(
         self,
         spoken_word_count: int,
         words_per_minute: int,
     ) -> None:
-        """The contract helper should match Chrono's arithmetic formula."""
-        assert _compute_estimated_seconds(spoken_word_count, words_per_minute) == (
+        """The public estimator should match Chrono's arithmetic formula."""
+        request = ChronoEvaluationRequest(
+            script_tei_xml=_script_with_word_count(spoken_word_count)
+        )
+        result = ChronoRuntimeEstimator(
+            config=ChronoEstimatorConfig(words_per_minute=words_per_minute)
+        ).estimate(request)
+
+        assert result.estimated_seconds == (
             _integer_ceiling_seconds(spoken_word_count, words_per_minute)
         )
+        assert result.metadata.spoken_word_count == spoken_word_count
+        assert result.metadata.words_per_minute == words_per_minute
 
     @given(words_per_minute=_VALID_WORDS_PER_MINUTE)
-    def test_compute_estimated_seconds_handles_zero_word_count(
+    def test_estimate_handles_zero_word_count(
         self,
         words_per_minute: int,
     ) -> None:
-        """The public contract helper should preserve the zero-case identity."""
-        assert _compute_estimated_seconds(0, words_per_minute) == 0
+        """The public estimator should preserve the zero-case identity."""
+        request = ChronoEvaluationRequest(script_tei_xml=_script_with_word_count(0))
+        result = ChronoRuntimeEstimator(
+            config=ChronoEstimatorConfig(words_per_minute=words_per_minute)
+        ).estimate(request)
+
+        assert result.estimated_seconds == 0
+        assert result.metadata.spoken_word_count == 0
+        assert result.metadata.words_per_minute == words_per_minute
 
     @given(
-        spoken_word_count=_VALID_WORD_COUNTS,
+        spoken_word_count=_PUBLIC_API_WORD_COUNTS,
         words_per_minute=_VALID_WORDS_PER_MINUTE,
     )
-    def test_compute_estimated_seconds_satisfies_postconditions(
+    def test_estimate_satisfies_postconditions(
         self,
         spoken_word_count: int,
         words_per_minute: int,
     ) -> None:
-        """Computed estimates should satisfy the CrossHair postcondition predicate."""
-        estimated_seconds = _compute_estimated_seconds(
-            spoken_word_count,
-            words_per_minute,
+        """Public estimates should satisfy the CrossHair postcondition predicate."""
+        request = ChronoEvaluationRequest(
+            script_tei_xml=_script_with_word_count(spoken_word_count)
         )
+        result = ChronoRuntimeEstimator(
+            config=ChronoEstimatorConfig(words_per_minute=words_per_minute)
+        ).estimate(request)
+        estimated_seconds = result.estimated_seconds
 
         assert estimated_seconds >= 0
         assert (spoken_word_count == 0) == (estimated_seconds == 0)

--- a/tests/test_chrono_contracts.py
+++ b/tests/test_chrono_contracts.py
@@ -133,21 +133,6 @@ class TestChronoContracts:
         assert result.metadata.spoken_word_count == spoken_word_count
         assert result.metadata.words_per_minute == words_per_minute
 
-    @given(words_per_minute=_VALID_WORDS_PER_MINUTE)
-    def test_estimate_handles_zero_word_count(
-        self,
-        words_per_minute: int,
-    ) -> None:
-        """The public estimator should preserve the zero-case identity."""
-        request = ChronoEvaluationRequest(script_tei_xml=_script_with_word_count(0))
-        result = ChronoRuntimeEstimator(
-            config=ChronoEstimatorConfig(words_per_minute=words_per_minute)
-        ).estimate(request)
-
-        assert result.estimated_seconds == 0
-        assert result.metadata.spoken_word_count == 0
-        assert result.metadata.words_per_minute == words_per_minute
-
     @given(
         spoken_word_count=_PUBLIC_API_WORD_COUNTS,
         words_per_minute=_VALID_WORDS_PER_MINUTE,

--- a/tests/test_chrono_contracts.py
+++ b/tests/test_chrono_contracts.py
@@ -43,143 +43,142 @@ def _integer_ceiling_seconds(spoken_word_count: int, words_per_minute: int) -> i
     return (spoken_word_count * 60 + words_per_minute - 1) // words_per_minute
 
 
-def test_ceil_seconds_matches_formula_for_boundary_inputs() -> None:
-    """The formula helper should match the documented ceiling calculation."""
-    assert _ceil_seconds(1, 150) == 1
-    assert _ceil_seconds(150, 150) == 60
-    assert _ceil_seconds(sys.maxsize, sys.maxsize) == 60
-    assert _ceil_seconds(1, 10**400) == 1
+class TestChronoContracts:
+    """Contract and property coverage for Chrono duration arithmetic."""
 
+    def test_ceil_seconds_matches_formula_for_boundary_inputs(self) -> None:
+        """The formula helper should match the documented ceiling calculation."""
+        assert _ceil_seconds(1, 150) == 1
+        assert _ceil_seconds(150, 150) == 60
+        assert _ceil_seconds(sys.maxsize, sys.maxsize) == 60
+        assert _ceil_seconds(1, 10**400) == 1
 
-def test_compute_estimated_seconds_preserves_zero_identity() -> None:
-    """Zero spoken words should produce a zero-second estimate."""
-    assert _compute_estimated_seconds(0, 1) == 0
-    assert _compute_estimated_seconds(0, sys.maxsize) == 0
+    def test_compute_estimated_seconds_preserves_zero_identity(self) -> None:
+        """Zero spoken words should produce a zero-second estimate."""
+        assert _compute_estimated_seconds(0, 1) == 0
+        assert _compute_estimated_seconds(0, sys.maxsize) == 0
 
+    def test_compute_estimated_seconds_avoids_float_underflow(self) -> None:
+        """Positive word counts should not round down under huge WPM configs."""
+        assert _compute_estimated_seconds(1, 10**400) == 1
 
-def test_compute_estimated_seconds_avoids_float_underflow() -> None:
-    """Positive word counts should not round down under huge WPM configs."""
-    assert _compute_estimated_seconds(1, 10**400) == 1
+    def test_seconds_contract_holds_rejects_invalid_estimates(self) -> None:
+        """The contract predicate should reject bad estimates."""
+        assert not _seconds_contract_holds(0, 150, -1)
+        assert not _seconds_contract_holds(0, 150, 1)
+        assert not _seconds_contract_holds(150, 150, 0)
+        assert not _seconds_contract_holds(150, 150, 59)
 
-
-def test_seconds_contract_holds_rejects_invalid_estimates() -> None:
-    """The contract predicate should reject negative or formula-mismatched values."""
-    assert not _seconds_contract_holds(0, 150, -1)
-    assert not _seconds_contract_holds(0, 150, 1)
-    assert not _seconds_contract_holds(150, 150, 0)
-    assert not _seconds_contract_holds(150, 150, 59)
-
-
-@pytest.mark.crosshair
-def test_chrono_crosshair_contracts_pass() -> None:
-    """CrossHair should verify Chrono's PEP 316 contracts automatically."""
-    completed = subprocess.run(  # noqa: S603
-        [
-            sys.executable,
-            "-m",
-            "crosshair",
-            "check",
-            "--analysis_kind=PEP316",
-            "episodic/qa/chrono.py",
-        ],
-        cwd=_REPOSITORY_ROOT,
-        check=False,
-        capture_output=True,
-        text=True,
-        timeout=30,
-    )
-
-    assert completed.returncode == 0, (
-        "CrossHair contract verification failed.\n"
-        f"stdout:\n{completed.stdout}\n"
-        f"stderr:\n{completed.stderr}"
-    )
-
-
-@given(
-    spoken_word_count=_VALID_WORD_COUNTS,
-    words_per_minute=_VALID_WORDS_PER_MINUTE,
-)
-def test_ceil_seconds_matches_ceiling_formula(
-    spoken_word_count: int,
-    words_per_minute: int,
-) -> None:
-    """The internal ceiling helper should match Chrono's arithmetic formula."""
-    assert _ceil_seconds(spoken_word_count, words_per_minute) == (
-        _integer_ceiling_seconds(spoken_word_count, words_per_minute)
-    )
-
-
-@given(words_per_minute=_VALID_WORDS_PER_MINUTE)
-def test_compute_estimated_seconds_handles_zero_word_count(
-    words_per_minute: int,
-) -> None:
-    """The public contract helper should preserve the zero-case identity."""
-    assert _compute_estimated_seconds(0, words_per_minute) == 0
-
-
-@given(
-    spoken_word_count=st.integers(min_value=1, max_value=sys.maxsize),
-    words_per_minute=_VALID_WORDS_PER_MINUTE,
-)
-def test_compute_estimated_seconds_matches_formula_for_positive_counts(
-    spoken_word_count: int,
-    words_per_minute: int,
-) -> None:
-    """Positive word counts should use the exact documented ceiling formula."""
-    assert _compute_estimated_seconds(
-        spoken_word_count,
-        words_per_minute,
-    ) == _integer_ceiling_seconds(spoken_word_count, words_per_minute)
-
-
-@given(
-    spoken_word_count=_VALID_WORD_COUNTS,
-    words_per_minute=_VALID_WORDS_PER_MINUTE,
-)
-def test_compute_estimated_seconds_satisfies_postconditions(
-    spoken_word_count: int,
-    words_per_minute: int,
-) -> None:
-    """Computed estimates should satisfy the CrossHair postcondition predicate."""
-    estimated_seconds = _compute_estimated_seconds(
-        spoken_word_count,
-        words_per_minute,
-    )
-
-    assert _seconds_contract_holds(
-        spoken_word_count,
-        words_per_minute,
-        estimated_seconds,
-    )
-
-
-@given(
-    spoken_word_count=_VALID_WORD_COUNTS,
-    words_per_minute=_VALID_WORDS_PER_MINUTE,
-    estimated_seconds=st.integers(min_value=-sys.maxsize, max_value=sys.maxsize),
-)
-def test_seconds_contract_holds_matches_independent_postcondition(
-    spoken_word_count: int,
-    words_per_minute: int,
-    estimated_seconds: int,
-) -> None:
-    """The predicate should encode the same postconditions CrossHair checks."""
-    expected = (
-        estimated_seconds >= 0
-        and (spoken_word_count == 0) == (estimated_seconds == 0)
-        and (
-            spoken_word_count == 0
-            or estimated_seconds
-            == _integer_ceiling_seconds(spoken_word_count, words_per_minute)
+    @pytest.mark.crosshair
+    def test_chrono_crosshair_contracts_pass(self) -> None:
+        """CrossHair should verify Chrono's PEP 316 contracts automatically."""
+        completed = subprocess.run(  # noqa: S603 - fixed argv, shell=False, no user input.
+            [
+                sys.executable,
+                "-m",
+                "crosshair",
+                "check",
+                "--analysis_kind=PEP316",
+                "episodic/qa/chrono.py",
+            ],
+            cwd=_REPOSITORY_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
         )
-    )
 
-    assert (
-        _seconds_contract_holds(
+        assert completed.returncode == 0, (
+            "CrossHair contract verification failed.\n"
+            f"stdout:\n{completed.stdout}\n"
+            f"stderr:\n{completed.stderr}"
+        )
+
+    @given(
+        spoken_word_count=_VALID_WORD_COUNTS,
+        words_per_minute=_VALID_WORDS_PER_MINUTE,
+    )
+    def test_ceil_seconds_matches_ceiling_formula(
+        self,
+        spoken_word_count: int,
+        words_per_minute: int,
+    ) -> None:
+        """The internal ceiling helper should match Chrono's arithmetic formula."""
+        assert _ceil_seconds(spoken_word_count, words_per_minute) == (
+            _integer_ceiling_seconds(spoken_word_count, words_per_minute)
+        )
+
+    @given(words_per_minute=_VALID_WORDS_PER_MINUTE)
+    def test_compute_estimated_seconds_handles_zero_word_count(
+        self,
+        words_per_minute: int,
+    ) -> None:
+        """The public contract helper should preserve the zero-case identity."""
+        assert _compute_estimated_seconds(0, words_per_minute) == 0
+
+    @given(
+        spoken_word_count=st.integers(min_value=1, max_value=sys.maxsize),
+        words_per_minute=_VALID_WORDS_PER_MINUTE,
+    )
+    def test_compute_estimated_seconds_matches_formula_for_positive_counts(
+        self,
+        spoken_word_count: int,
+        words_per_minute: int,
+    ) -> None:
+        """Positive word counts should use the exact documented ceiling formula."""
+        assert _compute_estimated_seconds(
+            spoken_word_count,
+            words_per_minute,
+        ) == _integer_ceiling_seconds(spoken_word_count, words_per_minute)
+
+    @given(
+        spoken_word_count=_VALID_WORD_COUNTS,
+        words_per_minute=_VALID_WORDS_PER_MINUTE,
+    )
+    def test_compute_estimated_seconds_satisfies_postconditions(
+        self,
+        spoken_word_count: int,
+        words_per_minute: int,
+    ) -> None:
+        """Computed estimates should satisfy the CrossHair postcondition predicate."""
+        estimated_seconds = _compute_estimated_seconds(
+            spoken_word_count,
+            words_per_minute,
+        )
+
+        assert _seconds_contract_holds(
             spoken_word_count,
             words_per_minute,
             estimated_seconds,
         )
-        is expected
+
+    @given(
+        spoken_word_count=_VALID_WORD_COUNTS,
+        words_per_minute=_VALID_WORDS_PER_MINUTE,
+        estimated_seconds=st.integers(min_value=-sys.maxsize, max_value=sys.maxsize),
     )
+    def test_seconds_contract_holds_matches_independent_postcondition(
+        self,
+        spoken_word_count: int,
+        words_per_minute: int,
+        estimated_seconds: int,
+    ) -> None:
+        """The predicate should encode the same postconditions CrossHair checks."""
+        expected = (
+            estimated_seconds >= 0
+            and (spoken_word_count == 0) == (estimated_seconds == 0)
+            and (
+                spoken_word_count == 0
+                or estimated_seconds
+                == _integer_ceiling_seconds(spoken_word_count, words_per_minute)
+            )
+        )
+
+        assert (
+            _seconds_contract_holds(
+                spoken_word_count,
+                words_per_minute,
+                estimated_seconds,
+            )
+            is expected
+        )

--- a/tests/test_chrono_contracts.py
+++ b/tests/test_chrono_contracts.py
@@ -60,27 +60,30 @@ def _script_with_word_count(spoken_word_count: int) -> str:
 class TestChronoContracts:
     """Contract and property coverage for Chrono duration arithmetic."""
 
-    def test_estimate_matches_boundary_inputs(self) -> None:
-        """The public estimator should match the documented ceiling calculation."""
-        request = ChronoEvaluationRequest(script_tei_xml=_script_with_word_count(1))
+    @pytest.mark.parametrize(
+        ("word_count", "words_per_minute", "expected_seconds"),
+        [
+            (1, 10**400, 1),
+            (0, sys.maxsize, 0),
+        ],
+    )
+    def test_estimate_matches_boundary_inputs(
+        self,
+        word_count: int,
+        words_per_minute: int,
+        expected_seconds: int,
+    ) -> None:
+        """The public estimator should match boundary duration cases."""
+        request = ChronoEvaluationRequest(
+            script_tei_xml=_script_with_word_count(word_count)
+        )
         result = ChronoRuntimeEstimator(
-            config=ChronoEstimatorConfig(words_per_minute=10**400)
+            config=ChronoEstimatorConfig(words_per_minute=words_per_minute)
         ).estimate(request)
 
-        assert result.estimated_seconds == 1
-        assert result.metadata.spoken_word_count == 1
-        assert result.metadata.words_per_minute == 10**400
-
-    def test_estimate_preserves_zero_identity(self) -> None:
-        """Zero spoken words should produce a zero-second estimate."""
-        request = ChronoEvaluationRequest(script_tei_xml=_script_with_word_count(0))
-        result = ChronoRuntimeEstimator(
-            config=ChronoEstimatorConfig(words_per_minute=sys.maxsize)
-        ).estimate(request)
-
-        assert result.estimated_seconds == 0
-        assert result.metadata.spoken_word_count == 0
-        assert result.metadata.words_per_minute == sys.maxsize
+        assert result.estimated_seconds == expected_seconds
+        assert result.metadata.spoken_word_count == word_count
+        assert result.metadata.words_per_minute == words_per_minute
 
     @pytest.mark.crosshair
     def test_chrono_crosshair_contracts_pass(self) -> None:

--- a/tests/test_chrono_contracts.py
+++ b/tests/test_chrono_contracts.py
@@ -108,21 +108,6 @@ class TestChronoContracts:
         assert _compute_estimated_seconds(0, words_per_minute) == 0
 
     @given(
-        spoken_word_count=st.integers(min_value=1, max_value=sys.maxsize),
-        words_per_minute=_VALID_WORDS_PER_MINUTE,
-    )
-    def test_compute_estimated_seconds_matches_formula_for_positive_counts(
-        self,
-        spoken_word_count: int,
-        words_per_minute: int,
-    ) -> None:
-        """Positive word counts should use the exact documented ceiling formula."""
-        assert _compute_estimated_seconds(
-            spoken_word_count,
-            words_per_minute,
-        ) == _integer_ceiling_seconds(spoken_word_count, words_per_minute)
-
-    @given(
         spoken_word_count=_VALID_WORD_COUNTS,
         words_per_minute=_VALID_WORDS_PER_MINUTE,
     )

--- a/tests/test_chrono_contracts.py
+++ b/tests/test_chrono_contracts.py
@@ -17,3 +17,127 @@ ChronoEstimatorMetadata __post_init__ guards):
 - spoken_word_count >= 0
 - words_per_minute > 0
 """
+
+import math
+import sys
+
+import hypothesis.strategies as st
+from hypothesis import given
+
+from episodic.qa.chrono import (
+    _ceil_seconds,
+    _compute_estimated_seconds,
+    _seconds_contract_holds,
+)
+
+_VALID_WORD_COUNTS = st.integers(min_value=0, max_value=sys.maxsize)
+_VALID_WORDS_PER_MINUTE = st.integers(min_value=1, max_value=sys.maxsize)
+
+
+def test_ceil_seconds_matches_formula_for_boundary_inputs() -> None:
+    """The formula helper should match the documented ceiling calculation."""
+    assert _ceil_seconds(1, 150) == 1
+    assert _ceil_seconds(150, 150) == 60
+    assert _ceil_seconds(sys.maxsize, sys.maxsize) == 60
+
+
+def test_compute_estimated_seconds_preserves_zero_identity() -> None:
+    """Zero spoken words should produce a zero-second estimate."""
+    assert _compute_estimated_seconds(0, 1) == 0
+    assert _compute_estimated_seconds(0, sys.maxsize) == 0
+
+
+def test_seconds_contract_holds_rejects_invalid_estimates() -> None:
+    """The contract predicate should reject negative or formula-mismatched values."""
+    assert not _seconds_contract_holds(0, 150, -1)
+    assert not _seconds_contract_holds(0, 150, 1)
+    assert not _seconds_contract_holds(150, 150, 0)
+    assert not _seconds_contract_holds(150, 150, 59)
+
+
+@given(
+    spoken_word_count=_VALID_WORD_COUNTS,
+    words_per_minute=_VALID_WORDS_PER_MINUTE,
+)
+def test_ceil_seconds_matches_ceiling_formula(
+    spoken_word_count: int,
+    words_per_minute: int,
+) -> None:
+    """The internal ceiling helper should match Chrono's arithmetic formula."""
+    assert _ceil_seconds(spoken_word_count, words_per_minute) == math.ceil(
+        spoken_word_count / words_per_minute * 60
+    )
+
+
+@given(words_per_minute=_VALID_WORDS_PER_MINUTE)
+def test_compute_estimated_seconds_handles_zero_word_count(
+    words_per_minute: int,
+) -> None:
+    """The public contract helper should preserve the zero-case identity."""
+    assert _compute_estimated_seconds(0, words_per_minute) == 0
+
+
+@given(
+    spoken_word_count=st.integers(min_value=1, max_value=sys.maxsize),
+    words_per_minute=_VALID_WORDS_PER_MINUTE,
+)
+def test_compute_estimated_seconds_matches_formula_for_positive_counts(
+    spoken_word_count: int,
+    words_per_minute: int,
+) -> None:
+    """Positive word counts should use the exact documented ceiling formula."""
+    assert _compute_estimated_seconds(
+        spoken_word_count,
+        words_per_minute,
+    ) == math.ceil(spoken_word_count / words_per_minute * 60)
+
+
+@given(
+    spoken_word_count=_VALID_WORD_COUNTS,
+    words_per_minute=_VALID_WORDS_PER_MINUTE,
+)
+def test_compute_estimated_seconds_satisfies_postconditions(
+    spoken_word_count: int,
+    words_per_minute: int,
+) -> None:
+    """Computed estimates should satisfy the CrossHair postcondition predicate."""
+    estimated_seconds = _compute_estimated_seconds(
+        spoken_word_count,
+        words_per_minute,
+    )
+
+    assert _seconds_contract_holds(
+        spoken_word_count,
+        words_per_minute,
+        estimated_seconds,
+    )
+
+
+@given(
+    spoken_word_count=_VALID_WORD_COUNTS,
+    words_per_minute=_VALID_WORDS_PER_MINUTE,
+    estimated_seconds=st.integers(min_value=-sys.maxsize, max_value=sys.maxsize),
+)
+def test_seconds_contract_holds_matches_independent_postcondition(
+    spoken_word_count: int,
+    words_per_minute: int,
+    estimated_seconds: int,
+) -> None:
+    """The predicate should encode the same postconditions CrossHair checks."""
+    expected = (
+        estimated_seconds >= 0
+        and (spoken_word_count == 0) == (estimated_seconds == 0)
+        and (
+            spoken_word_count == 0
+            or estimated_seconds == math.ceil(spoken_word_count / words_per_minute * 60)
+        )
+    )
+
+    assert (
+        _seconds_contract_holds(
+            spoken_word_count,
+            words_per_minute,
+            estimated_seconds,
+        )
+        is expected
+    )

--- a/tests/test_chrono_contracts.py
+++ b/tests/test_chrono_contracts.py
@@ -142,29 +142,3 @@ class TestChronoContracts:
         assert spoken_word_count == 0 or estimated_seconds == _integer_ceiling_seconds(
             spoken_word_count, words_per_minute
         )
-
-    @given(
-        spoken_word_count=_VALID_WORD_COUNTS,
-        words_per_minute=_VALID_WORDS_PER_MINUTE,
-    )
-    def test_compute_estimated_seconds_matches_independent_postcondition(
-        self,
-        spoken_word_count: int,
-        words_per_minute: int,
-    ) -> None:
-        """The helper should produce values matching the independent postcondition."""
-        estimated_seconds = _compute_estimated_seconds(
-            spoken_word_count,
-            words_per_minute,
-        )
-        expected = (
-            estimated_seconds >= 0
-            and (spoken_word_count == 0) == (estimated_seconds == 0)
-            and (
-                spoken_word_count == 0
-                or estimated_seconds
-                == _integer_ceiling_seconds(spoken_word_count, words_per_minute)
-            )
-        )
-
-        assert expected

--- a/tests/test_chrono_contracts.py
+++ b/tests/test_chrono_contracts.py
@@ -1,11 +1,12 @@
 """CrossHair contract verification for Chrono numeric arithmetic.
 
-Run with:
-    crosshair check --analysis_kind=PEP316 episodic/qa/chrono.py
+Run directly with:
+    make crosshair
 
-This module documents the symbolic verification gate for
-_compute_estimated_seconds as a Python-native alternative to Kani/Verus bounded
-model-checking (which are Rust tools and cannot be applied to this codebase).
+This module runs and documents the symbolic verification gate for
+_compute_estimated_seconds as a Python-native alternative to Kani/Verus
+bounded model-checking (which are Rust tools and cannot be applied to this
+codebase).
 
 Properties verified by CrossHair via SMT solving:
 - Non-negativity: estimated_seconds >= 0 for all valid (n, wpm) pairs.
@@ -18,10 +19,12 @@ ChronoEstimatorMetadata __post_init__ guards):
 - words_per_minute > 0
 """
 
-import math
+import subprocess  # noqa: S404  # Runs a fixed local CrossHair verification command.
 import sys
+from pathlib import Path
 
 import hypothesis.strategies as st
+import pytest
 from hypothesis import given
 
 from episodic.qa.chrono import (
@@ -32,6 +35,12 @@ from episodic.qa.chrono import (
 
 _VALID_WORD_COUNTS = st.integers(min_value=0, max_value=sys.maxsize)
 _VALID_WORDS_PER_MINUTE = st.integers(min_value=1, max_value=sys.maxsize)
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _integer_ceiling_seconds(spoken_word_count: int, words_per_minute: int) -> int:
+    """Return the independent integer form of ceil(n * 60 / wpm)."""
+    return (spoken_word_count * 60 + words_per_minute - 1) // words_per_minute
 
 
 def test_ceil_seconds_matches_formula_for_boundary_inputs() -> None:
@@ -55,6 +64,32 @@ def test_seconds_contract_holds_rejects_invalid_estimates() -> None:
     assert not _seconds_contract_holds(150, 150, 59)
 
 
+@pytest.mark.crosshair
+def test_chrono_crosshair_contracts_pass() -> None:
+    """CrossHair should verify Chrono's PEP 316 contracts automatically."""
+    completed = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-m",
+            "crosshair",
+            "check",
+            "--analysis_kind=PEP316",
+            "episodic/qa/chrono.py",
+        ],
+        cwd=_REPOSITORY_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    assert completed.returncode == 0, (
+        "CrossHair contract verification failed.\n"
+        f"stdout:\n{completed.stdout}\n"
+        f"stderr:\n{completed.stderr}"
+    )
+
+
 @given(
     spoken_word_count=_VALID_WORD_COUNTS,
     words_per_minute=_VALID_WORDS_PER_MINUTE,
@@ -64,8 +99,8 @@ def test_ceil_seconds_matches_ceiling_formula(
     words_per_minute: int,
 ) -> None:
     """The internal ceiling helper should match Chrono's arithmetic formula."""
-    assert _ceil_seconds(spoken_word_count, words_per_minute) == math.ceil(
-        spoken_word_count / words_per_minute * 60
+    assert _ceil_seconds(spoken_word_count, words_per_minute) == (
+        _integer_ceiling_seconds(spoken_word_count, words_per_minute)
     )
 
 
@@ -89,7 +124,7 @@ def test_compute_estimated_seconds_matches_formula_for_positive_counts(
     assert _compute_estimated_seconds(
         spoken_word_count,
         words_per_minute,
-    ) == math.ceil(spoken_word_count / words_per_minute * 60)
+    ) == _integer_ceiling_seconds(spoken_word_count, words_per_minute)
 
 
 @given(
@@ -129,7 +164,8 @@ def test_seconds_contract_holds_matches_independent_postcondition(
         and (spoken_word_count == 0) == (estimated_seconds == 0)
         and (
             spoken_word_count == 0
-            or estimated_seconds == math.ceil(spoken_word_count / words_per_minute * 60)
+            or estimated_seconds
+            == _integer_ceiling_seconds(spoken_word_count, words_per_minute)
         )
     )
 

--- a/tests/test_chrono_contracts.py
+++ b/tests/test_chrono_contracts.py
@@ -28,9 +28,7 @@ import pytest
 from hypothesis import given
 
 from episodic.qa.chrono import (
-    _ceil_seconds,
     _compute_estimated_seconds,
-    _seconds_contract_holds,
 )
 
 _VALID_WORD_COUNTS = st.integers(min_value=0, max_value=sys.maxsize)
@@ -46,12 +44,12 @@ def _integer_ceiling_seconds(spoken_word_count: int, words_per_minute: int) -> i
 class TestChronoContracts:
     """Contract and property coverage for Chrono duration arithmetic."""
 
-    def test_ceil_seconds_matches_formula_for_boundary_inputs(self) -> None:
+    def test_compute_estimated_seconds_matches_boundary_inputs(self) -> None:
         """The formula helper should match the documented ceiling calculation."""
-        assert _ceil_seconds(1, 150) == 1
-        assert _ceil_seconds(150, 150) == 60
-        assert _ceil_seconds(sys.maxsize, sys.maxsize) == 60
-        assert _ceil_seconds(1, 10**400) == 1
+        assert _compute_estimated_seconds(1, 150) == 1
+        assert _compute_estimated_seconds(150, 150) == 60
+        assert _compute_estimated_seconds(sys.maxsize, sys.maxsize) == 60
+        assert _compute_estimated_seconds(1, 10**400) == 1
 
     def test_compute_estimated_seconds_preserves_zero_identity(self) -> None:
         """Zero spoken words should produce a zero-second estimate."""
@@ -61,13 +59,6 @@ class TestChronoContracts:
     def test_compute_estimated_seconds_avoids_float_underflow(self) -> None:
         """Positive word counts should not round down under huge WPM configs."""
         assert _compute_estimated_seconds(1, 10**400) == 1
-
-    def test_seconds_contract_holds_rejects_invalid_estimates(self) -> None:
-        """The contract predicate should reject bad estimates."""
-        assert not _seconds_contract_holds(0, 150, -1)
-        assert not _seconds_contract_holds(0, 150, 1)
-        assert not _seconds_contract_holds(150, 150, 0)
-        assert not _seconds_contract_holds(150, 150, 59)
 
     @pytest.mark.crosshair
     def test_chrono_crosshair_contracts_pass(self) -> None:
@@ -98,13 +89,13 @@ class TestChronoContracts:
         spoken_word_count=_VALID_WORD_COUNTS,
         words_per_minute=_VALID_WORDS_PER_MINUTE,
     )
-    def test_ceil_seconds_matches_ceiling_formula(
+    def test_compute_estimated_seconds_matches_ceiling_formula(
         self,
         spoken_word_count: int,
         words_per_minute: int,
     ) -> None:
-        """The internal ceiling helper should match Chrono's arithmetic formula."""
-        assert _ceil_seconds(spoken_word_count, words_per_minute) == (
+        """The contract helper should match Chrono's arithmetic formula."""
+        assert _compute_estimated_seconds(spoken_word_count, words_per_minute) == (
             _integer_ceiling_seconds(spoken_word_count, words_per_minute)
         )
 
@@ -146,24 +137,26 @@ class TestChronoContracts:
             words_per_minute,
         )
 
-        assert _seconds_contract_holds(
-            spoken_word_count,
-            words_per_minute,
-            estimated_seconds,
+        assert estimated_seconds >= 0
+        assert (spoken_word_count == 0) == (estimated_seconds == 0)
+        assert spoken_word_count == 0 or estimated_seconds == _integer_ceiling_seconds(
+            spoken_word_count, words_per_minute
         )
 
     @given(
         spoken_word_count=_VALID_WORD_COUNTS,
         words_per_minute=_VALID_WORDS_PER_MINUTE,
-        estimated_seconds=st.integers(min_value=-sys.maxsize, max_value=sys.maxsize),
     )
-    def test_seconds_contract_holds_matches_independent_postcondition(
+    def test_compute_estimated_seconds_matches_independent_postcondition(
         self,
         spoken_word_count: int,
         words_per_minute: int,
-        estimated_seconds: int,
     ) -> None:
-        """The predicate should encode the same postconditions CrossHair checks."""
+        """The helper should produce values matching the independent postcondition."""
+        estimated_seconds = _compute_estimated_seconds(
+            spoken_word_count,
+            words_per_minute,
+        )
         expected = (
             estimated_seconds >= 0
             and (spoken_word_count == 0) == (estimated_seconds == 0)
@@ -174,11 +167,4 @@ class TestChronoContracts:
             )
         )
 
-        assert (
-            _seconds_contract_holds(
-                spoken_word_count,
-                words_per_minute,
-                estimated_seconds,
-            )
-            is expected
-        )
+        assert expected

--- a/tests/test_chrono_contracts.py
+++ b/tests/test_chrono_contracts.py
@@ -48,12 +48,18 @@ def test_ceil_seconds_matches_formula_for_boundary_inputs() -> None:
     assert _ceil_seconds(1, 150) == 1
     assert _ceil_seconds(150, 150) == 60
     assert _ceil_seconds(sys.maxsize, sys.maxsize) == 60
+    assert _ceil_seconds(1, 10**400) == 1
 
 
 def test_compute_estimated_seconds_preserves_zero_identity() -> None:
     """Zero spoken words should produce a zero-second estimate."""
     assert _compute_estimated_seconds(0, 1) == 0
     assert _compute_estimated_seconds(0, sys.maxsize) == 0
+
+
+def test_compute_estimated_seconds_avoids_float_underflow() -> None:
+    """Positive word counts should not round down under huge WPM configs."""
+    assert _compute_estimated_seconds(1, 10**400) == 1
 
 
 def test_seconds_contract_holds_rejects_invalid_estimates() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -384,9 +384,9 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "crosshair-tool" },
+    { name = "crosshair-tool", specifier = ">=0.0.104,<0.1" },
     { name = "hypothesis", extras = ["asyncio"], specifier = ">=6,<7" },
-    { name = "mypy" },
+    { name = "mypy", specifier = ">=2.1,<3" },
     { name = "py-pglite", extras = ["async"], specifier = ">=0.5.3,<0.6.0" },
     { name = "pyright" },
     { name = "pytest", specifier = ">=9,<11" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.14"
+resolution-markers = [
+    "python_full_version >= '3.15'",
+    "python_full_version < '3.15'",
+]
 
 [[package]]
 name = "alembic"
@@ -50,6 +54,44 @@ wheels = [
 ]
 
 [[package]]
+name = "ast-serialize"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/1f/50f241d4e01fe75f4bba6a209edd4047c4b26acf70992ff885fd161f79cb/ast_serialize-0.4.0.tar.gz", hash = "sha256:74e4e634ab82d1466acf0be27043178570b98ebeaa3165f9240a6fad4c286471", size = 60687, upload-time = "2026-05-14T22:44:38.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/85/232631c59b5ca7152c08f026e9a46f47d852298acff74edd04a1fc1d0005/ast_serialize-0.4.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:a6f26937ce0293aafbece0e39019e020369a5a70486ff4088227f0cc888844a9", size = 1182685, upload-time = "2026-05-14T22:43:40.205Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/5e/4838d4d3ddc4425555601467d4e2a565e4340899e45feee4e32c80fbc911/ast_serialize-0.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:074032142777e3e6091977dc3c5146a8ca58ae6825b7f64e9a0b604153ddabd8", size = 1173113, upload-time = "2026-05-14T22:43:41.937Z" },
+    { url = "https://files.pythonhosted.org/packages/22/fc/d622b19fc1c79a62028ec17f4ad4323177af25b174d32b07c84d61ef9d47/ast_serialize-0.4.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:404f3462b4532e13a70b8849bba241dbd82e30043ff58d98c7e762fd925b116a", size = 1234117, upload-time = "2026-05-14T22:43:43.977Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/b5/72f8c8659da0b64562e6d97f852d5c2022c74577df27c922e1e7065039ce/ast_serialize-0.4.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:97c55336e16f5c4ca2bde7be94cca4b8f7d665d64f7008925a82e02707ba14ac", size = 1231703, upload-time = "2026-05-14T22:43:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/98/ccc51ee4f90f97a1ed0a0848bd4c9d77a80969849db8a262b7d2970a6a15/ast_serialize-0.4.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:732b4ef76adcb0f298a7d18c4558336d83b1384f9ae0c7eaa1dc8d031b0a4390", size = 1441574, upload-time = "2026-05-14T22:43:47.784Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/ce/668c4efe79e09c9cc97a4d0a1c29e61fe6f78857fe1e57c086772af55f89/ast_serialize-0.4.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b3db87c4772097c0782250bcd550d66b1189a8c889793c7bcf153f4fee70005c", size = 1254040, upload-time = "2026-05-14T22:43:49.879Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/be/38b27bc2909b7236939801ca9f0d97cdc6198da4f435a81658e0db506fdb/ast_serialize-0.4.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:43729a5e369ebbe7750635c0c206bc616fcd36e703cb9c4497d6b4df0291ee64", size = 1257847, upload-time = "2026-05-14T22:43:51.607Z" },
+    { url = "https://files.pythonhosted.org/packages/68/df/360ebccc361235c167a8be2a0476870cb9ef44c42413bf1289b885684052/ast_serialize-0.4.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:91d3786f3929786cdc4eeedfd110abb4603e7f6c1390c5af398f333a947b742d", size = 1298683, upload-time = "2026-05-14T22:43:53.606Z" },
+    { url = "https://files.pythonhosted.org/packages/51/5c/7d5e0b4d47aafa1600c19e3670f962f81a9bf3da1bc25a1382529a447cf3/ast_serialize-0.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7fba7315fd4bd87cb5560792709f6e66e0606402d362c0a38dd32dfb66ba6066", size = 1409438, upload-time = "2026-05-14T22:43:55.316Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/3d/8875b2f1af3ec1539b88ff193dfbfa5573084ef7fcab27ea4cd09b6dc829/ast_serialize-0.4.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:4db9769d57deb5545ce56ebbbbe3436dcc0ae2688ce14c295cd14e106624ece7", size = 1507922, upload-time = "2026-05-14T22:43:56.959Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/5ec6927eb493ece7ba64263cdc556be889e0c62a013b1851bbe674a0dcda/ast_serialize-0.4.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:dcd04f85a29deb80400e8987cfaceb9907140f763453cbffdbd6ff36f1b32c12", size = 1502817, upload-time = "2026-05-14T22:43:59.081Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/c8/40cb818a08396b1f34d6189c0c42aec917dd331e11fb7c3b870cc61b795a/ast_serialize-0.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:905fc11940831454d93589bd7ce2acb6a5eb01c2936156f751d2a21087c98cd3", size = 1454318, upload-time = "2026-05-14T22:44:01.377Z" },
+    { url = "https://files.pythonhosted.org/packages/74/d5/d51494b60cc52f4792be5ddc951631cddb17a2990154634549abdbdbb5bf/ast_serialize-0.4.0-cp314-cp314t-win32.whl", hash = "sha256:3bdde2c4570143791f636aed4e3ef868f5b46eb90a18f8d5c41dd045aab08bef", size = 1060098, upload-time = "2026-05-14T22:44:03.265Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c9/b0086257c79ff95743a3621448a01fc71b234ae359d3d54cda383aa43939/ast_serialize-0.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6551d55b8607b97a7755683d743200b398c61a0b71a11b7f00c89c335a11d0f4", size = 1101015, upload-time = "2026-05-14T22:44:05.055Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6d/3dfddef4990fda47745af6615a3e51c4de711eda56c3a8072a0d8b6181c7/ast_serialize-0.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:7234ff086cb152ea2a3b7ef895b5ebeb6d80779df049d5c6431c8e3536d5b03c", size = 1074495, upload-time = "2026-05-14T22:44:07.186Z" },
+    { url = "https://files.pythonhosted.org/packages/be/d5/044c5f995ef75807a0effb56fc288cfdedeeb571222450fb6f7d94fd52f1/ast_serialize-0.4.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dcded5056d9f3d201df7833082c07ebcbc566ffc3d4105c9fc9fe278fa086ecb", size = 1189800, upload-time = "2026-05-14T22:44:09.333Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/5a/52163557789d59a8197c10912ab4a1791c9143731ba0e3d9283ac0791db6/ast_serialize-0.4.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:bd50d201098aae0d202805fe9606c0545492f69a3ec4403337e32c54ad29fc41", size = 1181713, upload-time = "2026-05-14T22:44:11.286Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c3/678ce3b6cb594b01c361da87f6c5679d26c1dae1583a082a8cd190e7232e/ast_serialize-0.4.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6615b39cd747967c3aabe68bf3f5f26748e823cc6b474ddc1510ed188a824149", size = 1243258, upload-time = "2026-05-14T22:44:13.345Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/dd/4810fbeb81c47b7e4e65db15ca65c71330efc59b460bd10c12338dc6012e/ast_serialize-0.4.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:91362c0a9fdf1c344b7f50a5b0508b11a0732102998fbd754a191f7187e77031", size = 1239226, upload-time = "2026-05-14T22:44:15.811Z" },
+    { url = "https://files.pythonhosted.org/packages/28/38/13a88d90b664c009ed208346ec2ed248b0ab2cb0b582ae467acaa7f44fa4/ast_serialize-0.4.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:70d9c5d527bbfa69bd3c7d17dac11fb6781e36186a434a06d7d5892e0b2f88f9", size = 1448867, upload-time = "2026-05-14T22:44:17.99Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/19/a069dba1a634b703bf07fb49df8f7e3c04e9ba8ef3f0d9f4495f72630f92/ast_serialize-0.4.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4738790cf54d8b416de992b87ee567056980bc82134d52458bd4985f389d1658", size = 1264135, upload-time = "2026-05-14T22:44:19.8Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/4c/76ec4279fecd7e78b60c3c99321f944c43cd11e5ff09c952746f5f9c0f4c/ast_serialize-0.4.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:faa008dccfcb793ae9101325e4d6d026caaa5d845c2182f03749c759834b0a3a", size = 1269060, upload-time = "2026-05-14T22:44:21.894Z" },
+    { url = "https://files.pythonhosted.org/packages/33/c5/9230ef7481e5cb63b93a1f7738e959586202b081caf32b8bc5d9f673ef56/ast_serialize-0.4.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1c5245228e65d38cb48e1251f0ca71b0fa417e527141491e8c92f740e8e2d121", size = 1309654, upload-time = "2026-05-14T22:44:23.725Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/54/7d7397528d181ad68e476e0c81aa3ceff7d1f1b5c7fa958d6be28628ef16/ast_serialize-0.4.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:8f5153e9c44a02e61f4042c5f9249d2e8a759773d621a0b2f445a899e536e181", size = 1418855, upload-time = "2026-05-14T22:44:25.415Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/8f/87d6428adaa0986b817404f09329b64f8d2614cfe061ebf4951b4a7e0d19/ast_serialize-0.4.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:1e1fb90def261f6a0db885876f7e1a49ad2dbac38ad9f2f62dba2f9543af16e7", size = 1516040, upload-time = "2026-05-14T22:44:27.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/bb/5aaa41a21314c8b0d6dee54867b16535682c6660dd28cac64dba1380062d/ast_serialize-0.4.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:cf2ff7b654c8e95143e20f5d75878cbb78b65b928b26c4d58ef71cdba9d6d981", size = 1511450, upload-time = "2026-05-14T22:44:29.522Z" },
+    { url = "https://files.pythonhosted.org/packages/87/16/cc729b5bb4b21da99db1379266cc367512e82ba10f9b3300a6f3e9941325/ast_serialize-0.4.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:90fc5c0d35a22f1a92dd33635508626d50f8fc64deb897c23e78e666a60804c9", size = 1463654, upload-time = "2026-05-14T22:44:31.265Z" },
+    { url = "https://files.pythonhosted.org/packages/43/97/7198321b0244d011093387b41affea934d58bda08d59a2adfde72976b6c4/ast_serialize-0.4.0-cp39-abi3-win32.whl", hash = "sha256:9ecd6a1fc1b86f1f4e8ae206759b6319c10019706b3496b01b54d02b9b2cd918", size = 1068636, upload-time = "2026-05-14T22:44:33.189Z" },
+    { url = "https://files.pythonhosted.org/packages/10/09/3b868f6d8df4bbe452903a5e0e039ebcec9ea0045f1a77951546205097e8/ast_serialize-0.4.0-cp39-abi3-win_amd64.whl", hash = "sha256:79c8d015c771c8bfdb1208003b227b27c40034790a2c29c09f2317a041825ce2", size = 1107137, upload-time = "2026-05-14T22:44:35.304Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/78/9387dffccdc55a12734f83aaccc4a987404a217a2a12a1920d8d4585950b/ast_serialize-0.4.0-cp39-abi3-win_arm64.whl", hash = "sha256:1026f565a7ab846337c630909089b3346a2fe417bf1552b1581ab01852137407", size = 1079199, upload-time = "2026-05-14T22:44:36.816Z" },
+]
+
+[[package]]
 name = "asyncpg"
 version = "0.31.0"
 source = { registry = "https://pypi.org/simple" }
@@ -74,12 +116,34 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "billiard"
 version = "4.2.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/23/b12ac0bcdfb7360d664f40a00b1bda139cbbbced012c34e375506dbd0143/billiard-4.2.4.tar.gz", hash = "sha256:55f542c371209e03cd5862299b74e52e4fbcba8250ba611ad94276b369b6a85f", size = 156537, upload-time = "2025-11-30T13:28:48.52Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/87/8bab77b323f16d67be364031220069f79159117dd5e43eeb4be2fef1ac9b/billiard-4.2.4-py3-none-any.whl", hash = "sha256:525b42bdec68d2b983347ac312f892db930858495db601b5836ac24e6477cde5", size = 87070, upload-time = "2025-11-30T13:28:47.016Z" },
+]
+
+[[package]]
+name = "cattrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/ec/ba18945e7d6e55a58364d9fb2e46049c1c2998b3d805f19b703f14e81057/cattrs-26.1.0.tar.gz", hash = "sha256:fa239e0f0ec0715ba34852ce813986dfed1e12117e209b816ab87401271cdd40", size = 495672, upload-time = "2026-02-18T22:15:19.406Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl", hash = "sha256:d1e0804c42639494d469d08d4f26d6b9de9b8ab26b446db7b5f8c2e97f7c3096", size = 73054, upload-time = "2026-02-18T22:15:17.958Z" },
 ]
 
 [[package]]
@@ -228,6 +292,30 @@ wheels = [
 ]
 
 [[package]]
+name = "crosshair-tool"
+version = "0.0.104"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "packaging" },
+    { name = "pygls" },
+    { name = "typeshed-client" },
+    { name = "typing-extensions" },
+    { name = "typing-inspect" },
+    { name = "z3-solver" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/c7/ac2e7a78fa58d08b66919de9c9e13d45974976407e53ef8bfc64d62d11d5/crosshair_tool-0.0.104.tar.gz", hash = "sha256:c92cc8554ec1f35e079c041025cf0534d8ce83f6a8aedb7dec68d60c6d6989c2", size = 487964, upload-time = "2026-04-26T11:39:24.845Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/83/e851837d69ea3ebce1bd1c6d755e976aab03086de69070f1dd06ca183367/crosshair_tool-0.0.104-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:1cb7d856355954c371361cfe6f1e3de2aa4e3ec9c9e00c71bebd6344f72a5a53", size = 562899, upload-time = "2026-04-26T11:38:53.76Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ca/d705535707dd4cadd0870540762d34ca3d287c8386b8a6678b761998ba03/crosshair_tool-0.0.104-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:93651387e63549a2c7578f81bc93aae1a237582da45a96b52f91143009fb16fb", size = 549622, upload-time = "2026-04-26T11:38:55.054Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/84/d3b9868079d6e2970ec230954694d084aa76024c37223f2a83456286335b/crosshair_tool-0.0.104-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:efe35ed148effc6bd8cc3d997a87d85edc4419af3fa0fa96486d7b1284d36c17", size = 550295, upload-time = "2026-04-26T11:38:56.513Z" },
+    { url = "https://files.pythonhosted.org/packages/97/54/b4b9143d36634f281b0122e01a7b57902813b1ab7daf3ce7da69cae3a131/crosshair_tool-0.0.104-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:26e8ec24a65e4a0d0af48c1c2fa6aa35fe0ed9dba6a9a631b733306eb28627dc", size = 621829, upload-time = "2026-04-26T11:38:57.834Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ec/cb3b1c419ec9353485a7df7f074def4af91e4b921011e916142a6b44683c/crosshair_tool-0.0.104-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:22aaa4f318a0b316c0b54dd9a0ebcd90bac17a4fc4a8f92159f9cb2d12510ba8", size = 619940, upload-time = "2026-04-26T11:38:59.327Z" },
+    { url = "https://files.pythonhosted.org/packages/26/4b/e73bd53016e5bc18ae8a65e156f9ccbdc879662609f77cc4248e8b8d2c8d/crosshair_tool-0.0.104-cp314-cp314-win32.whl", hash = "sha256:e830fac3b8cc05586afbef0ebe5ff1b1ec24fdb10654713b2a4b26f6508841f1", size = 548172, upload-time = "2026-04-26T11:39:00.991Z" },
+    { url = "https://files.pythonhosted.org/packages/50/19/85fd7ea65d07368e3e7ec364b169d163e3bfdaac35fd11d779ffab523b38/crosshair_tool-0.0.104-cp314-cp314-win_amd64.whl", hash = "sha256:d086515a49c881a2f234e75d62bfe59b9b19d954054be3ed18ea6150913db026", size = 549178, upload-time = "2026-04-26T11:39:02.291Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -260,7 +348,9 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "crosshair-tool" },
     { name = "hypothesis" },
+    { name = "mypy" },
     { name = "py-pglite", extra = ["async"] },
     { name = "pyright" },
     { name = "pytest" },
@@ -294,7 +384,9 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "crosshair-tool" },
     { name = "hypothesis", extras = ["asyncio"], specifier = ">=6,<7" },
+    { name = "mypy" },
     { name = "py-pglite", extras = ["async"], specifier = ">=0.5.3,<0.6.0" },
     { name = "pyright" },
     { name = "pytest", specifier = ">=9,<11" },
@@ -500,6 +592,27 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7", size = 27789, upload-time = "2026-03-20T06:42:55.665Z" },
+]
+
+[[package]]
+name = "importlib-resources"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/06/b56dfa750b44e86157093bc8fca0ab81dccbf5260510de4eaf1cb69b5b99/importlib_resources-7.1.0.tar.gz", hash = "sha256:0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708", size = 44985, upload-time = "2026-04-12T16:36:09.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl", hash = "sha256:1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1", size = 37232, upload-time = "2026-04-12T16:36:08.219Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -640,6 +753,53 @@ wheels = [
 ]
 
 [[package]]
+name = "librt"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/08/9e7f6b5d2b5bed6ad055cdd5925f192bb403a51280f86b56554d9d0699a2/librt-0.11.0.tar.gz", hash = "sha256:075dc3ef4458a278e0195cbf6ac9d38808d9b906c5a6c7f7f79c3888276a3fb1", size = 200139, upload-time = "2026-05-10T18:17:25.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/eb/dbce197da4e227779e56b5735f2decc3eb36e55a1cdbf1bd65d6639d76c1/librt-0.11.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4a017a95e5837dc15a8c5661d60e05daa96b90908b1aa6b7acdf443cd25c8ebd", size = 143345, upload-time = "2026-05-10T18:16:30.674Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/254bebd0c11c8ba684018efb8006ff22e466abce445215cca6c778e7d9de/librt-0.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:b1ecbd9819deccc39b7542bf4d2a740d8a620694d39989e58661d3763458f8d4", size = 143131, upload-time = "2026-05-10T18:16:32.037Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/3f/f77d6122d21ac7bf6ae8a7dfced1bd2a7ac545d3273ebdcaf8042f6d619f/librt-0.11.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7da327dacd7be8f8ec36547373550744a3cc0e536d54665cd83f8bcd961200e8", size = 477024, upload-time = "2026-05-10T18:16:33.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0a/2c996dadebaa7d9bbbd43ef2d4f3e66b6da545f838a41694ef6172cebec8/librt-0.11.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:0dc56b1f8d06e60db362cc3fdae206681817f86ce4725d34511473487f12a34b", size = 474221, upload-time = "2026-05-10T18:16:34.864Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7e/f5d92af8486b8272c23b3e686b46ff72d89c8169585eb61eef01a2ac7147/librt-0.11.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05fb8fb2ab90e21c8d12ea240d744ad514da9baf381ebfa70d91d20d21713175", size = 505174, upload-time = "2026-05-10T18:16:36.705Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1a/cb0734fe86398eb33193ab753b7326255c74cac5eb09e76b9b16536e7adb/librt-0.11.0-cp314-cp314-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cae74872be221df4374d10fec61f93ed1513b9546ea84f2c0bf73ab3e9bd0b03", size = 497216, upload-time = "2026-05-10T18:16:38.418Z" },
+    { url = "https://files.pythonhosted.org/packages/18/06/094820f91558b66e29943c0ec41c9914f460f48dd51fc503c3101e10842d/librt-0.11.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:32bcc918c0148eb7e3d57385125bac7e5f9e4359d05f07448b09f6f778c2f31c", size = 513921, upload-time = "2026-05-10T18:16:39.848Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c2/00de9018871a282f530cacb457d5ec0428f6ac7e6fedde9aff7468d9fb04/librt-0.11.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:f9743fc99135d5f78d2454435615f6dec0473ca507c26ce9d92b10b562a280d3", size = 520850, upload-time = "2026-05-10T18:16:41.471Z" },
+    { url = "https://files.pythonhosted.org/packages/51/9d/64631832348fd1834fb3a61b996434edddaaf25a31d03b0a76273159d2cf/librt-0.11.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5ba067f4aadae8fda802d91d2124c90c42195ff32d9161d3549e6d05cfe26f96", size = 504237, upload-time = "2026-05-10T18:16:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/ae5525eb16edc827a044e7bb8777a455ff95d4bca9379e7e6bddd7383647/librt-0.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:de3bf945454d032f9e390b85c4072e0a0570bf825421c8be0e71209fa65e1abe", size = 546261, upload-time = "2026-05-10T18:16:44.408Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/09/adce371f27ca039411da9659f7430fcc2ba6cd0c7b3e4467a0f091be7fa9/librt-0.11.0-cp314-cp314-win32.whl", hash = "sha256:d2277a05f6dcb9fd13db9566aac4fabd68c3ea1ea46ee5567d4eef8efa495a2f", size = 96965, upload-time = "2026-05-10T18:16:46.039Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ee/8ac720d98548f173c7ce2e632a7ca94673f74cacd5c8162a84af5b35958a/librt-0.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:ab73e8db5e3f564d812c1f5c3a175930a5f9bc96ccb5e3b22a34d7858b401cf7", size = 115151, upload-time = "2026-05-10T18:16:47.133Z" },
+    { url = "https://files.pythonhosted.org/packages/94/20/c900cf14efeb09b6bef2b2dff20779f73464b97fd58d1c6bccc379588ae3/librt-0.11.0-cp314-cp314-win_arm64.whl", hash = "sha256:aea3caa317752e3a466fa8af45d91ee0ea8c7fdd96e42b0a8dd9b76a7931eba1", size = 98850, upload-time = "2026-05-10T18:16:48.597Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/71/944bfe4b64e12abffcd3c15e1cce07f72f3d55655083786285f4dedeb532/librt-0.11.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d1b36540d7aaf9b9101b3a6f376c8d8e9f7a9aec93ed05918f2c69d493ffef72", size = 151138, upload-time = "2026-05-10T18:16:49.839Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/10/99e64a5c86989357fda078c8143c533389585f6473b7439172dd8f3b3b2d/librt-0.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:efbb343ab2ce3540f4ecbe6315d677ed70f37cd9a72b1e58066c918ca83acbaa", size = 151976, upload-time = "2026-05-10T18:16:51.062Z" },
+    { url = "https://files.pythonhosted.org/packages/21/31/5072ad880946d83e5ea4147d6d018c78eefce85b77819b19bdd0ee229435/librt-0.11.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0dd688aab3f7914d3e6e5e3554978e0383312fb8e771d84be008a35b9ee548", size = 557927, upload-time = "2026-05-10T18:16:52.632Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/8d/70b5fb7cfbab60edbe7381614ab985da58e144fbf465c86d44c95f43cdca/librt-0.11.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:f5fb36b8c6c63fdcbb1d526d94c0d1331610d43f4118cc1beb4efef4f3faacb2", size = 539698, upload-time = "2026-05-10T18:16:53.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/a3/ba3495a0b3edbd24a4cae0d1d3c64f39a9fc45d06e812101289b50c1a619/librt-0.11.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4a9a237d13addb93715b6fee74023d5ee3469b53fce527626c0e088aa585805f", size = 577162, upload-time = "2026-05-10T18:16:55.589Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/db/36e25fb81f99937ff1b96612a1dc9fd66f039cb9cc3aee12c01fac31aab9/librt-0.11.0-cp314-cp314t-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5ddd17bd87b2c56ddd60e546a7984a2e64c4e8eab92fb4cf3830a48ad5469d51", size = 566494, upload-time = "2026-05-10T18:16:56.975Z" },
+    { url = "https://files.pythonhosted.org/packages/33/0d/3f622b47f0b013eeb9cf4cc07ae9bfe378d832a4eec998b2b209fe84244d/librt-0.11.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd43992b4473d42f12ff9e68326079f0696d9d4e6000e8f39a0238d482ba6ee2", size = 596858, upload-time = "2026-05-10T18:16:58.374Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/02/71b90bc93039c46a2000651f6ad60122b114c8f54c4ad306e0e96f5b75ad/librt-0.11.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:f8e3e8056dd674e279741485e2e512d6e9a751c7455809d0114e6ebf8d781085", size = 590318, upload-time = "2026-05-10T18:16:59.676Z" },
+    { url = "https://files.pythonhosted.org/packages/04/04/418cb3f75621e2b761fb1ab0f017f4d70a1a72a6e7c74ee4f7e8d198c2f3/librt-0.11.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c1f708d8ae9c56cf38a903c44297243d2ec83fd82b396b977e0144a3e76217e3", size = 575115, upload-time = "2026-05-10T18:17:01.007Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/2c/5a2183ac58dd911f26b5d7e7d7d8f1d87fcecdddd99d6c12169a258ff62c/librt-0.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0add982e0e7b9fc14cf4b33789d5f13f66581889b88c2f58099f6ce8f92617bd", size = 617918, upload-time = "2026-05-10T18:17:02.682Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1f/dc6771a52592a4451be6effa200cbfc9cec61e4393d3033d81a9d307961d/librt-0.11.0-cp314-cp314t-win32.whl", hash = "sha256:2b481d846ac894c4e8403c5fd0e87c5d11d6499e404b474602508a224ff531c8", size = 103562, upload-time = "2026-05-10T18:17:03.99Z" },
+    { url = "https://files.pythonhosted.org/packages/62/4a/7d1415567027286a75ba1093ec4aca11f073e0f559c530cf3e0a757ad55c/librt-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:28edb433edde181112a908c78907af28f964eabc15f4dd16c9d66c834302677c", size = 124327, upload-time = "2026-05-10T18:17:05.465Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/62/b40b382fa0c66fee1478073eb8db352a4a6beda4a1adccf1df911d8c289c/librt-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dee008f20b542e3cd162ba338a7f9ec0f6d23d395f66fe8aeeec3c9d067ea253", size = 102572, upload-time = "2026-05-10T18:17:06.809Z" },
+]
+
+[[package]]
+name = "lsprotocol"
+version = "2025.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/26/67b84e6ec1402f0e6764ef3d2a0aaf9a79522cc1d37738f4e5bb0b21521a/lsprotocol-2025.0.0.tar.gz", hash = "sha256:e879da2b9301e82cfc3e60d805630487ac2f7ab17492f4f5ba5aaba94fe56c29", size = 74896, upload-time = "2025-06-17T21:30:18.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/f0/92f2d609d6642b5f30cb50a885d2bf1483301c69d5786286500d15651ef2/lsprotocol-2025.0.0-py3-none-any.whl", hash = "sha256:f9d78f25221f2a60eaa4a96d3b4ffae011b107537facee61d3da3313880995c7", size = 76250, upload-time = "2025-06-17T21:30:19.455Z" },
+]
+
+[[package]]
 name = "mako"
 version = "1.3.10"
 source = { registry = "https://pypi.org/simple" }
@@ -686,6 +846,45 @@ name = "msgspec"
 version = "0.19.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cf/9b/95d8ce458462b8b71b8a70fa94563b2498b89933689f3a7b8911edfae3d7/msgspec-0.19.0.tar.gz", hash = "sha256:604037e7cd475345848116e89c553aa9a233259733ab51986ac924ab1b976f8e", size = 216934, upload-time = "2024-12-27T17:40:28.597Z" }
+
+[[package]]
+name = "mypy"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ast-serialize" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "mypy-extensions" },
+    { name = "pathspec" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/15/cca9d88503549ed6fedeaa1d448cdddd542ee8a490232d732e278036fbf2/mypy-2.1.0.tar.gz", hash = "sha256:81e76ad12c2d804512e9b13240d1588316531bfba07558286078bfbce9613633", size = 3898359, upload-time = "2026-05-11T18:37:36.237Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/ca/b279a672e874aedd5498ae25f722dacc8aa86bbffb939b3f97cbb1cf6686/mypy-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7354c5a7f69d9345c3d6e69921d57088eea3ddeeb6b20d34c1b3855b02c36ec2", size = 14848422, upload-time = "2026-05-11T18:35:45.984Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e6/3efe56c631d959b9b4454e208b0ac4b7f4f58b404c89f8bec7b49efdfc21/mypy-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:49890d4f76ac9e06ec117f9e09f3174da70a620a0c300953d8595c926e80947f", size = 13677374, upload-time = "2026-05-11T18:36:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7f/8107ea87a44fd1f1b59882442f033c9c3488c127201b1d1d15f1cbd6022e/mypy-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:761be68e023ef5d94678772396a8af1220030f80837a3afd8d0aef3b419666f4", size = 14055743, upload-time = "2026-05-11T18:35:18.361Z" },
+    { url = "https://files.pythonhosted.org/packages/51/4d/b6d34db183133b83761b9199a82d31557cdbb70a380d8c3b3438e11882a3/mypy-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c90345fc182dc363b891350457ec69c35140858538f38b4540845afcc32b1aef", size = 15020937, upload-time = "2026-05-11T18:34:59.618Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/d7/f08360c691d758acb02f45022c34d98b92892f4ea756644e1000d4b9f3d8/mypy-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b84802e7b5a6daf1f5e15bc9fcd7ddae77be13981ffab037f1c67bb84d67d135", size = 15253371, upload-time = "2026-05-11T18:36:41.081Z" },
+    { url = "https://files.pythonhosted.org/packages/67/1b/09460a13719530a19bce27bd3bc8449e83569dd2ba7faf51c9c3c30c0b61/mypy-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:022c771234936ceac541ebaf836fe9e2abeb3f5e09aff21588fe543ff006fe21", size = 11326429, upload-time = "2026-05-11T18:34:13.526Z" },
+    { url = "https://files.pythonhosted.org/packages/40/62/75dbf0f82f7b6680340efc614af29dd0b3c17b8a4f1cd09b8bd2fd6bc814/mypy-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:498207db725cec88829a6a5c2fc771205fd043719ef98bc49aba8fb9fc4e6d57", size = 10218799, upload-time = "2026-05-11T18:32:23.491Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/66/caca04ed7d972fb6eb6dd1ccd6df1de5c38fae8c5b3dc1c4e8e0d85ee6b9/mypy-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7d5e5cad0efeba72b93cd17490cc0d69c5ac9ca132994fe3fb0314808aeeb83e", size = 15923458, upload-time = "2026-05-11T18:35:28.64Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/52/2d90cbe49d014b13ed7ff337930c30bad35893fe38a1e4641e756bb62191/mypy-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ff715050c127d724fd260a2e666e7747fdd83511c0c47d449d98238970aef780", size = 14757697, upload-time = "2026-05-11T18:36:14.208Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/37/d98f4a14e081b238992d0ed96b6d39c7cc0148c9699eb71eaa68629665ea/mypy-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:82208da9e09414d520e912d3e462d454854bed0810b71540bb016dcbca7308fd", size = 15405638, upload-time = "2026-05-11T18:33:48.249Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/c2/15c46613b24a84fad2aea1248bf9619b99c2767ae9071fe224c179a0b7d4/mypy-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e79ebc1b904b84f0310dff7469655a9c36c7a68bddb37bdd42b67a332df61d08", size = 16215852, upload-time = "2026-05-11T18:32:50.296Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/90/9c16a57f482c76d25f6379762b56bbf65c711d8158cf271fb2802cfb0640/mypy-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e583edc957cfb0deb142079162ae826f58449b116c1d442f2d91c69d9fced081", size = 16452695, upload-time = "2026-05-11T18:33:38.182Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/4c/215a4eeb63cacc5f17f516691ea7285d11e249802b942476bff15922a314/mypy-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b33b6cd332695bba180d55e717a79d3038e479a2c49cc5eb3d53603409b9a5d7", size = 12866622, upload-time = "2026-05-11T18:34:39.945Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/50/1043e1db5f455ffe4c9ab22747cd8ca2bc492b1e4f4e21b130a44ee2b217/mypy-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:4f910fe825376a7b66ef7ca8c98e5a149e8cd64c19ae71d84047a74ee060d4e6", size = 10610798, upload-time = "2026-05-11T18:36:31.444Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/2a/13ca1f292f6db1b98ff495ef3467736b331621c5917cad984b7043e7348d/mypy-2.1.0-py3-none-any.whl", hash = "sha256:a663814603a5c563fb87a4f96fb473eeb30d1f5a4885afcf44f9db000a366289", size = 2693302, upload-time = "2026-05-11T18:31:29.246Z" },
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
 
 [[package]]
 name = "nodeenv"
@@ -769,6 +968,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/ea/42ba6ce0abba04ab6e0b997dcb9b528a4661b62af1fe1b0d498120d5ea78/parse_type-0.6.6.tar.gz", hash = "sha256:513a3784104839770d690e04339a8b4d33439fcd5dd99f2e4580f9fc1097bfb2", size = 98012, upload-time = "2025-08-11T22:53:48.066Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/8d/eef3d8cdccc32abdd91b1286884c99b8c3a6d3b135affcc2a7a0f383bb32/parse_type-0.6.6-py2.py3-none-any.whl", hash = "sha256:3ca79bbe71e170dfccc8ec6c341edfd1c2a0fc1e5cfd18330f93af938de2348c", size = 27085, upload-time = "2025-08-11T22:53:46.396Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -928,6 +1136,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
     { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
     { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+]
+
+[[package]]
+name = "pygls"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cattrs" },
+    { name = "lsprotocol" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/2e/7bbe061d175c0baddde8fc9edb908a4c31ba5d9165b8c68e3439c3a9f138/pygls-2.1.1.tar.gz", hash = "sha256:1da03ba9053201bb337dcdd8d121df70feb2a91e1a0dcc74de5da79755b1a201", size = 55091, upload-time = "2026-03-25T11:19:10.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/1a/208293b6c350f5abea6941d5606080d4a492644052504f5312e5de30a902/pygls-2.1.1-py3-none-any.whl", hash = "sha256:510a6dea2476177230c7d851125e5948efdf3fdb9ebfd8543fc434972f8faed4", size = 68975, upload-time = "2026-03-25T11:19:11.374Z" },
 ]
 
 [[package]]
@@ -1211,12 +1433,38 @@ wheels = [
 ]
 
 [[package]]
+name = "typeshed-client"
+version = "2.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-resources" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/7d/62fbae352d5fb7ce5ef4d9ca73bf7a9b02b790d2524ab6ef1e0e799a5d1b/typeshed_client-2.11.0.tar.gz", hash = "sha256:0b8f2ab88f611f5e97b70d2a8123942d3d7d5c74cee8ae694db83422f32f9481", size = 522774, upload-time = "2026-05-01T14:51:52.38Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/22/fa16b462157bd869dfad528f5637506b9430ca63d48fb536ecf4cc78481a/typeshed_client-2.11.0-py3-none-any.whl", hash = "sha256:5745e0990b80b29a286b22d68f81779c5c7adf1cac8969eeafba44b73b486c36", size = 787609, upload-time = "2026-05-01T14:51:51.005Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspect"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827, upload-time = "2023-05-24T20:25:45.287Z" },
 ]
 
 [[package]]
@@ -1337,6 +1585,30 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/9a/c19c42c5b3f5a4aad748a6d5b4f23df3bed7ee5445accc65a0fb3ff03953/xxhash-3.6.0-cp314-cp314t-win32.whl", hash = "sha256:5851f033c3030dd95c086b4a36a2683c2ff4a799b23af60977188b057e467119", size = 31586, upload-time = "2025-10-02T14:36:15.603Z" },
     { url = "https://files.pythonhosted.org/packages/03/d6/4cc450345be9924fd5dc8c590ceda1db5b43a0a889587b0ae81a95511360/xxhash-3.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0444e7967dac37569052d2409b00a8860c2135cff05502df4da80267d384849f", size = 32526, upload-time = "2025-10-02T14:36:16.708Z" },
     { url = "https://files.pythonhosted.org/packages/0f/c9/7243eb3f9eaabd1a88a5a5acadf06df2d83b100c62684b7425c6a11bcaa8/xxhash-3.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:bb79b1e63f6fd84ec778a4b1916dfe0a7c3fdb986c06addd5db3a0d413819d95", size = 28898, upload-time = "2025-10-02T14:36:17.843Z" },
+]
+
+[[package]]
+name = "z3-solver"
+version = "4.16.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/3b/2b714c40ef2ecf6d8aa080056b9c24a77fe4ca2c83abd83e9c93d34212ac/z3_solver-4.16.0.0.tar.gz", hash = "sha256:263d9ad668966e832c2b246ba0389298a599637793da2dc01cc5e4ef4b0b6c78", size = 5098891, upload-time = "2026-02-19T04:14:08.818Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/5d/9b277a80333db6b85fedd0f5082e311efcbaec47f2c44c57d38953c2d4d9/z3_solver-4.16.0.0-py3-none-macosx_15_0_arm64.whl", hash = "sha256:cc52843cfdd3d3f2cd24bedc62e71c18af8c8b7b23fb05e639ab60b01b5f8f2f", size = 36963251, upload-time = "2026-02-19T04:13:44.303Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c4/fc99aa544930fb7bfcd88947c2788f318acaf1b9704a7a914445e204436a/z3_solver-4.16.0.0-py3-none-macosx_15_0_x86_64.whl", hash = "sha256:e292df40951523e4ecfbc8dee549d93dee00a3fe4ee4833270d19876b713e210", size = 47523873, upload-time = "2026-02-19T04:13:48.154Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/e6/98741b086b6e01630a55db1fbda596949f738204aac14ef35e64a9526ccb/z3_solver-4.16.0.0-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:afae2551f795670f0522cfce82132d129c408a2694adff71eb01ba0f2ece44f9", size = 31741807, upload-time = "2026-02-19T04:13:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/2e/295d467c7c796c01337bff790dbedc28cf279f9d365ed64aa9f8ca6b2ba1/z3_solver-4.16.0.0-py3-none-manylinux_2_38_aarch64.whl", hash = "sha256:358648c3b5ef82b9ec9a25711cf4fc498c7881f03a9f4a2ea6ffa9304ca65d94", size = 27326531, upload-time = "2026-02-19T04:13:55.787Z" },
+    { url = "https://files.pythonhosted.org/packages/34/df/29816ce4de24cca3acb007412f9c6fba603e55fcc27ce8c2aade0939057a/z3_solver-4.16.0.0-py3-none-win32.whl", hash = "sha256:cc64c4d41fbebe419fccddb044979c3d95b41214547db65eecdaa67fafef7fe0", size = 13341643, upload-time = "2026-02-19T04:13:58.88Z" },
+    { url = "https://files.pythonhosted.org/packages/86/20/cef4f4d70845df24572d005d19995f92b7f527eb2ffb63a3f5f938a0de2e/z3_solver-4.16.0.0-py3-none-win_amd64.whl", hash = "sha256:eb5df383cb6a3d6b7767dbdca348ac71f6f41e82f76c9ac42002a1f55e35f462", size = 16419861, upload-time = "2026-02-19T04:14:03.232Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/18/7dc1051093abfd6db56ce9addb63c624bfa31946ccb9cfc9be5e75237a26/z3_solver-4.16.0.0-py3-none-win_arm64.whl", hash = "sha256:28729eae2c89112e37697acce4d4517f5e44c6c54d36fed9cf914b06f380cbd6", size = 15084866, upload-time = "2026-02-19T04:14:06.355Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This branch adds Python-native contract verification for Chrono's numeric
runtime arithmetic. It keeps the spoken-duration calculation in one pure helper,
uses integer-only ceiling arithmetic to avoid floating-point precision edge
cases including huge-WPM float underflow, runs CrossHair PEP 316 verification
automatically through pytest, `make crosshair`, and the standard `make test`
gate, and documents why CrossHair is the applicable model checker for this
Python code while Kani and Verus remain out of scope.

Closes #102.

## Review walkthrough

- Start with [episodic/qa/chrono.py](https://github.com/leynos/episodic/blob/issue-102-chrono-model-checker/episodic/qa/chrono.py) to review `_compute_estimated_seconds(...)`, the inline integer-only formula, and the PEP 316 contracts.
- Then review [tests/test_chrono_contracts.py](https://github.com/leynos/episodic/blob/issue-102-chrono-model-checker/tests/test_chrono_contracts.py) for class-grouped direct unit, Hypothesis, underflow-regression, and `pytest.mark.crosshair` subprocess coverage of `_compute_estimated_seconds(...)`.
- Review [Makefile](https://github.com/leynos/episodic/blob/issue-102-chrono-model-checker/Makefile) for the dedicated `make crosshair` gate and the `make test` dependency that runs CrossHair before pytest.
- Review [docs/adr/adr-006-chrono-spoken-text-semantics.md](https://github.com/leynos/episodic/blob/issue-102-chrono-model-checker/docs/adr/adr-006-chrono-spoken-text-semantics.md), [docs/developers-guide.md](https://github.com/leynos/episodic/blob/issue-102-chrono-model-checker/docs/developers-guide.md), and [docs/execplans/2-2-6-chrono-runtime-estimator.md](https://github.com/leynos/episodic/blob/issue-102-chrono-model-checker/docs/execplans/2-2-6-chrono-runtime-estimator.md) for the model-checking rationale and maintainer guidance.
- Finish with [pyproject.toml](https://github.com/leynos/episodic/blob/issue-102-chrono-model-checker/pyproject.toml) and [uv.lock](https://github.com/leynos/episodic/blob/issue-102-chrono-model-checker/uv.lock) to confirm the constrained development-only dependency and pytest marker changes.

## Validation

- `ruff format episodic/qa/chrono.py tests/test_chrono_contracts.py`: passed
- `ruff check episodic/qa/chrono.py tests/test_chrono_contracts.py`: passed
- `mypy episodic/qa/chrono.py`: passed
- `crosshair check --analysis_kind=PEP316 episodic/qa/chrono.py`: passed
- `pytest tests/test_chrono.py tests/test_chrono_properties.py tests/test_chrono_contracts.py -v`: passed, 38 passed
- `make crosshair`: passed
- `make check-fmt`: passed
- `make lint`: passed
- `make typecheck`: passed
- `make markdownlint`: passed
- `make nixie`: passed
- `make test`: passed, 637 passed and 3 skipped; ran `crosshair check --analysis_kind=PEP316 episodic/qa/chrono.py` before pytest
- `coderabbit review --agent`: passed, 0 findings

## Notes

The CrossHair contract now keeps the postcondition formula inline on
`_compute_estimated_seconds(...)`, using integer-only ceiling arithmetic in both
the implementation and the PEP 316 contract. The contract test module verifies
boundary examples, Hypothesis integer ranges, the huge-WPM underflow regression
case, and the automated CrossHair subprocess gate. The `make test` target also
depends on `make crosshair`, so the standard local and CI test gate cannot pass
without contract verification.

## References

- Lody session: https://lody.ai/leynos/sessions/aa95ccc6-cb0f-48ae-bb8c-2592aba5b78b
