### PR TITLE
Introduce `/v1` target API prefix (4.1.1)

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -61,6 +61,22 @@ Health contract:
   verifies database connectivity and returns `503 Service Unavailable` when the
   probe fails.
 
+Versioned API routing:
+
+- `/v1` is the target prefix for client-facing canonical API resources,
+  including series-profile, episode-template, reusable-reference, and
+  binding-resolution routes.
+- Existing unversioned canonical routes are pre-v0.1.0 implementation details.
+  They are not compatibility aliases and should return Falcon's normal
+  `404 Not Found` response.
+- Health checks remain root-level operator endpoints at `/health/live` and
+  `/health/ready`.
+- New terminal user interface (TUI)-facing and vertical-slice REST endpoints
+  must be registered under `/v1`.
+- The routing decision follows
+  [`adr-009-source-to-script-rest-vertical-slice.md`](adr/adr-009-source-to-script-rest-vertical-slice.md)
+  and [`episodic-tui-api-design.md`](episodic-tui-api-design.md).
+
 Testing guidance:
 
 - Use `tests/test_http_service_scaffold.py` for in-memory ASGI coverage of the
@@ -194,9 +210,9 @@ Migration files follow the naming convention
 The `make check-migrations` target detects drift between the ORM models and the
 applied migration history. It starts an ephemeral Postgres via py-pglite,
 applies all Alembic migrations, and uses
-`alembic.autogenerate.compare_metadata()` to compare the migrated schema
-against `Base.metadata`. If they differ, the check exits non-zero and reports
-the discrepancies.
+`alembic.autogenerate.compare_metadata()` to compare the migrated schema against
+ `Base.metadata`. If they differ, the check exits non-zero and reports the
+discrepancies.
 
 Run it locally before committing model changes:
 
@@ -264,8 +280,8 @@ Key expectations:
 - If a non-SQLite backend is requested while py-pglite is unavailable, the
   fixtures raise a clear error instead of silently skipping tests.
 - `make check-migrations` uses the same database technology, but a separate
-  bootstrap path. `episodic/canonical/storage/migration_check.py` starts a
-  plain `PGliteManager`, creates an async SQLAlchemy engine from
+  bootstrap path. `episodic/canonical/storage/migration_check.py` starts a plain
+   `PGliteManager`, creates an async SQLAlchemy engine from
   `config.get_connection_string()`, applies Alembic migrations, and compares
   the migrated schema against `Base.metadata`.
 
@@ -312,8 +328,8 @@ The `SqlAlchemyUnitOfWork` manages transaction boundaries:
   rolls back automatically.
 
 Database-level constraints (unique slugs, foreign keys, and CHECK constraints
-such as the weight bound on source documents) are enforced by Postgres and
-raise `sqlalchemy.exc.IntegrityError` on violation.
+such as the weight bound on source documents) are enforced by Postgres and raise
+ `sqlalchemy.exc.IntegrityError` on violation.
 
 ### Architecture enforcement
 
@@ -375,18 +391,18 @@ adapter (`episodic/api/app.py`) over domain services in
 
 ### Endpoints
 
-- `POST /series-profiles`
-- `GET /series-profiles`
-- `GET /series-profiles/{profile_id}`
-- `PATCH /series-profiles/{profile_id}`
-- `GET /series-profiles/{profile_id}/history`
-- `GET /series-profiles/{profile_id}/brief`
-- `GET /series-profiles/{profile_id}/resolved-bindings`
-- `POST /episode-templates`
-- `GET /episode-templates`
-- `GET /episode-templates/{template_id}`
-- `PATCH /episode-templates/{template_id}`
-- `GET /episode-templates/{template_id}/history`
+- `POST /v1/series-profiles`
+- `GET /v1/series-profiles`
+- `GET /v1/series-profiles/{profile_id}`
+- `PATCH /v1/series-profiles/{profile_id}`
+- `GET /v1/series-profiles/{profile_id}/history`
+- `GET /v1/series-profiles/{profile_id}/brief`
+- `GET /v1/series-profiles/{profile_id}/resolved-bindings`
+- `POST /v1/episode-templates`
+- `GET /v1/episode-templates`
+- `GET /v1/episode-templates/{template_id}`
+- `PATCH /v1/episode-templates/{template_id}`
+- `GET /v1/episode-templates/{template_id}/history`
 
 ### Optimistic locking and history
 
@@ -399,7 +415,8 @@ adapter (`episodic/api/app.py`) over domain services in
 
 ### Structured brief payloads
 
-`GET /series-profiles/{profile_id}/brief` returns a stable payload containing:
+`GET /v1/series-profiles/{profile_id}/brief` returns a stable payload
+containing:
 
 - `series_profile`: profile metadata, configuration, persisted `guardrails`,
   and current revision.
@@ -416,7 +433,7 @@ The brief endpoint accepts optional query parameters:
   serialized. Omitting it preserves the legacy behaviour of returning all
   matching bindings.
 
-`GET /series-profiles/{profile_id}/resolved-bindings` returns the resolved
+`GET /v1/series-profiles/{profile_id}/resolved-bindings` returns the resolved
 binding set directly. It requires `episode_id`, accepts optional `template_id`,
 and responds with `items`, where each item includes serialized `binding`,
 `document`, and `revision` payloads.
@@ -438,16 +455,16 @@ binding-resolution behavior.
 
 Supported endpoints:
 
-- `POST /series-profiles/{profile_id}/reference-documents`
-- `GET /series-profiles/{profile_id}/reference-documents`
-- `GET /series-profiles/{profile_id}/reference-documents/{document_id}`
-- `PATCH /series-profiles/{profile_id}/reference-documents/{document_id}`
-- `POST /series-profiles/{profile_id}/reference-documents/{document_id}/revisions`
-- `GET /series-profiles/{profile_id}/reference-documents/{document_id}/revisions`
-- `GET /reference-document-revisions/{revision_id}`
-- `POST /reference-bindings`
-- `GET /reference-bindings`
-- `GET /reference-bindings/{binding_id}`
+- `POST /v1/series-profiles/{profile_id}/reference-documents`
+- `GET /v1/series-profiles/{profile_id}/reference-documents`
+- `GET /v1/series-profiles/{profile_id}/reference-documents/{document_id}`
+- `PATCH /v1/series-profiles/{profile_id}/reference-documents/{document_id}`
+- `POST /v1/series-profiles/{profile_id}/reference-documents/{document_id}/revisions`
+- `GET /v1/series-profiles/{profile_id}/reference-documents/{document_id}/revisions`
+- `GET /v1/reference-document-revisions/{revision_id}`
+- `POST /v1/reference-bindings`
+- `GET /v1/reference-bindings`
+- `GET /v1/reference-bindings/{binding_id}`
 
 Implementation notes:
 
@@ -691,8 +708,8 @@ async def enrich(llm_port, script_tei_xml: str) -> str:
   `ShowNotesResult`. Callers should catch this exception to handle malformed or
   unexpected LLM output gracefully. It is raised when the response text is not
   valid JSON; when the top-level JSON object does not contain an `entries`
-  list; when an entry in `entries` is not a JSON object; when a required field
-  (`topic` or `summary`) is absent, empty, or not a string; when an optional
+  list; when an entry in `entries` is not a JSON object; when a required field (
+  `topic` or `summary`) is absent, empty, or not a string; when an optional
   field (`timestamp` or `tei_locator`) is present but is not a string or null;
   and when a `timestamp` value does not match the ISO 8601 duration format.
 - `ChapterMarkersGenerator` follows the same boundary in
@@ -896,8 +913,8 @@ Roadmap item `2.4.1` introduces a dedicated orchestration package in
 
 The multi-source ingestion service normalizes heterogeneous source documents,
 applies source weighting heuristics, resolves conflicts, and merges the result
-into a canonical TEI episode. The service is implemented as an orchestrator
-(`ingest_multi_source`) that composes around the existing low-level
+into a canonical TEI episode. The service is implemented as an orchestrator (
+`ingest_multi_source`) that composes around the existing low-level
 `ingest_sources` persistence function.
 
 ### Port protocols

--- a/docs/execplans/4-1-1-introduce-v1-target-api-prefix.md
+++ b/docs/execplans/4-1-1-introduce-v1-target-api-prefix.md
@@ -39,7 +39,8 @@ Success is observable when:
 
 This work is a routing and contract-alignment change. It does not implement the
 future episode, upload, ingestion-job, generation-run, WebSocket, approval,
-CLI, or web-console resources described later in phase 4.
+command-line interface (CLI), or web-console resources described later in phase
+4.
 
 ## Context and orientation
 
@@ -86,8 +87,9 @@ The source documents that govern this work are:
 - `docs/adr/adr-009-source-to-script-rest-vertical-slice.md`, which records
   the accepted decision that existing unversioned routes do not need
   preservation before v0.1.0.
-- `docs/episodic-podcast-generation-system-design.md`, which links ADR 009 and
-  already describes the source-to-script vertical-slice direction.
+- `docs/episodic-podcast-generation-system-design.md`, which links
+  architecture decision record (ADR) 009 and already describes the
+  source-to-script vertical-slice direction.
 - `docs/async-sqlalchemy-with-pg-and-falcon.md`,
   `docs/testing-async-falcon-endpoints.md`,
   `docs/testing-sqlalchemy-with-pytest-and-py-pglite.md`, and
@@ -170,7 +172,7 @@ contract without adding those future endpoints here.
 - Risk: path churn is broad because many tests hard-code unversioned routes.
   Severity: medium. Likelihood: high. Mitigation: introduce or update shared
   test path helpers where that reduces repetition, then update direct tests and
-  BDD steps in one controlled pass.
+  behaviour-driven development (BDD) steps in one controlled pass.
 
 - Risk: health endpoints could be accidentally moved under `/v1`. Severity:
   medium. Likelihood: medium. Mitigation: add or preserve tests that assert
@@ -554,6 +556,31 @@ The final implementation should include short transcripts in this plan's
   `/tmp/coderabbit-review-episodic-4-1-1-introduce-v1-target-api-prefix.out`.
 - [x] Run focused tests, full gates and CodeRabbit review.
 - [x] Mark roadmap item `4.1.1` done after implementation and gates pass.
+- [x] 2026-05-22T19:05:00+02:00: Verified CodeRabbit follow-up findings with
+  Wyvern and scribe agents. Still-valid issues were limited to brittle
+  route-registration assertions, missing negative coverage for
+  `/v1/health/ready`, missing unversioned write-route coverage, one stale
+  user-guide route example, and first-use acronym definitions in this ExecPlan.
+- [x] 2026-05-22T19:31:00+02:00: Addressed the still-valid follow-up findings
+  by narrowing route-versioning coverage to representative route families,
+  asserting route registration as non-`404`, adding `/v1/health/ready` and
+  unversioned write-route negative coverage, and fixing the stale documentation
+  examples. `tests/test_api_route_versioning.py` passed with 8 tests. Log:
+  `/tmp/route-versioning-review-fixes-final-episodic-4-1-1-introduce-v1-target-api-prefix.out`.
+- [x] 2026-05-22T19:58:00+02:00: Re-ran validation after the follow-up fixes.
+  `make check-fmt`, `make markdownlint`, `make nixie`, `make typecheck`, and
+  `make lint` passed. `make test` passed with 669 tests and 3 skipped. Logs:
+  `/tmp/check-fmt-review-fixes-episodic-4-1-1-introduce-v1-target-api-prefix.out`,
+  `/tmp/markdownlint-review-fixes-episodic-4-1-1-introduce-v1-target-api-prefix.out`,
+  `/tmp/nixie-review-fixes-episodic-4-1-1-introduce-v1-target-api-prefix.out`,
+  `/tmp/typecheck-review-fixes-episodic-4-1-1-introduce-v1-target-api-prefix.out`,
+  `/tmp/lint-review-fixes-episodic-4-1-1-introduce-v1-target-api-prefix.out`,
+  and
+  `/tmp/test-review-fixes-episodic-4-1-1-introduce-v1-target-api-prefix.out`.
+- [x] 2026-05-22T20:03:00+02:00: Ran
+  `coderabbit review --agent` after the follow-up fixes. Result:
+  `review_completed` with zero findings. Log:
+  `/tmp/coderabbit-review-followup-fixes-episodic-4-1-1-introduce-v1-target-api-prefix.out`.
 
 ## Surprises and discoveries
 

--- a/docs/execplans/4-1-1-introduce-v1-target-api-prefix.md
+++ b/docs/execplans/4-1-1-introduce-v1-target-api-prefix.md
@@ -12,11 +12,11 @@ kept current as milestones complete.
 ## Purpose and big picture
 
 Roadmap item `4.1.1` makes `/v1` the target prefix for Episodic's client-facing
-REST API. After the implementation, clients, the terminal user interface (TUI),
-and future source-to-script vertical-slice endpoints will call canonical
-resources through `/v1/...` paths. Existing unversioned canonical API routes
-are pre-v0.1.0 implementation details and do not need compatibility
-preservation.
+representational state transfer (REST) API. After the implementation, clients,
+the terminal user interface (TUI), and future source-to-script vertical-slice
+endpoints will call canonical resources through `/v1/...` paths. Existing
+unversioned canonical API routes are pre-v0.1.0 implementation details and do
+not need compatibility preservation.
 
 Success is observable when:
 
@@ -105,13 +105,14 @@ implementation unexpectedly introduces Rust code; this plan does not require
 Rust, Verus, Kani or CrossHair changes.
 
 Firecrawl research resolved two external prior-art points. Falcon 4.2 routes
-are registered through `app.add_route()` URI templates, and unmatched routes
-fall through to Falcon's normal route-not-found responder. Microsoft REST API
-guidance treats REST APIs as resource-oriented HTTP surfaces, says versioning
-protects client compatibility during updates, and recommends `202 Accepted` for
-long-running asynchronous operations. These facts support a simple route prefix
-for the existing resources and preserve ADR 009's later long-running operation
-contract without adding those future endpoints here.
+are registered through `app.add_route()` uniform resource identifier (URI)
+templates, and unmatched routes fall through to Falcon's normal route-not-found
+responder. Microsoft REST API guidance treats REST APIs as resource-oriented
+hypertext transfer protocol (HTTP) surfaces, says versioning protects client
+compatibility during updates, and recommends `202 Accepted` for long-running
+asynchronous operations. These facts support a simple route prefix for the
+existing resources and preserve ADR 009's later long-running operation contract
+without adding those future endpoints here.
 
 ## Constraints
 
@@ -129,8 +130,8 @@ contract without adding those future endpoints here.
   compatibility weight.
 - Keep hexagonal architecture boundaries intact. Route registration belongs in
   the inbound Falcon adapter. Domain packages, application services, repository
-  ports, SQLAlchemy adapters and LLM adapters must not learn about HTTP path
-  prefixes.
+  ports, SQLAlchemy adapters and large language model (LLM) adapters must not
+  learn about HTTP path prefixes.
 - Do not introduce a new runtime dependency for this work.
 - Use Vidai Mock only for behavioural tests that exercise inference services.
   This route-prefix task should not need Vidai Mock because it does not call an
@@ -581,6 +582,33 @@ The final implementation should include short transcripts in this plan's
   `coderabbit review --agent` after the follow-up fixes. Result:
   `review_completed` with zero findings. Log:
   `/tmp/coderabbit-review-followup-fixes-episodic-4-1-1-introduce-v1-target-api-prefix.out`.
+- [x] 2026-05-22T21:17:00+02:00: Verified the latest failed-check findings
+  with Wyvern and scribe agents. The `/v1/health/ready` and users-guide path
+  findings were stale. The still-valid issues were route contract tests
+  relying only on status codes and remaining first-use acronym expansions in
+  this ExecPlan. Added response payload assertions to
+  `tests/test_api_route_versioning.py` and expanded the remaining acronyms.
+  `tests/test_api_route_versioning.py` passed with 8 tests. Log:
+  `/tmp/route-versioning-contract-behaviour-episodic-4-1-1-introduce-v1-target-api-prefix.out`.
+- [x] 2026-05-22T21:28:00+02:00: Ran follow-up gates for the contract
+  behaviour assertions. `make check-fmt`, `make markdownlint`,
+  `make typecheck`, and `make lint` passed. `make test` reached the updated
+  route-versioning tests successfully, then failed later in
+  `tests/test_guest_bios_properties.py::test_enriched_guest_bios_preserves_entry_order`
+  because Hypothesis generated the XML-forbidden character `U+FFFE` in an
+  unrelated guest biography payload. The single-test rerun reproduced the same
+  failure. Logs:
+  `/tmp/check-fmt-contract-behaviour-episodic-4-1-1-introduce-v1-target-api-prefix.out`,
+  `/tmp/markdownlint-contract-behaviour-episodic-4-1-1-introduce-v1-target-api-prefix.out`,
+  `/tmp/typecheck-contract-behaviour-episodic-4-1-1-introduce-v1-target-api-prefix.out`,
+  `/tmp/lint-contract-behaviour-episodic-4-1-1-introduce-v1-target-api-prefix.out`,
+  `/tmp/test-contract-behaviour-episodic-4-1-1-introduce-v1-target-api-prefix.out`,
+  and
+  `/tmp/guest-bios-property-validation-failure-episodic-4-1-1-introduce-v1-target-api-prefix.out`.
+- [x] 2026-05-22T21:31:00+02:00: Attempted
+  `coderabbit review --agent` after the contract behaviour fixes. CodeRabbit
+  returned a recoverable rate-limit error before review analysis began. Log:
+  `/tmp/coderabbit-review-contract-behaviour-episodic-4-1-1-introduce-v1-target-api-prefix.out`.
 
 ## Surprises and discoveries
 

--- a/docs/execplans/4-1-1-introduce-v1-target-api-prefix.md
+++ b/docs/execplans/4-1-1-introduce-v1-target-api-prefix.md
@@ -1,0 +1,514 @@
+# Introduce the `/v1` target API prefix
+
+This ExecPlan (execution plan) is a living document. The sections
+`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
+`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
+proceeds.
+
+Status: DRAFT
+
+This plan must be approved before implementation begins.
+
+## Purpose and big picture
+
+Roadmap item `4.1.1` makes `/v1` the target prefix for Episodic's client-facing
+REST API. After the implementation, clients, the terminal user interface (TUI),
+and future source-to-script vertical-slice endpoints will call canonical
+resources through `/v1/...` paths. Existing unversioned canonical API routes
+are pre-v0.1.0 implementation details and do not need compatibility
+preservation.
+
+Success is observable when:
+
+1. `GET /v1/series-profiles`, `POST /v1/series-profiles`,
+   `GET /v1/episode-templates`, the reusable-reference endpoints, and the
+   binding-resolution endpoints route through the existing Falcon resource
+   handlers.
+2. The old unversioned canonical API paths return Falcon's normal `404 Not
+   Found` response, proving there is no compatibility alias.
+3. Operator health checks remain at `GET /health/live` and
+   `GET /health/ready`, unless the implementation discovers a documented reason
+   to version them.
+4. The developers' guide documents version routing, and user-facing endpoint
+   examples that describe currently supported API behaviour use `/v1`.
+5. The new unit, behavioural, and end-to-end tests fail before the route change
+   and pass after the route change.
+6. `make check-fmt`, `make typecheck`, `make lint`, `make test`,
+   `make markdownlint`, `make nixie`, `make check-migrations`, and
+   `coderabbit review --agent` succeed before the implementation is committed.
+
+This work is a routing and contract-alignment change. It does not implement the
+future episode, upload, ingestion-job, generation-run, WebSocket, approval,
+CLI, or web-console resources described later in phase 4.
+
+## Context and orientation
+
+The active branch for this plan is `4-1-1-introduce-v1-target-api-prefix`.
+
+The canonical Falcon application is assembled in `episodic/api/app.py` by
+`create_app()`. That function currently registers health checks and canonical
+content routes directly at root paths. `episodic/api/runtime.py` calls
+`create_app()` from the Granian composition root without adding a prefix.
+
+The currently implemented canonical API paths are:
+
+- `/series-profiles`
+- `/series-profiles/{profile_id}`
+- `/series-profiles/{profile_id}/history`
+- `/series-profiles/{profile_id}/brief`
+- `/series-profiles/{profile_id}/resolved-bindings`
+- `/episode-templates`
+- `/episode-templates/{template_id}`
+- `/episode-templates/{template_id}/history`
+- `/series-profiles/{profile_id}/reference-documents`
+- `/series-profiles/{profile_id}/reference-documents/{document_id}`
+- `/series-profiles/{profile_id}/reference-documents/{document_id}/revisions`
+- `/reference-document-revisions/{revision_id}`
+- `/reference-bindings`
+- `/reference-bindings/{binding_id}`
+
+The target behaviour is to register those canonical content paths under `/v1`.
+For example, `/series-profiles` becomes `/v1/series-profiles`, and
+`/series-profiles/{profile_id}/brief` becomes
+`/v1/series-profiles/{profile_id}/brief`.
+
+Health checks are operator endpoints, not TUI-facing or vertical-slice
+resources. Keep `/health/live` and `/health/ready` unversioned so deployment
+platforms and readiness probes do not need to know the public API version.
+
+The source documents that govern this work are:
+
+- `docs/roadmap.md`, section `4.1.1`, which requires `/v1` routing and
+  developers' guide documentation.
+- `docs/episodic-tui-api-design.md`, especially "Current canonical endpoint
+  coverage" and "Proposed REST endpoints", which state that the target REST API
+  uses `/v1`.
+- `docs/adr/adr-009-source-to-script-rest-vertical-slice.md`, which records
+  the accepted decision that existing unversioned routes do not need
+  preservation before v0.1.0.
+- `docs/episodic-podcast-generation-system-design.md`, which links ADR 009 and
+  already describes the source-to-script vertical-slice direction.
+- `docs/async-sqlalchemy-with-pg-and-falcon.md`,
+  `docs/testing-async-falcon-endpoints.md`,
+  `docs/testing-sqlalchemy-with-pytest-and-py-pglite.md`, and
+  `docs/agentic-systems-with-langgraph-and-celery.md`, which provide the local
+  testing and integration background for Falcon, SQLAlchemy, py-pglite,
+  LangGraph and Celery.
+
+Use the `leta` skill for semantic code navigation. Use the
+`hexagonal-architecture` skill to preserve the rule that the Falcon API layer
+is an inbound adapter over domain/application services, not a place for domain
+logic or outbound-adapter coupling. Use the `rust-router` skill only if a later
+implementation unexpectedly introduces Rust code; this plan does not require
+Rust, Verus, Kani or CrossHair changes.
+
+Firecrawl research resolved two external prior-art points. Falcon 4.2 routes
+are registered through `app.add_route()` URI templates, and unmatched routes
+fall through to Falcon's normal route-not-found responder. Microsoft REST API
+guidance treats REST APIs as resource-oriented HTTP surfaces, says versioning
+protects client compatibility during updates, and recommends `202 Accepted` for
+long-running asynchronous operations. These facts support a simple route prefix
+for the existing resources and preserve ADR 009's later long-running operation
+contract without adding those future endpoints here.
+
+## Constraints
+
+- Do not implement the plan until the user explicitly approves it.
+- Keep this task scoped to route prefixing, tests, and documentation for
+  already implemented canonical API resources.
+- Do not implement future phase-4 resources such as `/v1/episodes`,
+  `/v1/uploads`, `/v1/ingestion-jobs`, `/v1/generation-runs`,
+  `/v1/voice-previews`, WebSocket streams, CLI commands, approval workflows, or
+  web-console flows.
+- Preserve health checks at `/health/live` and `/health/ready` unless a
+  documented requirement proves they should be versioned.
+- Do not preserve compatibility aliases for unversioned canonical API paths.
+  The repository is pre-v0.1.0, and ADR 009 deliberately avoids that
+  compatibility weight.
+- Keep hexagonal architecture boundaries intact. Route registration belongs in
+  the inbound Falcon adapter. Domain packages, application services, repository
+  ports, SQLAlchemy adapters and LLM adapters must not learn about HTTP path
+  prefixes.
+- Do not introduce a new runtime dependency for this work.
+- Use Vidai Mock only for behavioural tests that exercise inference services.
+  This route-prefix task should not need Vidai Mock because it does not call an
+  `LLMPort`.
+- Use property tests only if the implementation introduces a reusable route
+  joining or normalisation function with invariants over many path fragments. A
+  direct constant prefix does not need Hypothesis.
+- Do not mark roadmap item `4.1.1` done in a pre-implementation plan PR.
+  Mark it done only after implementation, documentation, gates and review are
+  complete.
+- Commit only after gates for the current change pass. This planning change is
+  documentation-only, so its commit gate is Markdown formatting/linting and
+  Mermaid validation, plus any repository-specific checks that prove the docs
+  remain healthy.
+
+## Tolerances (exception triggers)
+
+- Scope: stop and escalate if the implementation needs more than 12 production
+  files or 900 net lines of non-test code.
+- Route behaviour: stop and escalate if any unversioned canonical API path must
+  remain live for a client, fixture or deployment dependency.
+- Health checks: stop and escalate if tests or deployment documentation show
+  that health checks must be available under both root and `/v1` paths.
+- Dependencies: stop and escalate before adding any runtime dependency or any
+  new test dependency.
+- Architecture: stop and escalate if the route-prefix change requires domain,
+  application, repository, SQLAlchemy, LLM or worker modules to import from
+  `episodic.api`.
+- Interface: stop and escalate if resource request or response bodies must
+  change to introduce the prefix.
+- Tests: stop and escalate after three unsuccessful attempts to stabilise the
+  same failing test cluster.
+- Ambiguity: stop and present options if there are two materially different
+  interpretations of which endpoints are "TUI-facing" after reviewing the
+  current code and docs.
+
+## Risks
+
+- Risk: path churn is broad because many tests hard-code unversioned routes.
+  Severity: medium. Likelihood: high. Mitigation: introduce or update shared
+  test path helpers where that reduces repetition, then update direct tests and
+  BDD steps in one controlled pass.
+
+- Risk: health endpoints could be accidentally moved under `/v1`. Severity:
+  medium. Likelihood: medium. Mitigation: add or preserve tests that assert
+  `/health/live` and `/health/ready` remain root-level, and add a negative
+  assertion for `/v1/health/live` only if the behaviour is stable in Falcon.
+
+- Risk: a route-prefix helper could silently create double slashes or drop
+  path parameters. Severity: medium. Likelihood: low. Mitigation: prefer a tiny
+  local helper with tests if route registration is refactored; otherwise use
+  explicit `/v1/...` literals to avoid hidden path manipulation.
+
+- Risk: behavioural tests may be updated without first proving they fail
+  against the old unversioned app. Severity: medium. Likelihood: medium.
+  Mitigation: run the targeted API tests after changing tests but before
+  changing `episodic/api/app.py`, and record the expected 404 failures in
+  `Progress`.
+
+- Risk: documentation could overstate future `/v1` endpoints as implemented.
+  Severity: medium. Likelihood: medium. Mitigation: distinguish currently
+  implemented `/v1` canonical resources from planned TUI and vertical-slice
+  resources in the developers' guide and users' guide.
+
+- Risk: CodeRabbit may report concerns that require design changes. Severity:
+  medium. Likelihood: low. Mitigation: run `coderabbit review --agent` after
+  the route/test/docs milestone, resolve all actionable concerns, and rerun it
+  before moving on.
+
+## Work plan
+
+Begin each milestone by checking the branch and status:
+
+```shell
+git branch --show-current
+git status --short --branch
+```
+
+Use `tee` for long-running gates so truncated terminal output does not hide
+failures. The recommended log naming shape is:
+
+```shell
+set -o pipefail; make check-fmt 2>&1 | tee /tmp/check-fmt-episodic-$(git branch --show-current).out
+```
+
+### Milestone 1: establish the red route-contract tests
+
+Update tests before production code. The goal is to express the new contract
+and prove the current app does not satisfy it.
+
+Inspect the existing route tests and fixtures:
+
+```shell
+leta show create_app
+leta show tests/fixtures/api.py:canonical_api_client
+leta show tests/fixtures/api.py:canonical_api_async_client
+```
+
+Add or update unit-level route tests in the existing API test area so they
+assert:
+
+- each implemented canonical API route is reachable at `/v1/...`;
+- the equivalent unversioned canonical path returns `404 Not Found`;
+- `/health/live` and `/health/ready` still work at root paths.
+
+Use existing `canonical_api_client` and `canonical_api_async_client` fixtures.
+If a shared path helper is introduced for tests, place it near existing API
+test support, not in production code.
+
+Update BDD step definitions that exercise canonical API routes so their calls
+use `/v1/...`. The most likely files are:
+
+- `tests/steps/test_profile_template_api_steps.py`
+- `tests/steps/test_reference_document_api_steps.py`
+- `tests/steps/test_binding_resolution_steps.py`
+- `tests/steps/test_reference_document_model_steps.py`
+
+Update direct API tests and support helpers as needed:
+
+- `tests/test_profile_template_api.py`
+- `tests/test_binding_resolution_api.py`
+- `tests/test_reference_document_validation.py`
+- `tests/test_reference_document_access.py`
+- `tests/test_reference_document_roundtrip.py`
+- `tests/test_binding_resolution_brief_endpoint.py`
+- `tests/test_reference_document_api_support.py`
+- `tests/test_binding_resolution_support.py`
+
+Add syrupy snapshot coverage only where the response shape is contractually
+important and not already covered by clear field assertions. Strong candidates
+are the structured brief envelope, resolved-binding response, reference
+document list envelope, revision envelope, and binding envelope. Do not add
+snapshots for volatile identifiers or timestamps unless they are normalised.
+
+Run a focused red test pass:
+
+```shell
+set -o pipefail
+uv run pytest -q \
+  tests/test_profile_template_api.py \
+  tests/test_binding_resolution_api.py \
+  tests/test_reference_document_validation.py \
+  tests/test_reference_document_access.py \
+  tests/test_reference_document_roundtrip.py \
+  tests/test_binding_resolution_brief_endpoint.py \
+  2>&1 | tee /tmp/v1-red-api-tests-episodic-$(git branch --show-current).out
+```
+
+Expected result before production changes: assertions that call `/v1/...` fail
+with `404 Not Found`, while health checks continue to pass at root paths.
+Record the result in `Progress`.
+
+### Milestone 2: prefix existing canonical Falcon routes
+
+Edit `episodic/api/app.py`. Keep `create_app()` as the route factory. Keep
+health route registration unchanged:
+
+```python
+app.add_route("/health/live", HealthLiveResource())
+app.add_route("/health/ready", HealthReadyResource(...))
+```
+
+Register every implemented canonical content route under `/v1`. Either use
+explicit route strings or a small local helper such as:
+
+```python
+def _v1(path: str) -> str:
+    return f"/v1{path}"
+```
+
+If using a helper, keep it private to `episodic/api/app.py` and add focused
+unit coverage for edge cases only if the helper accepts arbitrary input. Do not
+move version routing into domain, application or storage modules.
+
+Do not add unversioned aliases. Do not change resource classes, serializers,
+request bodies, response bodies or service calls unless a test reveals an
+existing bug unrelated to routing. If that happens, record the decision and
+consider a separate fix.
+
+Run the focused test pass again:
+
+```shell
+set -o pipefail
+uv run pytest -q \
+  tests/test_profile_template_api.py \
+  tests/test_binding_resolution_api.py \
+  tests/test_reference_document_validation.py \
+  tests/test_reference_document_access.py \
+  tests/test_reference_document_roundtrip.py \
+  tests/test_binding_resolution_brief_endpoint.py \
+  2>&1 | tee /tmp/v1-green-api-tests-episodic-$(git branch --show-current).out
+```
+
+Expected result: the new `/v1` assertions pass, unversioned canonical routes
+return `404`, and health checks remain available at root paths.
+
+### Milestone 3: align behavioural and runtime coverage
+
+Run the API BDD scenarios that use Falcon route paths:
+
+```shell
+set -o pipefail
+uv run pytest -q \
+  tests/steps/test_profile_template_api_steps.py \
+  tests/steps/test_reference_document_api_steps.py \
+  tests/steps/test_binding_resolution_steps.py \
+  tests/steps/test_reference_document_model_steps.py \
+  2>&1 | tee /tmp/v1-bdd-api-tests-episodic-$(git branch --show-current).out
+```
+
+Run runtime health coverage to prove Granian/Falcon health behaviour remains
+root-level:
+
+```shell
+set -o pipefail
+uv run pytest -q \
+  tests/test_health_endpoints.py \
+  tests/test_env_runtime_wiring.py \
+  tests/steps/test_http_service_scaffold_steps.py \
+  2>&1 | tee /tmp/v1-runtime-tests-episodic-$(git branch --show-current).out
+```
+
+If a live Granian BDD test is already covered by `make test`, do not duplicate
+long process tests unless local evidence is needed to debug a failure.
+
+### Milestone 4: update documentation
+
+Update `docs/developers-guide.md` with a "Versioned API routing" section near
+the Falcon HTTP runtime guidance. It must state:
+
+- `/v1` is the target prefix for client-facing canonical API resources.
+- Existing unversioned canonical routes are pre-v0.1.0 implementation details
+  and are not compatibility aliases.
+- Health checks remain root-level operator endpoints.
+- New TUI-facing and vertical-slice endpoints must be registered under `/v1`.
+- The decision is aligned with ADR 009 and
+  `docs/episodic-tui-api-design.md`.
+
+Update any accepted-ADR or design-reference list in `docs/developers-guide.md`
+to include ADR 009 if the guide has such a list.
+
+Update `docs/users-guide.md` so examples for currently implemented API
+behaviour use `/v1/...` paths. Be careful not to imply that future phase-4
+resources are already implemented.
+
+Update `docs/episodic-podcast-generation-system-design.md` or
+`docs/episodic-tui-api-design.md` only if the implementation discovers a
+substantive design decision not already captured. Otherwise, leave those design
+documents unchanged because they already identify `/v1` as the target.
+
+Do not mark `docs/roadmap.md` item `4.1.1` complete until the implementation,
+documentation and gates have passed. At the end of the approved implementation
+branch, change:
+
+```markdown
+- [ ] 4.1.1. Introduce `/v1` as the target API prefix.
+```
+
+to:
+
+```markdown
+- [x] 4.1.1. Introduce `/v1` as the target API prefix.
+```
+
+### Milestone 5: run gates and review
+
+Run formatting first:
+
+```shell
+set -o pipefail; make fmt 2>&1 | tee /tmp/fmt-episodic-$(git branch --show-current).out
+```
+
+Then run gates sequentially:
+
+```shell
+set -o pipefail; mbake validate Makefile 2>&1 | tee /tmp/mbake-episodic-$(git branch --show-current).out
+set -o pipefail; make check-fmt 2>&1 | tee /tmp/check-fmt-episodic-$(git branch --show-current).out
+set -o pipefail; PATH=/root/.bun/bin:$PATH make markdownlint 2>&1 | tee /tmp/markdownlint-episodic-$(git branch --show-current).out
+set -o pipefail; make nixie 2>&1 | tee /tmp/nixie-episodic-$(git branch --show-current).out
+set -o pipefail; make build 2>&1 | tee /tmp/build-episodic-$(git branch --show-current).out
+set -o pipefail; make lint 2>&1 | tee /tmp/lint-episodic-$(git branch --show-current).out
+set -o pipefail; make typecheck 2>&1 | tee /tmp/typecheck-episodic-$(git branch --show-current).out
+set -o pipefail; make test 2>&1 | tee /tmp/test-episodic-$(git branch --show-current).out
+set -o pipefail; make check-migrations 2>&1 | tee /tmp/check-migrations-episodic-$(git branch --show-current).out
+set -o pipefail; coderabbit doctor 2>&1 | tee /tmp/coderabbit-doctor-episodic-$(git branch --show-current).out
+set -o pipefail; coderabbit review --agent 2>&1 | tee /tmp/coderabbit-review-episodic-$(git branch --show-current).out
+```
+
+Clear every actionable CodeRabbit concern before proceeding. If CodeRabbit
+raises a concern that conflicts with this plan, record the conflict in
+`Decision Log` and ask for direction.
+
+After all gates pass, commit with a file-based commit message. Do not use
+`git commit -m`.
+
+## Validation and expected evidence
+
+For the approved implementation, the minimum final validation evidence is:
+
+- Focused route tests show `/v1` canonical resources pass and unversioned
+  canonical resources return `404`.
+- API BDD scenarios pass with `/v1` paths.
+- Runtime health tests pass at root health paths.
+- `mbake validate Makefile` passes.
+- `make check-fmt` passes.
+- `make markdownlint` passes.
+- `make nixie` passes.
+- `make build` passes.
+- `make lint` passes.
+- `make typecheck` passes.
+- `make test` passes.
+- `make check-migrations` passes.
+- `coderabbit doctor` passes.
+- `coderabbit review --agent` reports no unresolved actionable concerns.
+
+The final implementation should include short transcripts in this plan's
+`Progress` section, for example:
+
+```plaintext
+2026-05-19T10:20:00+02:00: `make test` passed. Log:
+`/tmp/test-episodic-4-1-1-introduce-v1-target-api-prefix.out`.
+```
+
+## Progress
+
+- [x] 2026-05-19T00:56:00+02:00: Loaded `leta`,
+  `hexagonal-architecture`, `execplans`, `firecrawl`, `commit-message`,
+  `pr-creation`, and `en-gb-oxendict-style` skills for planning, research,
+  branch, commit and PR work.
+- [x] 2026-05-19T00:56:00+02:00: Created a `leta` workspace for the current
+  repository.
+- [x] 2026-05-19T00:56:00+02:00: Renamed the local branch from
+  `feat/v1apiexecplan` to `4-1-1-introduce-v1-target-api-prefix`.
+- [x] 2026-05-19T00:56:00+02:00: Created context pack `pk_p7rbuu6y` for the
+  Wyvern planning team.
+- [x] 2026-05-19T01:02:00+02:00: Gathered Wyvern findings for documentation
+  scope, route/test scope and PR/readiness constraints.
+- [x] 2026-05-19T01:04:00+02:00: Used Firecrawl to confirm Falcon route
+  registration behaviour and REST API versioning prior art.
+- [x] 2026-05-19T01:07:00+02:00: Drafted this pre-implementation ExecPlan.
+- [ ] Obtain explicit user approval before implementation.
+- [ ] During approved implementation, add route-contract tests first and
+  record the red test evidence here.
+- [ ] Prefix canonical API routes under `/v1`.
+- [ ] Update API BDD steps and direct API tests to use `/v1`.
+- [ ] Update developers' guide and users' guide.
+- [ ] Run focused tests, full gates and CodeRabbit review.
+- [ ] Mark roadmap item `4.1.1` done after implementation and gates pass.
+
+## Surprises and discoveries
+
+- `docs/episodic-tui-api-design.md` and ADR 009 already describe `/v1` as the
+  target API, but `docs/developers-guide.md` and `docs/users-guide.md` still
+  contain unversioned examples for currently implemented canonical endpoints.
+- The Falcon route table is centralised in `episodic/api/app.py`; no separate
+  route grouping abstraction currently exists.
+- Existing API tests and BDD step files hard-code many route paths, so the
+  implementation will be mostly coordinated test and documentation churn plus a
+  small production route-table change.
+- CodeRabbit CLI is available in this environment, and `coderabbit doctor`
+  was reported healthy by the Wyvern planning team.
+
+## Decision Log
+
+- 2026-05-19: Keep health endpoints unversioned. Rationale: roadmap item
+  `4.1.1` covers TUI-facing and vertical-slice endpoints, while health checks
+  are operator endpoints documented for runtime readiness and liveness.
+- 2026-05-19: Do not preserve unversioned canonical API aliases. Rationale:
+  ADR 009 and the TUI API design explicitly state that existing unversioned
+  routes are pre-v0.1.0 implementation details with no compatibility obligation.
+- 2026-05-19: Do not use Vidai Mock for this route-prefix implementation.
+  Rationale: the change does not exercise inference services. Existing
+  inference-backed behavioural tests continue to use Vidai Mock where relevant.
+- 2026-05-19: Do not mark roadmap item `4.1.1` done in this plan-only branch.
+  Rationale: the roadmap checkbox should reflect delivered implementation, not
+  pre-implementation planning.
+
+## Outcomes and retrospective
+
+This section is intentionally empty while the plan is in draft. During
+implementation, record what shipped, which tests and gates proved it, any
+deviations from this plan, and whether the route-prefix approach remained small
+enough to avoid a broader API-router abstraction.

--- a/docs/execplans/4-1-1-introduce-v1-target-api-prefix.md
+++ b/docs/execplans/4-1-1-introduce-v1-target-api-prefix.md
@@ -1,13 +1,13 @@
 # Introduce the `/v1` target API prefix
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+ `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
-Status: DRAFT
+Status: COMPLETE
 
-This plan must be approved before implementation begins.
+The user approved implementation on 2026-05-20 and asked for the plan to be
+kept current as milestones complete.
 
 ## Purpose and big picture
 
@@ -469,14 +469,91 @@ The final implementation should include short transcripts in this plan's
 - [x] 2026-05-19T01:04:00+02:00: Used Firecrawl to confirm Falcon route
   registration behaviour and REST API versioning prior art.
 - [x] 2026-05-19T01:07:00+02:00: Drafted this pre-implementation ExecPlan.
-- [ ] Obtain explicit user approval before implementation.
-- [ ] During approved implementation, add route-contract tests first and
-  record the red test evidence here.
-- [ ] Prefix canonical API routes under `/v1`.
-- [ ] Update API BDD steps and direct API tests to use `/v1`.
-- [ ] Update developers' guide and users' guide.
-- [ ] Run focused tests, full gates and CodeRabbit review.
-- [ ] Mark roadmap item `4.1.1` done after implementation and gates pass.
+- [x] 2026-05-20T13:34:49+02:00: User approved implementation and asked for
+  this ExecPlan to be kept current with decisions, findings, observations and
+  progress.
+- [x] 2026-05-20T13:38:00+02:00: Updated the focused API tests and shared
+  test helpers to call `/v1/...` canonical paths before changing production
+  routing. The focused red run failed as expected with 28 failures and one pass
+  because `/v1/series-profiles` returned Falcon `404 Not Found`. Log:
+  `/tmp/v1-red-api-tests-episodic-4-1-1-introduce-v1-target-api-prefix.out`.
+- [x] 2026-05-20T13:43:00+02:00: Prefixed canonical Falcon API route
+  registrations in `episodic/api/app.py` under `/v1`, leaving `/health/live` and
+   `/health/ready` unchanged at the root.
+- [x] 2026-05-20T13:45:00+02:00: Added explicit route-versioning contract
+  coverage in `tests/test_api_route_versioning.py` for unversioned canonical
+  route `404` responses and for `/v1/health/live` remaining unregistered.
+- [x] 2026-05-20T13:46:00+02:00: Re-ran the focused API test pass with the
+  route table changed. Result: 44 passed in 94.21 seconds. Log:
+  `/tmp/v1-green-api-tests-episodic-4-1-1-introduce-v1-target-api-prefix.out`.
+- [x] 2026-05-20T13:51:00+02:00: Addressed CodeRabbit's route-versioning
+  coverage concerns by adding positive `/v1` route-registration assertions and
+  positive root health assertions. `tests/test_api_route_versioning.py` passed
+  with 31 tests in 67.21 seconds. Log:
+  `/tmp/v1-route-versioning-tests-episodic-4-1-1-introduce-v1-target-api-prefix.out`.
+- [x] 2026-05-20T13:57:00+02:00: Re-ran `coderabbit review --agent` after
+  the route and test milestone. Result: `review_completed` with zero findings.
+  Log:
+  `/tmp/coderabbit-review-after-route-coverage-episodic-4-1-1-introduce-v1-target-api-prefix.out`.
+- [x] 2026-05-20T13:59:00+02:00: Ran API BDD step-module coverage after
+  updating the step paths to `/v1`. Result: 4 passed in 8.76 seconds. Log:
+  `/tmp/v1-bdd-api-tests-episodic-4-1-1-introduce-v1-target-api-prefix.out`.
+- [x] 2026-05-20T13:59:00+02:00: Ran runtime health and HTTP scaffold
+  coverage. Result: 10 passed and 1 skipped in 8.40 seconds, with health
+  endpoints still root-level. Log:
+  `/tmp/v1-runtime-tests-episodic-4-1-1-introduce-v1-target-api-prefix.out`.
+- [x] Update API BDD steps and direct API tests to use `/v1`.
+- [x] 2026-05-20T14:13:00+02:00: Re-ran `coderabbit review --agent` after
+  clearing readability concerns in `tests/test_api_route_versioning.py`. Result:
+   `review_completed` with zero findings. Log:
+  `/tmp/coderabbit-review-after-test-readability-episodic-4-1-1-introduce-v1-target-api-prefix.out`.
+- [x] 2026-05-20T14:14:00+02:00: Updated `docs/developers-guide.md` with
+  versioned API routing guidance, added ADR 009 to the accepted-design list,
+  and updated currently implemented endpoint examples in
+  `docs/developers-guide.md` and `docs/users-guide.md` to use `/v1`.
+- [x] 2026-05-20T14:32:00+02:00: Cleared CodeRabbit's documentation and test
+  readability concerns. The latest `coderabbit review --agent` completed with
+  zero findings. Log:
+  `/tmp/coderabbit-review-after-route-docstring-episodic-4-1-1-introduce-v1-target-api-prefix.out`.
+- [x] Update developers' guide and users' guide.
+- [x] 2026-05-20T14:34:00+02:00: Marked roadmap item `4.1.1` done after
+  implementation, focused tests, documentation updates, and milestone
+  CodeRabbit reviews completed.
+- [x] 2026-05-20T14:36:00+02:00: Ran `make fmt`. Result: passed. The command
+  attempted unrelated Markdown wrapping in older documents; that unrelated
+  formatter churn was reverted, leaving only task-scoped files changed. Log:
+  `/tmp/fmt-episodic-4-1-1-introduce-v1-target-api-prefix.out`.
+- [x] 2026-05-20T14:38:00+02:00: Ran `mbake validate Makefile`,
+  `make check-fmt`, `make markdownlint`, `make nixie`, and `make build`.
+  Results: all passed. Logs:
+  `/tmp/mbake-episodic-4-1-1-introduce-v1-target-api-prefix.out`,
+  `/tmp/check-fmt-episodic-4-1-1-introduce-v1-target-api-prefix.out`,
+  `/tmp/markdownlint-episodic-4-1-1-introduce-v1-target-api-prefix.out`,
+  `/tmp/nixie-episodic-4-1-1-introduce-v1-target-api-prefix.out`, and
+  `/tmp/build-episodic-4-1-1-introduce-v1-target-api-prefix.out`.
+- [x] 2026-05-20T14:42:00+02:00: Ran `make lint`. The first run found two
+  issues in the new route-versioning test file. After moving the Falcon
+  `testing` import under `TYPE_CHECKING` and making string concatenation
+  explicit, the rerun passed. Log:
+  `/tmp/lint-episodic-4-1-1-introduce-v1-target-api-prefix.out`.
+- [x] 2026-05-20T14:43:00+02:00: Ran `make typecheck`. Result: passed. Log:
+  `/tmp/typecheck-episodic-4-1-1-introduce-v1-target-api-prefix.out`.
+- [x] 2026-05-20T14:50:00+02:00: Ran `make test`. Result: 662 passed and
+  3 skipped in 325.31 seconds. Log:
+  `/tmp/test-episodic-4-1-1-introduce-v1-target-api-prefix.out`.
+- [x] 2026-05-20T14:56:00+02:00: Ran `make check-migrations`. Result:
+  passed. Log:
+  `/tmp/check-migrations-episodic-4-1-1-introduce-v1-target-api-prefix.out`.
+- [x] 2026-05-20T14:57:00+02:00: Ran `coderabbit doctor`. Result: 9 passed,
+  0 warnings, 0 failed. Log:
+  `/tmp/coderabbit-doctor-episodic-4-1-1-introduce-v1-target-api-prefix.out`.
+- [x] 2026-05-20T15:03:49+02:00: Ran final `coderabbit review --agent`.
+  It first requested removal of the redundant Python 3.14 future import from
+  `tests/test_api_route_versioning.py`; after removal and a successful
+  `make lint` rerun, the final review completed with zero findings. Log:
+  `/tmp/coderabbit-review-episodic-4-1-1-introduce-v1-target-api-prefix.out`.
+- [x] Run focused tests, full gates and CodeRabbit review.
+- [x] Mark roadmap item `4.1.1` done after implementation and gates pass.
 
 ## Surprises and discoveries
 
@@ -508,7 +585,17 @@ The final implementation should include short transcripts in this plan's
 
 ## Outcomes and retrospective
 
-This section is intentionally empty while the plan is in draft. During
-implementation, record what shipped, which tests and gates proved it, any
-deviations from this plan, and whether the route-prefix approach remained small
-enough to avoid a broader API-router abstraction.
+The implementation shipped the `/v1` target prefix for the existing canonical
+Falcon API resources without adding unversioned compatibility aliases. Root
+health checks remain available at `/health/live` and `/health/ready`, while
+`/v1/health/live` returns `404`.
+
+The route-prefix approach stayed inside the planned inbound-adapter boundary:
+production changes were limited to Falcon route registration and docstring
+examples in the API adapter package. Domain, application, repository,
+SQLAlchemy, LLM, and worker modules did not learn about HTTP path prefixes.
+
+The work updated direct API tests, shared API fixtures, BDD step modules,
+developer and user documentation, and the roadmap checkbox. Full repository
+gates passed, and CodeRabbit review completed with zero findings after
+addressing its test coverage and readability suggestions.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -589,7 +589,7 @@ context.
 Finalize REST API surfaces with consistent contracts and version routing.
 Completion enables stable API consumption by clients.
 
-- [ ] 4.1.1. Introduce `/v1` as the target API prefix.
+- [x] 4.1.1. Introduce `/v1` as the target API prefix.
   - Route TUI-facing and vertical-slice endpoints under `/v1`.
   - Treat existing unversioned routes as pre-v0.1.0 implementation details
     that do not require compatibility preservation.
@@ -633,10 +633,9 @@ full approval, QA, audio, and export surfaces land. See
 design source-to-script vertical slice], and the [TUI API source-to-script
 vertical slice].
 
-[system design source-to-script vertical slice]:
-episodic-podcast-generation-system-design.md#source-to-script-vertical-slice
-[TUI API source-to-script vertical slice]:
-episodic-tui-api-design.md#source-to-script-vertical-slice
+[system design source-to-script vertical slice]: episodic-podcast-generation-system-design.md#source-to-script-vertical-slice
+
+[TUI API source-to-script vertical slice]: episodic-tui-api-design.md#source-to-script-vertical-slice
 
 - [ ] 4.3.1. Implement source and presenter-profile intake for script
   generation.

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -45,10 +45,10 @@ This guide will cover:
   profile. TEI headers automatically capture provenance metadata including
   source priorities, ingestion timestamps, and reviewer identities. Source
   normalisation fan-out now uses metadata-aware asyncio task creation, so
-  custom event-loop task factories can receive operation metadata
-  (`operation_name`, `correlation_id`, `priority_hint`) for diagnostics.
-  Storage identifiers generated during canonical ingestion use time-ordered
-  UUIDv7 values for improved chronological locality.
+  custom event-loop task factories can receive operation metadata (
+  `operation_name`, `correlation_id`, `priority_hint`) for diagnostics. Storage
+  identifiers generated during canonical ingestion use time-ordered UUIDv7
+  values for improved chronological locality.
 - Large canonical TEI XML payloads are compressed with standard-library
   Zstandard in persistence storage while API and domain read paths continue to
   return plain text transparently.
@@ -57,11 +57,11 @@ This guide will cover:
 - Creating and updating episode templates linked to series profiles
 - Retrieving change history for series profiles and episode templates
 - Fetching structured brief payloads for downstream generators through
-  `GET /series-profiles/{profile_id}/brief`
+  `GET /v1/series-profiles/{profile_id}/brief`
 - Managing reusable reference documents (including series-aligned host and
   guest profiles) through pinned revision bindings used by structured briefs
 - Resolving the exact reference bindings for a target episode through
-  `GET /series-profiles/{profile_id}/resolved-bindings`
+  `GET /v1/series-profiles/{profile_id}/resolved-bindings`
 - Rendering deterministic prompt scaffolds from structured briefs for
   downstream Large Language Model (LLM) adapters, including interpolation audit
   metadata and optional escaping policies
@@ -133,7 +133,7 @@ the canonical TEI document is enriched.
 Guest biographies are generated from guest profile reference documents that are
 bound to the series, template, or episode context. The generator resolves the
 same pinned reference revisions exposed by
-`GET /series-profiles/{profile_id}/resolved-bindings`, filters them to
+`GET /v1/series-profiles/{profile_id}/resolved-bindings`, filters them to
 `guest_profile` documents, and asks the configured execution model for a short,
 source-grounded biography for each resolved guest.
 
@@ -167,26 +167,28 @@ metadata.
 Reusable reference-document workflows currently support:
 
 - Creating and listing reusable documents per series profile at
-  `POST /series-profiles/{profile_id}/reference-documents` and
-  `GET /series-profiles/{profile_id}/reference-documents`.
+  `POST /v1/series-profiles/{profile_id}/reference-documents` and
+  `GET /v1/series-profiles/{profile_id}/reference-documents`.
 - Updating reusable documents with optimistic locking using
   `expected_lock_version` at
-  `PATCH /series-profiles/{profile_id}/reference-documents/{document_id}`.
+  `PATCH /v1/series-profiles/{profile_id}/reference-documents/{document_id}`.
   Stale updates return `409 Conflict`.
 - Creating and listing immutable document revisions at
-  `POST /series-profiles/{profile_id}/reference-documents/{document_id}/revisions`
+  `POST /v1/series-profiles/{profile_id}/reference-documents/{document_id}/revisions`
    and
-  `GET /series-profiles/{profile_id}/reference-documents/{document_id}/revisions`.
-- Creating, listing, and fetching target bindings at `POST /reference-bindings`,
-  `GET /reference-bindings`, and `GET /reference-bindings/{binding_id}`.
+  `GET /v1/series-profiles/{profile_id}/reference-documents/{document_id}/revisions`.
+- Creating, listing, and fetching target bindings at
+  `POST /v1/reference-bindings`,
+  `GET /v1/reference-bindings`, and `GET /v1/reference-bindings/{binding_id}`.
 - Series-aligned access behaviour for host and guest profile documents:
   cross-series profile paths do not expose documents owned by another series.
-- Requesting `GET /series-profiles/{profile_id}/brief?episode_id=...` to apply
+- Requesting `GET /v1/series-profiles/{profile_id}/brief?episode_id=...` to
+  apply
   `effective_from_episode_id` precedence for series-level bindings while still
   including any selected template bindings. Add optional `template_id=...` to
   restrict the template section selection to one episode template.
 - Requesting
-  `GET /series-profiles/{profile_id}/resolved-bindings?episode_id=...` to
+  `GET /v1/series-profiles/{profile_id}/resolved-bindings?episode_id=...` to
   inspect the resolved binding, document, and revision payloads for one episode
   context without fetching the full structured brief. Add optional
   `template_id=...` to restrict template-scoped bindings to one episode
@@ -199,6 +201,11 @@ Reusable reference-document workflows currently support:
 
 The canonical-content HTTP service now runs as a Falcon ASGI application under
 Granian.
+
+Client-facing canonical API resources are served under the `/v1` prefix.
+Unversioned canonical resource paths are internal pre-v0.1.0 implementation
+details and should not be used by clients. Health checks stay outside the
+client API prefix because deployment platforms use them as operator endpoints.
 
 Start the service with:
 
@@ -226,16 +233,15 @@ Health endpoints:
 
 ### Logging
 
-`episodic.logging.LogLevel` accepts these string levels: `TRACE`, `DEBUG`,
+`episodic.logging.LogLevel` accepts the configured log levels: `TRACE`, `DEBUG`,
 `INFO`, `WARNING`, `ERROR`, and `CRITICAL`. `WARN` remains available as a
 deprecated alias for `WARNING`.
 
 Use `configure_logging(level, ...)` to configure process logging. The `level`
-argument accepts strings case-insensitively, so `debug`, `Debug`, and `DEBUG`
-all select `LogLevel.DEBUG`. The function returns a `tuple[LogLevel, bool]`:
-the normalized `LogLevel` value and a flag indicating whether the default
-`INFO` level was substituted. Substitution happens when no level is provided or
-when the provided string is not recognized.
+argument is case-insensitive, and the function returns a
+`tuple[LogLevel, bool]`: the normalized `LogLevel` value and a flag indicating
+whether the default (`INFO`) was substituted because the input was absent or
+unrecognized.
 
 ### Worker runtime
 

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -178,15 +178,15 @@ Reusable reference-document workflows currently support:
    and
   `GET /v1/series-profiles/{profile_id}/reference-documents/{document_id}/revisions`.
 - Creating, listing, and fetching target bindings at
-  `POST /v1/reference-bindings`,
-  `GET /v1/reference-bindings`, and `GET /v1/reference-bindings/{binding_id}`.
+  `POST /v1/reference-bindings`, `GET /v1/reference-bindings`, and
+  `GET /v1/reference-bindings/{binding_id}`.
 - Series-aligned access behaviour for host and guest profile documents:
   cross-series profile paths do not expose documents owned by another series.
 - Requesting `GET /v1/series-profiles/{profile_id}/brief?episode_id=...` to
-  apply
-  `effective_from_episode_id` precedence for series-level bindings while still
-  including any selected template bindings. Add optional `template_id=...` to
-  restrict the template section selection to one episode template.
+  apply `effective_from_episode_id` precedence for series-level bindings while
+  still including any selected template bindings. Add optional
+  `template_id=...` to restrict the template section selection to one episode
+  template.
 - Requesting
   `GET /v1/series-profiles/{profile_id}/resolved-bindings?episode_id=...` to
   inspect the resolved binding, document, and revision payloads for one episode

--- a/episodic/api/app.py
+++ b/episodic/api/app.py
@@ -76,50 +76,52 @@ def create_app(dependencies: ApiDependencies) -> asgi.App:
         HealthReadyResource(dependencies.readiness_probes),
     )
 
-    app.add_route("/series-profiles", SeriesProfilesResource(uow_factory))
-    app.add_route("/series-profiles/{profile_id}", SeriesProfileResource(uow_factory))
+    app.add_route("/v1/series-profiles", SeriesProfilesResource(uow_factory))
     app.add_route(
-        "/series-profiles/{profile_id}/history",
+        "/v1/series-profiles/{profile_id}", SeriesProfileResource(uow_factory)
+    )
+    app.add_route(
+        "/v1/series-profiles/{profile_id}/history",
         SeriesProfileHistoryResource(uow_factory),
     )
     app.add_route(
-        "/series-profiles/{profile_id}/brief",
+        "/v1/series-profiles/{profile_id}/brief",
         SeriesProfileBriefResource(uow_factory),
     )
     app.add_route(
-        "/series-profiles/{profile_id}/resolved-bindings",
+        "/v1/series-profiles/{profile_id}/resolved-bindings",
         ResolvedBindingsResource(uow_factory),
     )
 
-    app.add_route("/episode-templates", EpisodeTemplatesResource(uow_factory))
+    app.add_route("/v1/episode-templates", EpisodeTemplatesResource(uow_factory))
     app.add_route(
-        "/episode-templates/{template_id}",
+        "/v1/episode-templates/{template_id}",
         EpisodeTemplateResource(uow_factory),
     )
     app.add_route(
-        "/episode-templates/{template_id}/history",
+        "/v1/episode-templates/{template_id}/history",
         EpisodeTemplateHistoryResource(uow_factory),
     )
 
     app.add_route(
-        "/series-profiles/{profile_id}/reference-documents",
+        "/v1/series-profiles/{profile_id}/reference-documents",
         ReferenceDocumentsResource(uow_factory),
     )
     app.add_route(
-        "/series-profiles/{profile_id}/reference-documents/{document_id}",
+        "/v1/series-profiles/{profile_id}/reference-documents/{document_id}",
         ReferenceDocumentResource(uow_factory),
     )
     app.add_route(
-        "/series-profiles/{profile_id}/reference-documents/{document_id}/revisions",
+        "/v1/series-profiles/{profile_id}/reference-documents/{document_id}/revisions",
         ReferenceDocumentRevisionsResource(uow_factory),
     )
     app.add_route(
-        "/reference-document-revisions/{revision_id}",
+        "/v1/reference-document-revisions/{revision_id}",
         ReferenceDocumentRevisionResource(uow_factory),
     )
-    app.add_route("/reference-bindings", ReferenceBindingsResource(uow_factory))
+    app.add_route("/v1/reference-bindings", ReferenceBindingsResource(uow_factory))
     app.add_route(
-        "/reference-bindings/{binding_id}",
+        "/v1/reference-bindings/{binding_id}",
         ReferenceBindingResource(uow_factory),
     )
 

--- a/episodic/api/resources/episode_templates.py
+++ b/episodic/api/resources/episode_templates.py
@@ -8,7 +8,7 @@ behaviour from the API resource base layer.
 Examples
 --------
 >>> from episodic.api.resources.episode_templates import EpisodeTemplatesResource
->>> app.add_route("/episode-templates", EpisodeTemplatesResource(uow_factory))
+>>> app.add_route("/v1/episode-templates", EpisodeTemplatesResource(uow_factory))
 """
 
 import typing as typ

--- a/episodic/api/resources/series_profiles.py
+++ b/episodic/api/resources/series_profiles.py
@@ -7,7 +7,7 @@ when wiring Falcon routes to canonical series-profile services.
 Examples
 --------
 >>> from episodic.api.resources.series_profiles import SeriesProfilesResource
->>> app.add_route("/series-profiles", SeriesProfilesResource(uow_factory))
+>>> app.add_route("/v1/series-profiles", SeriesProfilesResource(uow_factory))
 """
 
 import typing as typ

--- a/tests/api_fixtures.py
+++ b/tests/api_fixtures.py
@@ -84,19 +84,19 @@ def build_api_fixture(client: testing.TestClient) -> ApiFixture:
     """Build common API fixture entities for reference-document endpoint tests."""
     primary_profile_id = post_and_return_id(
         client,
-        "/series-profiles",
+        "/v1/series-profiles",
         profile_body("api-reference-primary"),
         assertion_message="Expected profile creation to return 201.",
     )
     secondary_profile_id = post_and_return_id(
         client,
-        "/series-profiles",
+        "/v1/series-profiles",
         profile_body("api-reference-secondary"),
         assertion_message="Expected profile creation to return 201.",
     )
     template_id = post_and_return_id(
         client,
-        "/episode-templates",
+        "/v1/episode-templates",
         {
             "series_profile_id": primary_profile_id,
             "slug": "api-reference-template",
@@ -110,7 +110,7 @@ def build_api_fixture(client: testing.TestClient) -> ApiFixture:
     )
     secondary_template_id = post_and_return_id(
         client,
-        "/episode-templates",
+        "/v1/episode-templates",
         {
             "series_profile_id": secondary_profile_id,
             "slug": "api-reference-secondary-template",
@@ -139,7 +139,7 @@ def create_reference_document(
 ) -> str:
     """Create one reusable reference document and return its identifier."""
     response = client.simulate_post(
-        f"/series-profiles/{profile_id}/reference-documents",
+        f"/v1/series-profiles/{profile_id}/reference-documents",
         json={
             "kind": kind,
             "lifecycle_state": "active",
@@ -169,7 +169,7 @@ def assert_reference_document_list(
         params["kind"] = kind
 
     response = client.simulate_get(
-        f"/series-profiles/{profile_id}/reference-documents",
+        f"/v1/series-profiles/{profile_id}/reference-documents",
         params=params,
     )
     _assert_status(
@@ -200,7 +200,7 @@ def create_reference_document_revision(
 ) -> str:
     """Create one immutable reference-document revision and return its id."""
     response = client.simulate_post(
-        f"/series-profiles/{profile_id}/reference-documents/{document_id}/revisions",
+        f"/v1/series-profiles/{profile_id}/reference-documents/{document_id}/revisions",
         json={
             "content": {"summary": revision.summary},
             "content_hash": revision.content_hash,
@@ -226,7 +226,7 @@ def assert_reference_revision_history(
 ) -> list[dict[str, object]]:
     """List immutable revisions and assert a valid list envelope."""
     response = client.simulate_get(
-        f"/series-profiles/{profile_id}/reference-documents/{document_id}/revisions",
+        f"/v1/series-profiles/{profile_id}/reference-documents/{document_id}/revisions",
         params={"limit": "10", "offset": "0"},
     )
     _assert_status(
@@ -254,7 +254,7 @@ def create_reference_binding(
 ) -> str:
     """Create one reference binding and return its identifier."""
     response = client.simulate_post(
-        "/reference-bindings",
+        "/v1/reference-bindings",
         json={
             "reference_document_revision_id": revision_id,
             "target_kind": "episode_template",

--- a/tests/steps/test_binding_resolution_steps.py
+++ b/tests/steps/test_binding_resolution_steps.py
@@ -170,7 +170,7 @@ def create_binding_resolution_bindings(
         (context["late_revision_id"], context["late_episode_id"]),
     ):
         response = canonical_api_client.simulate_post(
-            "/reference-bindings",
+            "/v1/reference-bindings",
             json={
                 "reference_document_revision_id": revision_id,
                 "target_kind": "series_profile",
@@ -223,7 +223,7 @@ def request_early_episode_brief(
     """Request the structured brief using the early-episode context."""
     payload = _simulate_get_ok(
         canonical_api_client,
-        f"/series-profiles/{context['profile_id']}/brief",
+        f"/v1/series-profiles/{context['profile_id']}/brief",
         {
             "template_id": context["template_id"],
             "episode_id": context["early_episode_id"],
@@ -245,7 +245,7 @@ def request_late_episode_resolution(
     """Request the resolved-bindings endpoint using the late-episode context."""
     payload = _simulate_get_ok(
         canonical_api_client,
-        f"/series-profiles/{context['profile_id']}/resolved-bindings",
+        f"/v1/series-profiles/{context['profile_id']}/resolved-bindings",
         {
             "template_id": context["template_id"],
             "episode_id": context["late_episode_id"],

--- a/tests/steps/test_profile_template_api_steps.py
+++ b/tests/steps/test_profile_template_api_steps.py
@@ -130,7 +130,7 @@ def create_profile(
     _create_entity_and_store_id(
         canonical_api_client,
         EntityCreationSpec(
-            path="/series-profiles",
+            path="/v1/series-profiles",
             payload={
                 "slug": "bdd-profile",
                 "title": "BDD Profile",
@@ -154,7 +154,7 @@ def create_template(
     _create_entity_and_store_id(
         canonical_api_client,
         EntityCreationSpec(
-            path="/episode-templates",
+            path="/v1/episode-templates",
             payload={
                 "series_profile_id": context["profile_id"],
                 "slug": "bdd-template",
@@ -178,7 +178,7 @@ def update_profile(
     """Update profile using expected revision."""
     _update_entity_and_assert_revision(
         canonical_api_client,
-        f"/series-profiles/{context['profile_id']}",
+        f"/v1/series-profiles/{context['profile_id']}",
         {
             "expected_revision": 1,
             "title": "BDD Profile Updated",
@@ -201,7 +201,7 @@ def assert_history(
         canonical_api_client,
         HttpRequest(
             method="GET",
-            path=f"/series-profiles/{context['profile_id']}/history",
+            path=f"/v1/series-profiles/{context['profile_id']}/history",
         ),
         200,
     )
@@ -219,7 +219,7 @@ def assert_brief(
         canonical_api_client,
         HttpRequest(
             method="GET",
-            path=f"/series-profiles/{context['profile_id']}/brief",
+            path=f"/v1/series-profiles/{context['profile_id']}/brief",
             params={"template_id": context["template_id"]},
         ),
         200,

--- a/tests/steps/test_reference_document_api_steps.py
+++ b/tests/steps/test_reference_document_api_steps.py
@@ -33,7 +33,7 @@ def test_reference_document_api_behaviour() -> None:
 def _create_profile(client: testing.TestClient, slug: str) -> str:
     """Create one series profile and return its identifier."""
     response = client.simulate_post(
-        "/series-profiles",
+        "/v1/series-profiles",
         json={
             "slug": slug,
             "title": f"{slug} title",
@@ -58,7 +58,7 @@ def reference_fixtures(
         "bdd-reference-secondary",
     )
     template_response = canonical_api_client.simulate_post(
-        "/episode-templates",
+        "/v1/episode-templates",
         json={
             "series_profile_id": primary_profile_id,
             "slug": "bdd-reference-template",
@@ -87,7 +87,7 @@ def create_host_document(
 ) -> None:
     """Create one host reference document for the primary profile."""
     response = canonical_api_client.simulate_post(
-        f"/series-profiles/{context['primary_profile_id']}/reference-documents",
+        f"/v1/series-profiles/{context['primary_profile_id']}/reference-documents",
         json={
             "kind": "host_profile",
             "lifecycle_state": "active",
@@ -107,7 +107,7 @@ def update_host_document(
 ) -> None:
     """Update the host reference document with lock precondition."""
     response = canonical_api_client.simulate_patch(
-        f"/series-profiles/{context['primary_profile_id']}/reference-documents/"
+        f"/v1/series-profiles/{context['primary_profile_id']}/reference-documents/"
         f"{context['document_id']}",
         json={
             "expected_lock_version": 1,
@@ -127,7 +127,7 @@ def add_revisions(
     """Create two immutable revisions for the host reference document."""
     first = canonical_api_client.simulate_post(
         (
-            f"/series-profiles/{context['primary_profile_id']}/reference-documents/"
+            f"/v1/series-profiles/{context['primary_profile_id']}/reference-documents/"
             f"{context['document_id']}/revisions"
         ),
         json={
@@ -144,7 +144,7 @@ def add_revisions(
 
     second = canonical_api_client.simulate_post(
         (
-            f"/series-profiles/{context['primary_profile_id']}/reference-documents/"
+            f"/v1/series-profiles/{context['primary_profile_id']}/reference-documents/"
             f"{context['document_id']}/revisions"
         ),
         json={
@@ -167,7 +167,7 @@ def bind_revision(
 ) -> None:
     """Bind the latest revision to the prepared episode template."""
     response = canonical_api_client.simulate_post(
-        "/reference-bindings",
+        "/v1/reference-bindings",
         json={
             "reference_document_revision_id": context["second_revision_id"],
             "target_kind": "episode_template",
@@ -188,7 +188,7 @@ def assert_history(
     """Ensure revision history endpoint returns both revisions in order."""
     response = canonical_api_client.simulate_get(
         (
-            f"/series-profiles/{context['primary_profile_id']}/reference-documents/"
+            f"/v1/series-profiles/{context['primary_profile_id']}/reference-documents/"
             f"{context['document_id']}/revisions"
         ),
         params={"limit": "10", "offset": "0"},
@@ -210,7 +210,7 @@ def assert_stale_rejected(
     """Ensure stale optimistic-lock updates return conflict."""
     response = canonical_api_client.simulate_patch(
         (
-            f"/series-profiles/{context['primary_profile_id']}/reference-documents/"
+            f"/v1/series-profiles/{context['primary_profile_id']}/reference-documents/"
             f"{context['document_id']}"
         ),
         json={
@@ -229,7 +229,7 @@ def assert_series_alignment(
 ) -> None:
     """Ensure host/guest filtering and cross-series guard behaviour."""
     guest_document_response = canonical_api_client.simulate_post(
-        f"/series-profiles/{context['primary_profile_id']}/reference-documents",
+        f"/v1/series-profiles/{context['primary_profile_id']}/reference-documents",
         json={
             "kind": "guest_profile",
             "lifecycle_state": "active",
@@ -239,7 +239,7 @@ def assert_series_alignment(
     assert guest_document_response.status_code == 201
 
     host_list = canonical_api_client.simulate_get(
-        f"/series-profiles/{context['primary_profile_id']}/reference-documents",
+        f"/v1/series-profiles/{context['primary_profile_id']}/reference-documents",
         params={"kind": "host_profile", "limit": "10", "offset": "0"},
     )
     assert host_list.status_code == 200
@@ -250,7 +250,7 @@ def assert_series_alignment(
     assert len(host_items) == 1
 
     guest_list = canonical_api_client.simulate_get(
-        f"/series-profiles/{context['primary_profile_id']}/reference-documents",
+        f"/v1/series-profiles/{context['primary_profile_id']}/reference-documents",
         params={"kind": "guest_profile", "limit": "10", "offset": "0"},
     )
     assert guest_list.status_code == 200
@@ -261,7 +261,7 @@ def assert_series_alignment(
     assert len(guest_items) == 1
 
     cross_series = canonical_api_client.simulate_get(
-        f"/series-profiles/{context['secondary_profile_id']}/reference-documents/"
+        f"/v1/series-profiles/{context['secondary_profile_id']}/reference-documents/"
         f"{context['document_id']}"
     )
     assert cross_series.status_code == 404

--- a/tests/steps/test_reference_document_model_steps.py
+++ b/tests/steps/test_reference_document_model_steps.py
@@ -65,7 +65,7 @@ def create_profile_and_template(
 ) -> None:
     """Create profile/template entities used for binding checks."""
     profile_response = canonical_api_client.simulate_post(
-        "/series-profiles",
+        "/v1/series-profiles",
         json={
             "slug": "bdd-ref-profile",
             "title": "BDD Reference Profile",
@@ -79,7 +79,7 @@ def create_profile_and_template(
     profile_id = typ.cast("str", profile_response.json["id"])
 
     template_response = canonical_api_client.simulate_post(
-        "/episode-templates",
+        "/v1/episode-templates",
         json={
             "series_profile_id": profile_id,
             "slug": "bdd-ref-template",
@@ -217,7 +217,7 @@ def retrieve_brief(
 ) -> None:
     """Retrieve structured brief payload via API."""
     response = canonical_api_client.simulate_get(
-        f"/series-profiles/{context['profile_id']}/brief",
+        f"/v1/series-profiles/{context['profile_id']}/brief",
         params={"template_id": context["template_id"]},
     )
     assert response.status_code == 200

--- a/tests/test_api_route_versioning.py
+++ b/tests/test_api_route_versioning.py
@@ -18,6 +18,8 @@ import pytest
 if typ.TYPE_CHECKING:
     from falcon import testing
 
+_NOT_FOUND_PAYLOAD = {"title": "404 Not Found"}
+
 _CANONICAL_ROUTE_CONTRACT_PATHS = (
     ("/series-profiles", "series-profiles"),
     ("/series-profiles/not-a-valid-uuid", "series-profile"),
@@ -66,6 +68,9 @@ def test_versioned_canonical_api_routes_are_registered(
         assert response.status_code != 404, (
             f"Expected registered /v1 route for {case_id}, got 404."
         )
+        assert response.json != _NOT_FOUND_PAYLOAD, (
+            f"Expected {case_id} to bypass Falcon's not-found responder."
+        )
 
 
 def test_unversioned_canonical_api_routes_are_not_registered(
@@ -77,6 +82,9 @@ def test_unversioned_canonical_api_routes_are_not_registered(
 
         assert response.status_code == 404, (
             f"Expected 404 for unversioned {case_id}, got {response.status_code}."
+        )
+        assert response.json == _NOT_FOUND_PAYLOAD, (
+            f"Expected Falcon not-found payload for unversioned {case_id}."
         )
 
 
@@ -91,6 +99,9 @@ def test_versioned_health_routes_are_not_registered(
     assert response.status_code == 404, (
         f"Expected 404 for {path}, got {response.status_code}."
     )
+    assert response.json == _NOT_FOUND_PAYLOAD, (
+        f"Expected Falcon not-found payload for {path}."
+    )
 
 
 @pytest.mark.parametrize("path", ["/series-profiles", "/episode-templates"])
@@ -104,6 +115,9 @@ def test_unversioned_canonical_write_routes_are_not_registered(
     assert response.status_code == 404, (
         f"Expected 404 for unversioned POST {path}, got {response.status_code}."
     )
+    assert response.json == _NOT_FOUND_PAYLOAD, (
+        f"Expected Falcon not-found payload for unversioned POST {path}."
+    )
 
 
 @pytest.mark.parametrize("path", ["/health/live", "/health/ready"])
@@ -116,4 +130,10 @@ def test_unversioned_health_routes_remain_registered(
 
     assert response.status_code == 200, (
         f"Expected 200 for {path}, got {response.status_code}."
+    )
+    assert response.json["status"] == "ok", (
+        f"Expected healthy status payload for {path}, got {response.json}."
+    )
+    assert isinstance(response.json["checks"], list), (
+        f"Expected health checks list for {path}, got {response.json}."
     )

--- a/tests/test_api_route_versioning.py
+++ b/tests/test_api_route_versioning.py
@@ -1,0 +1,125 @@
+"""Route-versioning contract tests for the Falcon canonical API.
+
+These tests implement the roadmap 4.1.1 route-versioning strategy. Canonical
+client resources such as series profiles, episode templates, reference
+documents, reference-document revisions, and reference bindings must be
+registered under `/v1`. Unversioned canonical resource paths must return
+`404`, proving they are not compatibility aliases.
+
+Health endpoints are operator endpoints rather than client API resources.
+`/health/live` and `/health/ready` must stay registered at root paths, while
+`/v1/health/live` remains unregistered.
+"""
+
+import typing as typ
+
+import pytest
+
+if typ.TYPE_CHECKING:
+    from falcon import testing
+
+_CANONICAL_ROUTES = (
+    ("/series-profiles", 200, "series-profiles"),
+    ("/series-profiles/not-a-valid-uuid", 400, "series-profile"),
+    ("/series-profiles/not-a-valid-uuid/history", 400, "series-profile-history"),
+    ("/series-profiles/not-a-valid-uuid/brief", 400, "series-profile-brief"),
+    (
+        "/series-profiles/not-a-valid-uuid/resolved-bindings",
+        400,
+        "resolved-bindings",
+    ),
+    ("/episode-templates", 200, "episode-templates"),
+    ("/episode-templates/not-a-valid-uuid", 400, "episode-template"),
+    (
+        "/episode-templates/not-a-valid-uuid/history",
+        400,
+        "episode-template-history",
+    ),
+    (
+        "/series-profiles/not-a-valid-uuid/reference-documents",
+        400,
+        "reference-documents",
+    ),
+    (
+        "/series-profiles/not-a-valid-uuid/reference-documents/not-a-valid-uuid",
+        400,
+        "reference-document",
+    ),
+    (
+        (
+            "/series-profiles/not-a-valid-uuid/reference-documents/"
+            "not-a-valid-uuid/revisions"
+        ),
+        400,
+        "reference-document-revisions",
+    ),
+    (
+        "/reference-document-revisions/not-a-valid-uuid",
+        400,
+        "reference-document-revision",
+    ),
+    # Expects 400: listing reference bindings requires target_kind and target_id.
+    ("/reference-bindings", 400, "reference-bindings"),
+    ("/reference-bindings/not-a-valid-uuid", 400, "reference-binding"),
+)
+
+_UNVERSIONED_CANONICAL_PATHS = tuple(
+    pytest.param(path, id=case_id)
+    for path, _expected_status, case_id in _CANONICAL_ROUTES
+)
+
+_VERSIONED_CANONICAL_PATHS = tuple(
+    pytest.param(f"/v1{path}", expected_status, id=case_id)
+    for path, expected_status, case_id in _CANONICAL_ROUTES
+)
+
+
+@pytest.mark.parametrize(("path", "expected_status"), _VERSIONED_CANONICAL_PATHS)
+def test_versioned_canonical_api_routes_are_registered(
+    canonical_api_client: testing.TestClient,
+    path: str,
+    expected_status: int,
+) -> None:
+    """Route canonical API requests through `/v1` to their resource handlers."""
+    response = canonical_api_client.simulate_get(path)
+
+    assert response.status_code == expected_status, (
+        f"Expected {expected_status} for {path}, got {response.status_code}."
+    )
+
+
+@pytest.mark.parametrize("path", _UNVERSIONED_CANONICAL_PATHS)
+def test_unversioned_canonical_api_routes_are_not_registered(
+    canonical_api_client: testing.TestClient,
+    path: str,
+) -> None:
+    """Keep pre-v0.1.0 canonical API routes unavailable without `/v1`."""
+    response = canonical_api_client.simulate_get(path)
+
+    assert response.status_code == 404, (
+        f"Expected 404 for unversioned {path}, got {response.status_code}."
+    )
+
+
+def test_versioned_health_route_is_not_registered(
+    canonical_api_client: testing.TestClient,
+) -> None:
+    """Keep operator health endpoints outside the client-facing API prefix."""
+    response = canonical_api_client.simulate_get("/v1/health/live")
+
+    assert response.status_code == 404, (
+        f"Expected 404 for /v1/health/live, got {response.status_code}."
+    )
+
+
+@pytest.mark.parametrize("path", ["/health/live", "/health/ready"])
+def test_unversioned_health_routes_remain_registered(
+    canonical_api_client: testing.TestClient,
+    path: str,
+) -> None:
+    """Keep liveness and readiness endpoints available at root paths."""
+    response = canonical_api_client.simulate_get(path)
+
+    assert response.status_code == 200, (
+        f"Expected 200 for {path}, got {response.status_code}."
+    )

--- a/tests/test_api_route_versioning.py
+++ b/tests/test_api_route_versioning.py
@@ -3,12 +3,12 @@
 These tests implement the roadmap 4.1.1 route-versioning strategy. Canonical
 client resources such as series profiles, episode templates, reference
 documents, reference-document revisions, and reference bindings must be
-registered under `/v1`. Unversioned canonical resource paths must return
-`404`, proving they are not compatibility aliases.
+registered under `/v1`. Representative unversioned canonical resource paths
+must return `404`, proving they are not compatibility aliases.
 
 Health endpoints are operator endpoints rather than client API resources.
 `/health/live` and `/health/ready` must stay registered at root paths, while
-`/v1/health/live` remains unregistered.
+`/v1/health/live` and `/v1/health/ready` remain unregistered.
 """
 
 import typing as typ
@@ -18,97 +18,91 @@ import pytest
 if typ.TYPE_CHECKING:
     from falcon import testing
 
-_CANONICAL_ROUTES = (
-    ("/series-profiles", 200, "series-profiles"),
-    ("/series-profiles/not-a-valid-uuid", 400, "series-profile"),
-    ("/series-profiles/not-a-valid-uuid/history", 400, "series-profile-history"),
-    ("/series-profiles/not-a-valid-uuid/brief", 400, "series-profile-brief"),
+_CANONICAL_ROUTE_CONTRACT_PATHS = (
+    ("/series-profiles", "series-profiles"),
+    ("/series-profiles/not-a-valid-uuid", "series-profile"),
+    ("/series-profiles/not-a-valid-uuid/brief", "series-profile-brief"),
     (
         "/series-profiles/not-a-valid-uuid/resolved-bindings",
-        400,
         "resolved-bindings",
     ),
-    ("/episode-templates", 200, "episode-templates"),
-    ("/episode-templates/not-a-valid-uuid", 400, "episode-template"),
-    (
-        "/episode-templates/not-a-valid-uuid/history",
-        400,
-        "episode-template-history",
-    ),
+    ("/episode-templates", "episode-templates"),
+    ("/episode-templates/not-a-valid-uuid", "episode-template"),
     (
         "/series-profiles/not-a-valid-uuid/reference-documents",
-        400,
         "reference-documents",
-    ),
-    (
-        "/series-profiles/not-a-valid-uuid/reference-documents/not-a-valid-uuid",
-        400,
-        "reference-document",
     ),
     (
         (
             "/series-profiles/not-a-valid-uuid/reference-documents/"
             "not-a-valid-uuid/revisions"
         ),
-        400,
         "reference-document-revisions",
     ),
     (
         "/reference-document-revisions/not-a-valid-uuid",
-        400,
         "reference-document-revision",
     ),
-    # Expects 400: listing reference bindings requires target_kind and target_id.
-    ("/reference-bindings", 400, "reference-bindings"),
-    ("/reference-bindings/not-a-valid-uuid", 400, "reference-binding"),
+    ("/reference-bindings", "reference-bindings"),
+    ("/reference-bindings/not-a-valid-uuid", "reference-binding"),
 )
 
 _UNVERSIONED_CANONICAL_PATHS = tuple(
-    pytest.param(path, id=case_id)
-    for path, _expected_status, case_id in _CANONICAL_ROUTES
+    (path, case_id) for path, case_id in _CANONICAL_ROUTE_CONTRACT_PATHS
 )
 
 _VERSIONED_CANONICAL_PATHS = tuple(
-    pytest.param(f"/v1{path}", expected_status, id=case_id)
-    for path, expected_status, case_id in _CANONICAL_ROUTES
+    (f"/v1{path}", case_id) for path, case_id in _CANONICAL_ROUTE_CONTRACT_PATHS
 )
 
 
-@pytest.mark.parametrize(("path", "expected_status"), _VERSIONED_CANONICAL_PATHS)
 def test_versioned_canonical_api_routes_are_registered(
     canonical_api_client: testing.TestClient,
-    path: str,
-    expected_status: int,
 ) -> None:
     """Route canonical API requests through `/v1` to their resource handlers."""
-    response = canonical_api_client.simulate_get(path)
+    for path, case_id in _VERSIONED_CANONICAL_PATHS:
+        response = canonical_api_client.simulate_get(path)
 
-    assert response.status_code == expected_status, (
-        f"Expected {expected_status} for {path}, got {response.status_code}."
-    )
+        assert response.status_code != 404, (
+            f"Expected registered /v1 route for {case_id}, got 404."
+        )
 
 
-@pytest.mark.parametrize("path", _UNVERSIONED_CANONICAL_PATHS)
 def test_unversioned_canonical_api_routes_are_not_registered(
+    canonical_api_client: testing.TestClient,
+) -> None:
+    """Keep pre-v0.1.0 canonical API routes unavailable without `/v1`."""
+    for path, case_id in _UNVERSIONED_CANONICAL_PATHS:
+        response = canonical_api_client.simulate_get(path)
+
+        assert response.status_code == 404, (
+            f"Expected 404 for unversioned {case_id}, got {response.status_code}."
+        )
+
+
+@pytest.mark.parametrize("path", ["/v1/health/live", "/v1/health/ready"])
+def test_versioned_health_routes_are_not_registered(
     canonical_api_client: testing.TestClient,
     path: str,
 ) -> None:
-    """Keep pre-v0.1.0 canonical API routes unavailable without `/v1`."""
+    """Keep operator health endpoints outside the client-facing API prefix."""
     response = canonical_api_client.simulate_get(path)
 
     assert response.status_code == 404, (
-        f"Expected 404 for unversioned {path}, got {response.status_code}."
+        f"Expected 404 for {path}, got {response.status_code}."
     )
 
 
-def test_versioned_health_route_is_not_registered(
+@pytest.mark.parametrize("path", ["/series-profiles", "/episode-templates"])
+def test_unversioned_canonical_write_routes_are_not_registered(
     canonical_api_client: testing.TestClient,
+    path: str,
 ) -> None:
-    """Keep operator health endpoints outside the client-facing API prefix."""
-    response = canonical_api_client.simulate_get("/v1/health/live")
+    """Keep unversioned canonical write routes unavailable without `/v1`."""
+    response = canonical_api_client.simulate_post(path, json={})
 
     assert response.status_code == 404, (
-        f"Expected 404 for /v1/health/live, got {response.status_code}."
+        f"Expected 404 for unversioned POST {path}, got {response.status_code}."
     )
 
 

--- a/tests/test_binding_resolution_api.py
+++ b/tests/test_binding_resolution_api.py
@@ -67,7 +67,7 @@ def test_resolved_bindings_endpoint_returns_resolved_payloads(
     )
 
     response = canonical_api_client.simulate_get(
-        f"/series-profiles/{fixture.primary_profile_id}/resolved-bindings",
+        f"/v1/series-profiles/{fixture.primary_profile_id}/resolved-bindings",
         params={"episode_id": episode_id, "template_id": fixture.template_id},
     )
 
@@ -110,7 +110,7 @@ def test_resolved_bindings_endpoint_rejects_bad_episode_id(
     """Resolved-bindings endpoint should reject malformed or absent episode_id."""
     fixture = reference_support.build_api_fixture(canonical_api_client)
     response = canonical_api_client.simulate_get(
-        f"/series-profiles/{fixture.primary_profile_id}/resolved-bindings",
+        f"/v1/series-profiles/{fixture.primary_profile_id}/resolved-bindings",
         params=params,
     )
     assert response.status_code == 400
@@ -125,7 +125,7 @@ def test_resolved_bindings_endpoint_returns_404_for_unknown_profile(
     unknown_profile_id = str(uuid.uuid4())
     episode_id = str(uuid.uuid4())
     response = canonical_api_client.simulate_get(
-        f"/series-profiles/{unknown_profile_id}/resolved-bindings",
+        f"/v1/series-profiles/{unknown_profile_id}/resolved-bindings",
         params={"episode_id": episode_id},
     )
     assert response.status_code == 404, "Expected 404 for unknown series profile."
@@ -153,7 +153,7 @@ def test_endpoint_returns_404_for_episode_not_in_profile(
         )
     )
     response = canonical_api_client.simulate_get(
-        f"/series-profiles/{fixture.primary_profile_id}/{endpoint}",
+        f"/v1/series-profiles/{fixture.primary_profile_id}/{endpoint}",
         params={"episode_id": episode_id},
     )
     assert response.status_code == 404, (
@@ -188,7 +188,7 @@ def test_resolved_bindings_endpoint_returns_404_for_invalid_template(
         else str(uuid.uuid4())
     )
     response = canonical_api_client.simulate_get(
-        f"/series-profiles/{fixture.primary_profile_id}/resolved-bindings",
+        f"/v1/series-profiles/{fixture.primary_profile_id}/resolved-bindings",
         params={"episode_id": episode_id, "template_id": template_id},
     )
     assert response.status_code == 404, (

--- a/tests/test_binding_resolution_brief_endpoint.py
+++ b/tests/test_binding_resolution_brief_endpoint.py
@@ -47,7 +47,7 @@ def test_brief_endpoint_returns_404_for_invalid_episode(
     fixture = reference_support.build_api_fixture(canonical_api_client)
     nonexistent_episode_id = str(uuid.uuid4())
     response = canonical_api_client.simulate_get(
-        f"/series-profiles/{fixture.primary_profile_id}/brief",
+        f"/v1/series-profiles/{fixture.primary_profile_id}/brief",
         params={"episode_id": nonexistent_episode_id},
     )
     assert response.status_code == 404, "Expected 404 when episode_id does not exist."

--- a/tests/test_binding_resolution_support.py
+++ b/tests/test_binding_resolution_support.py
@@ -62,7 +62,7 @@ def create_series_binding(
 ) -> str:
     """Create a series-profile binding through the API."""
     response = client.simulate_post(
-        "/reference-bindings",
+        "/v1/reference-bindings",
         json={
             "reference_document_revision_id": revision_id,
             "target_kind": "series_profile",
@@ -264,7 +264,7 @@ def assert_brief_response(
 ) -> None:
     """Assert that one brief response contains the expected revision ids."""
     response = client.simulate_get(
-        f"/series-profiles/{request.profile_id}/brief",
+        f"/v1/series-profiles/{request.profile_id}/brief",
         params={
             "template_id": request.template_id,
             "episode_id": request.episode_id,

--- a/tests/test_lifespan_hooks.py
+++ b/tests/test_lifespan_hooks.py
@@ -49,7 +49,7 @@ async def test_create_app_keeps_existing_canonical_routes_working(
     canonical_api_async_client: httpx.AsyncClient,
 ) -> None:
     """Keep the canonical-content routes available through the new seam."""
-    response = await canonical_api_async_client.get("/series-profiles")
+    response = await canonical_api_async_client.get("/v1/series-profiles")
 
     assert response.status_code == 200
     assert response.json() == {"items": []}

--- a/tests/test_profile_template_api.py
+++ b/tests/test_profile_template_api.py
@@ -23,7 +23,7 @@ def _create_profile(
 ) -> tuple[str, dict[str, typ.Any]]:
     """Create a series profile and return its identifier and payload."""
     create_profile_response = client.simulate_post(
-        "/series-profiles",
+        "/v1/series-profiles",
         json={
             "slug": slug,
             "title": "API Profile",
@@ -53,7 +53,7 @@ def _create_template(
 ) -> tuple[str, dict[str, typ.Any]]:
     """Create an episode template and return its identifier and payload."""
     create_template_response = client.simulate_post(
-        "/episode-templates",
+        "/v1/episode-templates",
         json={
             "series_profile_id": profile_id,
             "slug": "api-template",
@@ -140,7 +140,7 @@ def _update_profile(client: testing.TestClient, profile_id: str) -> None:
     _update_entity_and_verify_revision(
         client,
         EntityUpdateSpec(
-            endpoint_path=f"/series-profiles/{profile_id}",
+            endpoint_path=f"/v1/series-profiles/{profile_id}",
             payload={
                 "expected_revision": 1,
                 "title": "API Profile Updated",
@@ -160,7 +160,7 @@ def _update_template(client: testing.TestClient, template_id: str) -> None:
     _update_entity_and_verify_revision(
         client,
         EntityUpdateSpec(
-            endpoint_path=f"/episode-templates/{template_id}",
+            endpoint_path=f"/v1/episode-templates/{template_id}",
             payload={
                 "expected_revision": 1,
                 "title": "API Template Updated",
@@ -183,7 +183,7 @@ def _verify_stale_update_rejected(
     _verify_stale_update_rejected_generic(
         client,
         EntityUpdateSpec(
-            endpoint_path=f"/series-profiles/{profile_id}",
+            endpoint_path=f"/v1/series-profiles/{profile_id}",
             payload={
                 "expected_revision": 1,
                 "title": "Stale update",
@@ -206,7 +206,7 @@ def _verify_episode_template_stale_update_rejected(
     _verify_stale_update_rejected_generic(
         client,
         EntityUpdateSpec(
-            endpoint_path=f"/episode-templates/{template_id}",
+            endpoint_path=f"/v1/episode-templates/{template_id}",
             payload={
                 "expected_revision": 1,
                 "title": "Stale template update",
@@ -225,7 +225,7 @@ def _verify_profile_history(client: testing.TestClient, profile_id: str) -> None
     """Verify profile history includes both create and update revisions."""
     _verify_entity_history(
         client,
-        f"/series-profiles/{profile_id}/history",
+        f"/v1/series-profiles/{profile_id}/history",
         "profile",
     )
 
@@ -237,7 +237,7 @@ def _verify_episode_template_history(
     """Verify template history includes both create and update revisions."""
     _verify_entity_history(
         client,
-        f"/episode-templates/{template_id}/history",
+        f"/v1/episode-templates/{template_id}/history",
         "episode-template",
     )
 
@@ -249,7 +249,7 @@ def _verify_structured_brief(
 ) -> None:
     """Verify structured brief returns the expected profile and template."""
     brief_response = client.simulate_get(
-        f"/series-profiles/{profile_id}/brief",
+        f"/v1/series-profiles/{profile_id}/brief",
         params={"template_id": template_id},
     )
     assert brief_response.status_code == 200, (
@@ -303,7 +303,7 @@ def test_get_structured_brief_template_not_in_profile(
     )
 
     response = canonical_api_client.simulate_get(
-        f"/series-profiles/{profile_id_2}/brief",
+        f"/v1/series-profiles/{profile_id_2}/brief",
         params={"template_id": template_id},
     )
 
@@ -320,7 +320,7 @@ def test_update_rejects_non_integer_expected_revision(
     template_id, _ = _create_template(canonical_api_client, profile_id)
 
     profile_response = canonical_api_client.simulate_patch(
-        f"/series-profiles/{profile_id}",
+        f"/v1/series-profiles/{profile_id}",
         json={
             "expected_revision": "not-an-int",
             "title": "Invalid profile update",
@@ -333,7 +333,7 @@ def test_update_rejects_non_integer_expected_revision(
     )
 
     template_response = canonical_api_client.simulate_patch(
-        f"/episode-templates/{template_id}",
+        f"/v1/episode-templates/{template_id}",
         json={
             "expected_revision": "not-an-int",
             "title": "Invalid template update",
@@ -354,7 +354,7 @@ def test_update_rejects_missing_expected_revision(
     template_id, _ = _create_template(canonical_api_client, profile_id)
 
     profile_response = canonical_api_client.simulate_patch(
-        f"/series-profiles/{profile_id}",
+        f"/v1/series-profiles/{profile_id}",
         json={
             "title": "Invalid profile update",
             "description": "Should fail",
@@ -366,7 +366,7 @@ def test_update_rejects_missing_expected_revision(
     )
 
     template_response = canonical_api_client.simulate_patch(
-        f"/episode-templates/{template_id}",
+        f"/v1/episode-templates/{template_id}",
         json={
             "title": "Invalid template update",
             "description": "Should fail",

--- a/tests/test_reference_document_access.py
+++ b/tests/test_reference_document_access.py
@@ -15,7 +15,7 @@ def test_series_aligned_host_guest_access_paths(
     fixture = support.build_api_fixture(canonical_api_client)
 
     host_response = canonical_api_client.simulate_post(
-        f"/series-profiles/{fixture.primary_profile_id}/reference-documents",
+        f"/v1/series-profiles/{fixture.primary_profile_id}/reference-documents",
         json={
             "kind": "host_profile",
             "lifecycle_state": "active",
@@ -28,7 +28,7 @@ def test_series_aligned_host_guest_access_paths(
     )
 
     guest_response = canonical_api_client.simulate_post(
-        f"/series-profiles/{fixture.primary_profile_id}/reference-documents",
+        f"/v1/series-profiles/{fixture.primary_profile_id}/reference-documents",
         json={
             "kind": "guest_profile",
             "lifecycle_state": "active",
@@ -38,7 +38,7 @@ def test_series_aligned_host_guest_access_paths(
     assert guest_response.status_code == 201
 
     host_list_response = canonical_api_client.simulate_get(
-        f"/series-profiles/{fixture.primary_profile_id}/reference-documents",
+        f"/v1/series-profiles/{fixture.primary_profile_id}/reference-documents",
         params={"kind": "host_profile", "limit": "10", "offset": "0"},
     )
     assert host_list_response.status_code == 200
@@ -49,7 +49,7 @@ def test_series_aligned_host_guest_access_paths(
     assert len(host_list_items) == 1, "Expected one host-profile document."
 
     guest_list_response = canonical_api_client.simulate_get(
-        f"/series-profiles/{fixture.primary_profile_id}/reference-documents",
+        f"/v1/series-profiles/{fixture.primary_profile_id}/reference-documents",
         params={"kind": "guest_profile", "limit": "10", "offset": "0"},
     )
     assert guest_list_response.status_code == 200
@@ -60,7 +60,7 @@ def test_series_aligned_host_guest_access_paths(
     assert len(guest_list_items) == 1, "Expected one guest-profile document."
 
     cross_series_get = canonical_api_client.simulate_get(
-        f"/series-profiles/{fixture.secondary_profile_id}/reference-documents/{host_document_id}"
+        f"/v1/series-profiles/{fixture.secondary_profile_id}/reference-documents/{host_document_id}"
     )
     assert cross_series_get.status_code == 404, (
         "Expected cross-series document lookup to return 404."
@@ -80,7 +80,7 @@ def test_reference_document_api_rejects_boolean_expected_lock_version(
     )
 
     response = canonical_api_client.simulate_patch(
-        f"/series-profiles/{fixture.primary_profile_id}/reference-documents/{document_id}",
+        f"/v1/series-profiles/{fixture.primary_profile_id}/reference-documents/{document_id}",
         json={
             "expected_lock_version": True,
             "lifecycle_state": "active",

--- a/tests/test_reference_document_api_support.py
+++ b/tests/test_reference_document_api_support.py
@@ -27,7 +27,7 @@ def _assert_document_get_and_optimistic_lock(
 ) -> None:
     """Assert get and optimistic-lock update behaviour for one document."""
     get_document_response = client.simulate_get(
-        f"/series-profiles/{profile_id}/reference-documents/{document_id}"
+        f"/v1/series-profiles/{profile_id}/reference-documents/{document_id}"
     )
     assert get_document_response.status_code == 200, (
         "unexpected status for GET reference document: "
@@ -35,7 +35,7 @@ def _assert_document_get_and_optimistic_lock(
     )
 
     update_document_response = client.simulate_patch(
-        f"/series-profiles/{profile_id}/reference-documents/{document_id}",
+        f"/v1/series-profiles/{profile_id}/reference-documents/{document_id}",
         json={
             "expected_lock_version": 1,
             "lifecycle_state": "active",
@@ -52,7 +52,7 @@ def _assert_document_get_and_optimistic_lock(
     )
 
     stale_update_response = client.simulate_patch(
-        f"/series-profiles/{profile_id}/reference-documents/{document_id}",
+        f"/v1/series-profiles/{profile_id}/reference-documents/{document_id}",
         json={
             "expected_lock_version": 1,
             "lifecycle_state": "archived",
@@ -101,7 +101,7 @@ def _assert_revision_and_binding_workflow(
     ], "Expected revision history to preserve creation order."
 
     get_revision_response = client.simulate_get(
-        f"/reference-document-revisions/{second_revision_id}"
+        f"/v1/reference-document-revisions/{second_revision_id}"
     )
     assert get_revision_response.status_code == 200, (
         f"Unexpected status for GET revision: {get_revision_response.status_code}"
@@ -126,13 +126,13 @@ def _assert_binding_list_workflow(
         revision_id=second_revision_id,
         template_id=template_id,
     )
-    get_binding_response = client.simulate_get(f"/reference-bindings/{binding_id}")
+    get_binding_response = client.simulate_get(f"/v1/reference-bindings/{binding_id}")
     assert get_binding_response.status_code == 200, (
         f"Unexpected status for GET binding: {get_binding_response.status_code}"
     )
 
     list_bindings_response = client.simulate_get(
-        "/reference-bindings",
+        "/v1/reference-bindings",
         params={
             "target_kind": "episode_template",
             "target_id": template_id,

--- a/tests/test_reference_document_validation.py
+++ b/tests/test_reference_document_validation.py
@@ -16,32 +16,32 @@ if typ.TYPE_CHECKING:
     ("path_template", "params_builder", "description"),
     [
         (
-            "/series-profiles/{profile_id}/reference-documents",
+            "/v1/series-profiles/{profile_id}/reference-documents",
             lambda fixture: {"limit": "not-an-int"},
             "Pagination parameters limit/offset must be integers.",
         ),
         (
-            "/series-profiles/{profile_id}/reference-documents",
+            "/v1/series-profiles/{profile_id}/reference-documents",
             lambda fixture: {"offset": "not-an-int"},
             "Pagination parameters limit/offset must be integers.",
         ),
         (
-            "/series-profiles/{profile_id}/reference-documents",
+            "/v1/series-profiles/{profile_id}/reference-documents",
             lambda fixture: {"limit": "0"},
             "limit must be between 1 and 100.",
         ),
         (
-            "/series-profiles/{profile_id}/reference-documents",
+            "/v1/series-profiles/{profile_id}/reference-documents",
             lambda fixture: {"limit": "101"},
             "limit must be between 1 and 100.",
         ),
         (
-            "/series-profiles/{profile_id}/reference-documents",
+            "/v1/series-profiles/{profile_id}/reference-documents",
             lambda fixture: {"offset": "-1"},
             "offset must be a non-negative integer.",
         ),
         (
-            "/reference-bindings",
+            "/v1/reference-bindings",
             lambda fixture: support._binding_list_params(
                 fixture,
                 limit="not-an-int",
@@ -49,7 +49,7 @@ if typ.TYPE_CHECKING:
             "Pagination parameters limit/offset must be integers.",
         ),
         (
-            "/reference-bindings",
+            "/v1/reference-bindings",
             lambda fixture: support._binding_list_params(
                 fixture,
                 offset="not-an-int",
@@ -57,17 +57,17 @@ if typ.TYPE_CHECKING:
             "Pagination parameters limit/offset must be integers.",
         ),
         (
-            "/reference-bindings",
+            "/v1/reference-bindings",
             lambda fixture: support._binding_list_params(fixture, limit="0"),
             "limit must be between 1 and 100.",
         ),
         (
-            "/reference-bindings",
+            "/v1/reference-bindings",
             lambda fixture: support._binding_list_params(fixture, limit="101"),
             "limit must be between 1 and 100.",
         ),
         (
-            "/reference-bindings",
+            "/v1/reference-bindings",
             lambda fixture: support._binding_list_params(fixture, offset="-1"),
             "offset must be a non-negative integer.",
         ),
@@ -95,7 +95,7 @@ def test_reference_document_api_rejects_missing_required_binding_params(
     support._seed_reference_binding(canonical_api_client, fixture)
 
     missing_target_kind = canonical_api_client.simulate_get(
-        "/reference-bindings",
+        "/v1/reference-bindings",
         params={"target_id": fixture.template_id},
     )
     support._assert_bad_request_error(
@@ -104,7 +104,7 @@ def test_reference_document_api_rejects_missing_required_binding_params(
     )
 
     missing_target_id = canonical_api_client.simulate_get(
-        "/reference-bindings",
+        "/v1/reference-bindings",
         params={"target_kind": "episode_template"},
     )
     support._assert_bad_request_error(
@@ -120,7 +120,7 @@ def test_reference_document_api_rejects_invalid_uuids(
     fixture = support.build_api_fixture(canonical_api_client)
 
     invalid_document_id = canonical_api_client.simulate_get(
-        f"/series-profiles/{fixture.primary_profile_id}/reference-documents/not-a-valid-uuid"
+        f"/v1/series-profiles/{fixture.primary_profile_id}/reference-documents/not-a-valid-uuid"
     )
     support._assert_bad_request_error(
         invalid_document_id,
@@ -128,7 +128,7 @@ def test_reference_document_api_rejects_invalid_uuids(
     )
 
     invalid_revision_id = canonical_api_client.simulate_get(
-        "/reference-document-revisions/not-a-valid-uuid"
+        "/v1/reference-document-revisions/not-a-valid-uuid"
     )
     support._assert_bad_request_error(
         invalid_revision_id,
@@ -136,7 +136,7 @@ def test_reference_document_api_rejects_invalid_uuids(
     )
 
     invalid_binding_id = canonical_api_client.simulate_get(
-        "/reference-bindings/not-a-valid-uuid"
+        "/v1/reference-bindings/not-a-valid-uuid"
     )
     support._assert_bad_request_error(
         invalid_binding_id,
@@ -144,7 +144,7 @@ def test_reference_document_api_rejects_invalid_uuids(
     )
 
     invalid_target_id = canonical_api_client.simulate_get(
-        "/reference-bindings",
+        "/v1/reference-bindings",
         params={
             "target_kind": "episode_template",
             "target_id": "not-a-valid-uuid",


### PR DESCRIPTION
## Summary

This branch implements roadmap task (4.1.1) by introducing `/v1` as the target prefix for Episodic's existing client-facing canonical REST API resources.

It registers series-profile, episode-template, reusable-reference, reference-binding, and binding-resolution Falcon routes under `/v1`, leaves root health endpoints unversioned, and does not add compatibility aliases for old pre-v0.1.0 canonical paths.

Execplan: [docs/execplans/4-1-1-introduce-v1-target-api-prefix.md](https://github.com/leynos/episodic/blob/927ebb2b5e57b7f289b4be5dc22d38ef7931e28a/docs/execplans/4-1-1-introduce-v1-target-api-prefix.md)

## Review walkthrough

- Start with `episodic/api/app.py` for the route-table change.
- Review `tests/test_api_route_versioning.py` for the explicit `/v1`, unversioned `404`, and root-health routing contract.
- Review the updated API tests and BDD step modules for `/v1` client paths.
- Review `docs/developers-guide.md`, `docs/users-guide.md`, and `docs/roadmap.md` for the documented routing convention and roadmap completion.

## Validation

- `make fmt`: passed. Unrelated Markdown formatter churn was reverted.
- `mbake validate Makefile`: passed.
- `make check-fmt`: passed.
- `PATH=/root/.bun/bin:$PATH make markdownlint`: passed with 0 errors.
- `make nixie`: passed; all diagrams validated successfully.
- `make build`: passed.
- `make lint`: passed.
- `make typecheck`: passed.
- `make test`: passed with 662 passed and 3 skipped.
- `make check-migrations`: passed.
- `coderabbit doctor`: passed with 9 passed, 0 warnings, 0 failed.
- `coderabbit review --agent`: passed with 0 findings after clearing all concerns.

## References

- Lody session: https://lody.ai/leynos/sessions/b33e77aa-4c5e-41e4-b03a-64fbf23fa4f7

## Summary by Sourcery

Route existing canonical REST API resources under a new `/v1` API prefix and document the versioning contract while keeping health endpoints unversioned.

New Features:
- Expose series-profile, episode-template, reusable-reference, reference-binding, and binding-resolution HTTP resources under the `/v1` API namespace.

Enhancements:
- Clarify API versioning and routing conventions in the developers guide and users guide, including which endpoints are versioned and which remain internal.
- Add explicit tests to assert `/v1` routes are registered, unversioned canonical routes return 404, and health endpoints continue to work at root paths.
- Mark roadmap item 4.1.1 as complete and record the associated execution plan document for the `/v1` prefix rollout.

Documentation:
- Add an execution plan document detailing the rationale, constraints, and validation steps for introducing the `/v1` target API prefix.

Tests:
- Update existing API, BDD, and support tests to target `/v1` paths for canonical resources and validate route-versioning behaviour via a new dedicated test module.