### PR TITLE
Configure Celery queue routing (2.4.3)

### DIFF
--- a/docs/adr/adr-003-celery-worker-scaffold.md
+++ b/docs/adr/adr-003-celery-worker-scaffold.md
@@ -27,7 +27,9 @@ clear scope decision.
 The worker scaffold now follows these rules:
 
 1. `episodic/worker/topology.py` is the single source of truth for the
-   exchange, queues, workload classes, and task-route metadata.
+   exchange, queues, workload classes, and task-route metadata. Route-table
+   construction rejects malformed task names and workload values that are not
+   `WorkloadClass` members.
 2. `episodic/worker/runtime.py` is the Celery composition root. It reads
    environment variables, validates RabbitMQ-backed configuration, exposes
    worker launch profiles, and builds the Celery application through
@@ -37,9 +39,11 @@ The worker scaffold now follows these rules:
    diagnostic, not business-complete workflow implementations.
 4. The canonical queue topology uses one topic exchange, `episodic.tasks`, and
    two queues:
-   - `episodic.io` for I/O-bound tasks, routed with
+   - `episodic.io` for I/O-bound tasks, bound with `episodic.io.#` and used by
+     the `episodic.worker.io_diagnostic` route through
      `episodic.io.diagnostic`;
-   - `episodic.cpu` for CPU-bound tasks, routed with
+   - `episodic.cpu` for CPU-bound tasks, bound with `episodic.cpu.#` and used
+     by the `episodic.worker.cpu_diagnostic` route through
      `episodic.cpu.diagnostic`.
 5. The initial worker-profile split is:
    - I/O-bound workloads default to the `gevent` pool with high concurrency;
@@ -53,9 +57,10 @@ The worker scaffold now follows these rules:
      workers with `EPISODIC_INTERPRETER_POOL_MAX_WORKERS`.
 6. Behavioural coverage for this roadmap slice remains contract-level rather
    than broker-backed. Tests create the Celery app from environment
-   configuration, inspect routing metadata, and execute representative tasks in
-   eager mode. A live RabbitMQ dispatch path is deferred until the repository
-   has a stable broker fixture strategy.
+   configuration, inspect queue, exchange, exchange type, and routing-key
+   metadata, and execute representative tasks in eager mode. A live RabbitMQ
+   dispatch path is deferred until the repository has a stable broker fixture
+   strategy.
 
 ## Rationale
 

--- a/docs/adr/adr-007-durable-generation-checkpoints.md
+++ b/docs/adr/adr-007-durable-generation-checkpoints.md
@@ -48,8 +48,10 @@ insert hits the idempotency-key constraint.
 - The graph can prove suspend/resume behaviour without exposing LangGraph
   checkpoint classes in public contracts.
 - Durable checkpoint state survives fresh unit-of-work and graph instances.
-- Queue routing remains a later concern; `TaskResumePort` is the seam that
-  future Celery callbacks will use.
+- Celery queue routing is now handled inside the worker adapter boundary:
+  worker topology owns queue, exchange, exchange type, routing-key metadata,
+  and workload classification. `TaskResumePort` remains the seam that future
+  Celery callbacks will use when LangGraph-to-Celery dispatch lands.
 - Planning may run again on repeated suspend attempts in this slice, but the
   side-effecting execution step is deduplicated by the checkpoint key.
 - The in-memory adapter is suitable for tests and local demos only. It has no

--- a/docs/agentic-systems-with-langgraph-and-celery.md
+++ b/docs/agentic-systems-with-langgraph-and-celery.md
@@ -96,12 +96,12 @@ systems require a high-performance, external store. Redis is the standard
 choice here.10 The langgraph-checkpoint-redis library utilizes Redis’s advanced
 data structures to serialize the graph state.
 
-| **Feature**     | **In-Memory Checkpointer**         | **Redis Checkpointer**                                                    |
-| --------------- | ---------------------------------- | ------------------------------------------------------------------------- |
-| **Durability**  | Lost on process restart.           | Persists across restarts and deployments.                                 |
-| **Scalability** | Single server only.                | Horizontal scaling across multiple API workers.                           |
-| **Time Travel** | Limited to current session memory. | Allows reverting to any previous state (“Time Travel”) for debugging.     |
-| **Concurrency** | Not thread-safe across processes.  | Supports distributed locking and atomic writes.                           |
+| **Feature**     | **In-Memory Checkpointer**         | **Redis Checkpointer**                                                |
+| --------------- | ---------------------------------- | --------------------------------------------------------------------- |
+| **Durability**  | Lost on process restart.           | Persists across restarts and deployments.                             |
+| **Scalability** | Single server only.                | Horizontal scaling across multiple API workers.                       |
+| **Time Travel** | Limited to current session memory. | Allows reverting to any previous state (“Time Travel”) for debugging. |
+| **Concurrency** | Not thread-safe across processes.  | Supports distributed locking and atomic writes.                       |
 
 The use of Redis ensures that an agent’s “brain” is not tied to a specific
 Python process. If the Kubernetes pod hosting the LangGraph API is recycled,

--- a/docs/complexity-antipatterns-and-refactoring-strategies.md
+++ b/docs/complexity-antipatterns-and-refactoring-strategies.md
@@ -46,8 +46,8 @@ the number of edges, N is the number of nodes, and P is the number of connected
 components (typically 1 for a single program or method).[^3] A simpler
 formulation for a single subroutine is
 
-M = number of decision points + 1, where decision points include constructs
-like `if` statements and conditional loops.[^3]
+M = number of decision points + 1, where decision points include constructs like
+`if` statements and conditional loops.[^3]
 
 Thresholds and Implications:
 
@@ -196,11 +196,11 @@ much like a physical bumpy road slows down driving.[^9]
 ### B. How It Forms and Its Impact
 
 The Bumpy Road antipattern, like many software antipatterns, often emerges from
-development practices that prioritize short-term speed over long-term
-structural integrity.[^2] Rushed development cycles, lack of clear design, or
-cutting corners on maintenance can lead to the gradual accumulation of
-conditional logic within a single function.[^2] As new requirements or edge
-cases are handled, developers might add more
+development practices that prioritize short-term speed over long-term structural
+integrity.[^2] Rushed development cycles, lack of clear design, or cutting
+corners on maintenance can lead to the gradual accumulation of conditional
+logic within a single function.[^2] As new requirements or edge cases are
+handled, developers might add more
 
 `if` statements or loops to an existing method, rather than stepping back to
 refactor and create appropriate abstractions.
@@ -387,10 +387,10 @@ maintainable systems.
 1\. Separation of Concerns (SoC)
 
 Separation of Concerns is a design principle that advocates for dividing a
-computer program into distinct sections, where each section addresses a
-separate concern.[^13] A "concern" is a set of information that affects the
-code of a computer program. Modularity is achieved by encapsulating information
-within a section of code that has a well-defined interface.[^13]
+computer program into distinct sections, where each section addresses a separate
+concern.[^13] A "concern" is a set of information that affects the code of a
+computer program. Modularity is achieved by encapsulating information within a
+section of code that has a well-defined interface.[^13]
 
 The Bumpy Road antipattern is a direct violation of SoC. Each "bump" in the
 code often represents a distinct concern or responsibility that has been

--- a/docs/cost-management-in-langgraph-agentic-systems.md
+++ b/docs/cost-management-in-langgraph-agentic-systems.md
@@ -8,7 +8,7 @@ supplement addresses token usage tracking, per-task cost modelling, anomaly
 handling, and feedback loops for budget enforcement. Port definitions for
 `BudgetPort` and `CostLedgerPort` live in
 [Orchestration ports and adapters](episodic-podcast-generation-system-design.md#orchestration-ports-and-adapters).
- The strategies below ensure that a **Generation 2** agentic system remains not
+The strategies below ensure that a **Generation 2** agentic system remains not
 only intelligent and scalable, but also **cost-aware** and economically
 efficient.
 
@@ -52,9 +52,9 @@ By attaching such a callback to every LLM invocation (via the LangGraph config
 or LangChain `callbacks` list), **token usage is tracked per task** and
 centrally aggregated. This approach can be extended to *all* model
 interactions. For instance, enabling `stream_usage=True` on OpenAI chat models
-ensures the usage info is populated in the
-callback([1](https://forum.langchain.com/t/how-to-obtain-token-usage-from-langgraph/1727#:~:text=Thanks%20for%20your%20help%2C%20I,I%20just%20needed%20to%20add)).
- In addition, structured logging can record each call’s token count alongside
+ensures the usage info is populated in the callback(
+[1](https://forum.langchain.com/t/how-to-obtain-token-usage-from-langgraph/1727#:~:text=Thanks%20for%20your%20help%2C%20I,I%20just%20needed%20to%20add)).
+In addition, structured logging can record each call’s token count alongside
 task identifiers, making it easier to analyse cost per user query or per agent
 run.
 
@@ -86,15 +86,15 @@ services. The system can export metrics such as *tokens_per_request*,
 usage and cost for each trace, giving a unified view of spend across the entire
 application(
 [2](https://docs.langchain.com/langsmith/cost-tracking#:~:text=Building%20agents%20at%20scale%20introduces,This%20guide%20covers)).
- In production, one might send these metrics to a time-series database
+In production, one might send these metrics to a time-series database
 (Prometheus, CloudWatch) or use LangSmith/Langfuse tracers to visualize
 per-task costs. By monitoring these metrics, operators can detect anomalies
 (e.g. a sudden spike in tokens/minute) and also enforce rate limits. For
 example, concurrency in LangGraph should be configured with awareness of rate
 limits: if multiple nodes call an API in parallel, they might hit provider
-limits
-faster([3](https://aipractitioner.substack.com/p/scaling-langgraph-agents-parallelization#:~:text=This%20shift%20creates%20several%20practical,implications)).
- Tracking the call rate via metrics allows dynamic throttling – e.g. if calls
+limits faster(
+[3](https://aipractitioner.substack.com/p/scaling-langgraph-agents-parallelization#:~:text=This%20shift%20creates%20several%20practical,implications)).
+Tracking the call rate via metrics allows dynamic throttling – e.g. if calls
 per minute approach the API’s cap, new calls can be delayed or queued to avoid
 429 errors. Overall, a combination of **callback logging and external
 monitoring** provides transparency into token usage, retry overhead, and
@@ -202,17 +202,17 @@ While timeouts alone don’t track tokens, they prevent a hung process from
 accumulating unlimited cost.
 
 **Unexpected Parallel Fan-Out:** One advantage of LangGraph is the ability to
-execute nodes in parallel for
-speed([3](https://aipractitioner.substack.com/p/scaling-langgraph-agents-parallelization#:~:text=What%20is%20parallelization%20in%20LangGraph%3F)
- )(
+execute nodes in parallel for speed(
+[3](https://aipractitioner.substack.com/p/scaling-langgraph-agents-parallelization#:~:text=What%20is%20parallelization%20in%20LangGraph%3F)
+)(
 [3](https://aipractitioner.substack.com/p/scaling-langgraph-agents-parallelization#:~:text=This%20shift%20creates%20several%20practical,implications)).
- However, if misused, parallel fan-out can spawn a large number of simultaneous
+However, if misused, parallel fan-out can spawn a large number of simultaneous
 calls, consuming resources and quota in a burst. For example, an agent might
 naively launch dozens of search queries or sub-agents at once when a smaller
 number would do. To control this, LangGraph provides a `max_concurrency`
-configuration to cap how many nodes run in
-parallel([3](https://aipractitioner.substack.com/p/scaling-langgraph-agents-parallelization#:~:text=,off)).
- Setting reasonable limits (based on API rate limits and budget) prevents an
+configuration to cap how many nodes run in parallel(
+[3](https://aipractitioner.substack.com/p/scaling-langgraph-agents-parallelization#:~:text=,off)).
+Setting reasonable limits (based on API rate limits and budget) prevents an
 explosion of parallel tasks from *overwhelming quotas*. At the infrastructure
 level, the message broker (RabbitMQ) can also help: tasks can be routed into
 separate queues with limited worker processes for certain expensive operations,
@@ -241,9 +241,9 @@ particular tool caused an infinite loop, or a user input consistently triggers
 a pathological case. Moreover, the system can raise immediate **alerts** when
 tasks land in the DLQ or when failure rates exceed a threshold. Best practices
 include setting up notifications if, say, more than X tasks per hour go to
-dead-letter (indicating a systemic
-issue)([4](https://blog.gitguardian.com/celery-tasks-retries-errors/#:~:text=A%20Deep%20Dive%20into%20Celery,This)).
- Additionally, **threshold guards** can be baked into the code: for instance,
+dead-letter (indicating a systemic issue)(
+[4](https://blog.gitguardian.com/celery-tasks-retries-errors/#:~:text=A%20Deep%20Dive%20into%20Celery,This)).
+Additionally, **threshold guards** can be baked into the code: for instance,
 if an agent’s `total_cost` in state exceeds a safe limit, have the next node
 intentionally throw an exception to halt the process (this exception would be
 caught and could route to DLQ or an error handler). This proactive fail-fast
@@ -257,8 +257,8 @@ should trigger to limit damage:
   the frequency of LLM calls by introducing delays or using a token bucket
   algorithm per user. If an infinite loop is making rapid-fire calls, a rate
   limiter will slow it down and give an opportunity for other monitors to
-  intervene (or for the loop to self-terminate when hitting other
-  limits)([3](https://aipractitioner.substack.com/p/scaling-langgraph-agents-parallelization#:~:text=This%20shift%20creates%20several%20practical,implications)).
+  intervene (or for the loop to self-terminate when hitting other limits)(
+  [3](https://aipractitioner.substack.com/p/scaling-langgraph-agents-parallelization#:~:text=This%20shift%20creates%20several%20practical,implications)).
 
 - **Graceful Degradation:** Scale back the task complexity dynamically. If a
   particular workflow is consuming too many resources, the system can switch to
@@ -444,8 +444,8 @@ managing and limiting the costs of its computations.
   handlers capturing token usage and implementing rate limit logic.
 
 - *LangChain Forum – Token Usage in LangGraph* – Discussion on enabling usage
-  tracking (e.g. `stream_usage=True`) to obtain token counts for agent
-  calls([1](https://forum.langchain.com/t/how-to-obtain-token-usage-from-langgraph/1727#:~:text=Thanks%20for%20your%20help%2C%20I,I%20just%20needed%20to%20add)).
+  tracking (e.g. `stream_usage=True`) to obtain token counts for agent calls(
+  [1](https://forum.langchain.com/t/how-to-obtain-token-usage-from-langgraph/1727#:~:text=Thanks%20for%20your%20help%2C%20I,I%20just%20needed%20to%20add)).
 
 - *A.I. Practitioner – Scaling LangGraph Agents (Part 4)* – Notes on parallel
   execution trade-offs, including concurrency limits to avoid rapid quota
@@ -453,8 +453,8 @@ managing and limiting the costs of its computations.
   [3](https://aipractitioner.substack.com/p/scaling-langgraph-agents-parallelization#:~:text=This%20shift%20creates%20several%20practical,implications)).
 
 - *LangSmith Documentation – Cost Tracking* – Describes automatic recording of
-  LLM token usage and unified cost views for monitoring and
-  alerts([2](https://docs.langchain.com/langsmith/cost-tracking#:~:text=Building%20agents%20at%20scale%20introduces,This%20guide%20covers)).
+  LLM token usage and unified cost views for monitoring and alerts(
+  [2](https://docs.langchain.com/langsmith/cost-tracking#:~:text=Building%20agents%20at%20scale%20introduces,This%20guide%20covers)).
 
 - Stack Overflow – *Routing Celery failed tasks to Dead Letter Queue* – Best
   practices on using RabbitMQ Dead Letter Exchanges to capture failed tasks for

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -173,8 +173,8 @@ Queue contract:
   `episodic.io`, exchange `episodic.tasks`, exchange type `topic`, and routing
   key `episodic.io.diagnostic`.
 - CPU diagnostic route: `episodic.worker.cpu_diagnostic` routes to queue
-  `episodic.cpu`, exchange `episodic.tasks`, exchange type `topic`, and
-  routing key `episodic.cpu.diagnostic`.
+  `episodic.cpu`, exchange `episodic.tasks`, exchange type `topic`, and routing
+  key `episodic.cpu.diagnostic`.
 
 ### Python dependencies
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -167,8 +167,14 @@ Optional interpreter-pool flags:
 Queue contract:
 
 - Exchange: `episodic.tasks` (`topic`)
-- I/O queue: `episodic.io`, routed via `episodic.io.diagnostic`
-- CPU queue: `episodic.cpu`, routed via `episodic.cpu.diagnostic`
+- I/O queue: `episodic.io`, bound with `episodic.io.#`
+- CPU queue: `episodic.cpu`, bound with `episodic.cpu.#`
+- I/O diagnostic route: `episodic.worker.io_diagnostic` routes to queue
+  `episodic.io`, exchange `episodic.tasks`, exchange type `topic`, and routing
+  key `episodic.io.diagnostic`.
+- CPU diagnostic route: `episodic.worker.cpu_diagnostic` routes to queue
+  `episodic.cpu`, exchange `episodic.tasks`, exchange type `topic`, and
+  routing key `episodic.cpu.diagnostic`.
 
 ### Python dependencies
 
@@ -194,6 +200,8 @@ Testing guidance:
 
 - Use `tests/test_worker_service_scaffold.py` for unit coverage of topology,
   runtime parsing, Celery app assembly, and eager task execution.
+- Use `tests/test_worker_routing_contract.py` for route-table completeness,
+  exchange metadata, and malformed route validation.
 - Use `tests/features/worker_service_scaffold.feature` and
   `tests/steps/test_worker_service_scaffold_steps.py` for contract-level
   behavioural coverage.
@@ -208,8 +216,11 @@ When adding new worker tasks:
   in `episodic/worker/tasks.py` or a sibling worker-only module.
 - Depend on ports or injected callables rather than importing concrete
   adapters directly into task code.
-- Extend `SCAFFOLD_TASK_WORKLOADS` and the topology-backed routing metadata, so
-  the new task's queue assignment remains explicit.
+- Extend the explicit task-name tuple and workload map together, then update
+  the topology-backed routing tests so the new task's queue assignment remains
+  deliberate. Unknown or malformed task names, and non-`WorkloadClass`
+  workload values, must fail during route-table construction instead of falling
+  through to Celery's default queue.
 - For CPU-bound tasks on `episodic.cpu` that can split pure-Python inner work
   into independent items, build the task-level executor from the environment:
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -218,9 +218,9 @@ When adding new worker tasks:
   adapters directly into task code.
 - Extend the explicit task-name tuple and workload map together, then update
   the topology-backed routing tests so the new task's queue assignment remains
-  deliberate. Unknown or malformed task names, and non-`WorkloadClass`
-  workload values, must fail during route-table construction instead of falling
-  through to Celery's default queue.
+  deliberate. Unknown or malformed task names, and non-`WorkloadClass` workload
+  values, must fail during route-table construction instead of falling through
+  to Celery's default queue.
 - For CPU-bound tasks on `episodic.cpu` that can split pure-Python inner work
   into independent items, build the task-level executor from the environment:
 

--- a/docs/episodic-podcast-generation-system-design.md
+++ b/docs/episodic-podcast-generation-system-design.md
@@ -92,11 +92,12 @@ dependency object.
 
 The worker data plane now follows the same pattern.
 `episodic/worker/topology.py` defines the canonical RabbitMQ exchange, queue,
-and routing-key taxonomy, `episodic/worker/tasks.py` holds typed representative
-task seams, and `episodic/worker/runtime.py` acts as the Celery composition
-root that reads environment configuration and constructs the worker
-application. ADR-003 records the accepted queue topology, pool split, and
-test-scope decision.
+and routing-key taxonomy, validates explicit task-to-workload route maps, and
+emits Celery route metadata with queue, exchange, exchange type, and routing
+key. `episodic/worker/tasks.py` holds typed representative task seams, and
+`episodic/worker/runtime.py` acts as the Celery composition root that reads
+environment configuration and constructs the worker application. ADR-003
+records the accepted queue topology, pool split, and test-scope decision.
 
 ### Hexagonal architecture enforcement
 
@@ -692,10 +693,15 @@ characteristics.
 
 The current scaffold instantiates this split with one topic exchange,
 `episodic.tasks`, and two queues: `episodic.io` for I/O-bound tasks and
-`episodic.cpu` for CPU-bound tasks. The first implementation validates this
-contract through eager-mode factory and routing tests rather than a broker-
-backed RabbitMQ harness; later roadmap items can layer live dispatch coverage
-on top of the same topology without changing the worker boundary.
+`episodic.cpu` for CPU-bound tasks. Queue bindings use `episodic.io.#` and
+`episodic.cpu.#`; representative diagnostic task routes use
+`episodic.io.diagnostic` and `episodic.cpu.diagnostic`. Route-table
+construction rejects malformed task names and non-`WorkloadClass` workload
+values before Celery can fall back to the default queue. The first
+implementation validates this contract through eager-mode factory and routing
+tests rather than a broker-backed RabbitMQ harness; later roadmap items can
+layer live dispatch coverage on top of the same topology without changing the
+worker boundary.
 
 For selected pure-Python CPU workloads, adapters may optionally use Python 3.14
 interpreter pools within a worker process before escalating to broader process
@@ -788,6 +794,10 @@ In the current worker scaffold, representative Celery tasks use injected
 callable seams instead of importing concrete adapters directly. Future task
 implementations should preserve this pattern by resolving storage, LLM, and
 other infrastructure through ports or composition-root-owned dependencies.
+This roadmap slice does not add LangGraph-to-Celery dispatch. Orchestration
+continues to expose provider-neutral request, checkpoint, and resume DTOs,
+whilst the worker adapter owns Celery queues, routing keys, and pool launch
+profiles.
 
 The first durable content-generation checkpoint implementation stores
 `WorkflowCheckpoint` records in `workflow_checkpoints`. The graph persists the

--- a/docs/episodic-podcast-generation-system-design.md
+++ b/docs/episodic-podcast-generation-system-design.md
@@ -793,8 +793,8 @@ adapter implementations.
 In the current worker scaffold, representative Celery tasks use injected
 callable seams instead of importing concrete adapters directly. Future task
 implementations should preserve this pattern by resolving storage, LLM, and
-other infrastructure through ports or composition-root-owned dependencies.
-This roadmap slice does not add LangGraph-to-Celery dispatch. Orchestration
+other infrastructure through ports or composition-root-owned dependencies. This
+roadmap slice does not add LangGraph-to-Celery dispatch. Orchestration
 continues to expose provider-neutral request, checkpoint, and resume DTOs,
 whilst the worker adapter owns Celery queues, routing keys, and pool launch
 profiles.
@@ -1774,13 +1774,13 @@ and all criteria below are met:
 The canonical persistence layer follows the hexagonal architecture by defining
 Protocol-based port interfaces in `episodic/canonical/ports.py` and
 implementing them as async SQLAlchemy adapters in
-`episodic/canonical/storage/`. Twelve repository protocols define the
-persistence contract: `SeriesProfileRepository`, `TeiHeaderRepository`,
-`EpisodeRepository`, `IngestionJobRepository`, `SourceDocumentRepository`,
-`ApprovalEventRepository`, `EpisodeTemplateRepository`,
-`SeriesProfileHistoryRepository`, `EpisodeTemplateHistoryRepository`,
-`ReferenceDocumentRepository`, `ReferenceDocumentRevisionRepository`, and
-`ReferenceBindingRepository`. `CanonicalUnitOfWork` aggregates them behind a
+`episodic/canonical/storage/`. Twelve repository protocols
+(`SeriesProfileRepository`, `TeiHeaderRepository`, `EpisodeRepository`,
+`IngestionJobRepository`, `SourceDocumentRepository`, `ApprovalEventRepository`,
+`EpisodeTemplateRepository`, `SeriesProfileHistoryRepository`,
+`EpisodeTemplateHistoryRepository`, `ReferenceDocumentRepository`,
+`ReferenceDocumentRevisionRepository`, and `ReferenceBindingRepository`) define
+the persistence contract, and `CanonicalUnitOfWork` aggregates them behind a
 transactional boundary with `commit()`, `flush()`, and `rollback()` methods.
 
 The `SqlAlchemyUnitOfWork` adapter creates a fresh `AsyncSession` on entry,

--- a/docs/episodic-tui-api-design.md
+++ b/docs/episodic-tui-api-design.md
@@ -626,11 +626,11 @@ Three mechanisms control backpressure, applied in escalating order:
    set to a small value to prevent client message spam.
 2. **Event compaction.** When the gap between the most recent event
    `seq` and the last acknowledged `seq` exceeds a configurable soft threshold
-   (for example, 500 events), the server begins compacting high-frequency
-   events (`token.delta`, `node.progress`) into periodic aggregates before
-   sending them. The server does not notify the client when compaction
-   activates; compacted events are indistinguishable from normal events apart
-   from coarser granularity.
+   (for example, 500 events), the server begins compacting high-frequency events
+   (`token.delta`, `node.progress`) into periodic aggregates before sending
+   them. The server does not notify the client when compaction activates;
+   compacted events are indistinguishable from normal events apart from coarser
+   granularity.
 3. **Acknowledgement-gated disconnect.** The server maintains a bounded
    ring buffer per run subscription (for example, the last 2000 events). If the
    acknowledgement lag exceeds a hard threshold (for example, 1500 events)

--- a/docs/execplans/1-4-3-reference-binding-resolution.md
+++ b/docs/execplans/1-4-3-reference-binding-resolution.md
@@ -1,9 +1,8 @@
 # Implement reference-binding resolution
 
-This Execution Plan (ExecPlan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This Execution Plan (ExecPlan) is a living document. The sections `Constraints`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 No `PLANS.md` file is present in the repository root.
 
@@ -35,8 +34,8 @@ After implementation, the system will:
    ingestion job to the exact reference content it consumed.
 3. Expose resolution behaviour through the existing
    `GET /series-profiles/{profile_id}/brief` endpoint, which will accept an
-   optional `episode_id` query parameter to control which episode context
-   drives `effective_from_episode_id` precedence.
+   optional `episode_id` query parameter to control which episode context drives
+   `effective_from_episode_id` precedence.
 4. Expose a new dedicated resolution endpoint
    `GET /series-profiles/{profile_id}/resolved-bindings` that returns the
    resolved set of bindings for a profile/template/episode combination without

--- a/docs/execplans/1-5-1-scaffold-falcon-http-services-on-granian.md
+++ b/docs/execplans/1-5-1-scaffold-falcon-http-services-on-granian.md
@@ -1,9 +1,8 @@
 # Scaffold Falcon HTTP services on Granian
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: COMPLETE
 

--- a/docs/execplans/1-5-2-scaffold-celery-workers-with-rabbit-mq-integration.md
+++ b/docs/execplans/1-5-2-scaffold-celery-workers-with-rabbit-mq-integration.md
@@ -143,8 +143,7 @@ Success is observable in the following ways:
   medium. Mitigation: decide early whether the scaffold includes an
   `LLMPort-facing` task. If not, document explicitly why Vidai Mock is not
   exercised in this slice; if yes, route all behavioural coverage for that task
-  through
-  Vidai Mock.
+  through Vidai Mock.
 
 ## Progress
 

--- a/docs/execplans/1-5-2-scaffold-celery-workers-with-rabbit-mq-integration.md
+++ b/docs/execplans/1-5-2-scaffold-celery-workers-with-rabbit-mq-integration.md
@@ -1,9 +1,8 @@
 # Scaffold Celery workers with RabbitMQ integration
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: COMPLETE
 
@@ -141,10 +140,10 @@ Success is observable in the following ways:
 
 - Risk: Vidai Mock integration may be underspecified for worker contexts if no
   current inference-facing task scaffold exists. Severity: low. Likelihood:
-  medium. Mitigation: decide early whether the scaffold includes an
-  `LLMPort`-facing task. If not, document explicitly why Vidai Mock is not
-  exercised in this slice; if yes, route all behavioural coverage for that task
-  through Vidai Mock.
+  medium. Mitigation: decide early whether the scaffold includes an `LLMPort`
+  -facing task. If not, document explicitly why Vidai Mock is not exercised in
+  this slice; if yes, route all behavioural coverage for that task through
+  Vidai Mock.
 
 ## Progress
 

--- a/docs/execplans/1-5-2-scaffold-celery-workers-with-rabbit-mq-integration.md
+++ b/docs/execplans/1-5-2-scaffold-celery-workers-with-rabbit-mq-integration.md
@@ -140,9 +140,10 @@ Success is observable in the following ways:
 
 - Risk: Vidai Mock integration may be underspecified for worker contexts if no
   current inference-facing task scaffold exists. Severity: low. Likelihood:
-  medium. Mitigation: decide early whether the scaffold includes an `LLMPort`
-  -facing task. If not, document explicitly why Vidai Mock is not exercised in
-  this slice; if yes, route all behavioural coverage for that task through
+  medium. Mitigation: decide early whether the scaffold includes an
+  `LLMPort-facing` task. If not, document explicitly why Vidai Mock is not
+  exercised in this slice; if yes, route all behavioural coverage for that task
+  through
   Vidai Mock.
 
 ## Progress

--- a/docs/execplans/1-5-4-architectural-enforcement-for-hexagonal-boundaries.md
+++ b/docs/execplans/1-5-4-architectural-enforcement-for-hexagonal-boundaries.md
@@ -1,9 +1,8 @@
 # Implement architectural enforcement for hexagonal boundaries
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: SHIPPED - implementation complete
 
@@ -92,8 +91,8 @@ Implementation approval rule:
   behavioural tests.
 - Use Vidai Mock for behavioural testing of inference services. This roadmap
   item does not need to invoke an inference path merely to mention Vidai Mock.
-  If an implementation change causes a behavioural test to exercise
-  `LLMPort`-backed inference directly, that behaviour test must use Vidai Mock.
+  If an implementation change causes a behavioural test to exercise `LLMPort`
+  -backed inference directly, that behaviour test must use Vidai Mock.
 - Keep existing public API and runtime behaviour stable. This work adds
   enforcement, not new user-facing endpoints or protocol changes.
 - Record the enforcement design in a new ADR under `docs/adr/`.
@@ -244,8 +243,8 @@ Implementation approval rule:
 - Observation: Post-turn hooks run in a narrower `PATH` than the interactive
   shell, so Makefile targets that required global `ruff`, `ty`, or
   `markdownlint-cli2` binaries failed before reaching the actual checks.
-  Impact: the Makefile now invokes Python developer tools through `uv`, pins
-  the `ty` tool runner to the already validated `0.0.32` version, and invokes
+  Impact: the Makefile now invokes Python developer tools through `uv`, pins the
+  `ty` tool runner to the already validated `0.0.32` version, and invokes
   Markdown lint through `npx -y markdownlint-cli2`.
 
 - Observation: The hook environment can also omit `uv` from `PATH`, and the

--- a/docs/execplans/2-2-1-pedante-factuality-and-accuracy-evaluator.md
+++ b/docs/execplans/2-2-1-pedante-factuality-and-accuracy-evaluator.md
@@ -1,9 +1,8 @@
 # Align Pedante implementation with revised ADR 001
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: DRAFT
 

--- a/docs/execplans/2-2-2-migration-tooling-with-alembic.md
+++ b/docs/execplans/2-2-2-migration-tooling-with-alembic.md
@@ -430,7 +430,7 @@ Add migration check step to `.github/workflows/ci.yml`.
 ### Step 8: Update documentation
 
 Edit `docs/developers-guide.md`,
-`docs/episodic-podcast-generation-system- design.md`, `docs/users-guide.md`, and
+`docs/episodic-podcast-generation-system-design.md`, `docs/users-guide.md`, and
 `docs/roadmap.md` as described in Stage E.
 
 ### Step 9: Run quality gates

--- a/docs/execplans/2-2-2-migration-tooling-with-alembic.md
+++ b/docs/execplans/2-2-2-migration-tooling-with-alembic.md
@@ -107,8 +107,8 @@ Success is observable when:
   `ix_source_documents_ingestion_job_id`, `ix_approval_events_episode_id`) on
   foreign key columns, but the ORM models did not declare `index=True` on those
   columns. `compare_metadata()` reported these as `remove_index` diffs (false
-  positives from the drift check perspective). Evidence: First test run showed
-  4 `remove_index` differences. Impact: Added `index=True` to the four FK
+  positives from the drift check perspective). Evidence: First test run showed 4
+  `remove_index` differences. Impact: Added `index=True` to the four FK
   columns in `episodic/canonical/storage/models.py` to align models with the
   migration. This is the correct fix since models should be the source of truth.
 
@@ -374,7 +374,7 @@ and `migrated_engine` fixtures. Import `detect_schema_drift` from
 
 For "an unmigrated table has been added to the ORM metadata", use
 `sa.Table("_test_drift_table", Base.metadata, sa.Column("id", sa.Integer, primary_key=True))`
- and store the table reference in a context dict so it can be removed from
+and store the table reference in a context dict so it can be removed from
 `Base.metadata` after the scenario.
 
 ### Step 3: Create the unit test file
@@ -430,8 +430,8 @@ Add migration check step to `.github/workflows/ci.yml`.
 ### Step 8: Update documentation
 
 Edit `docs/developers-guide.md`,
-`docs/episodic-podcast-generation-system- design.md`, `docs/users-guide.md`,
-and `docs/roadmap.md` as described in Stage E.
+`docs/episodic-podcast-generation-system- design.md`, `docs/users-guide.md`, and
+`docs/roadmap.md` as described in Stage E.
 
 ### Step 9: Run quality gates
 

--- a/docs/execplans/2-2-5-capture-provenance-metadata.md
+++ b/docs/execplans/2-2-5-capture-provenance-metadata.md
@@ -1,9 +1,8 @@
 # Capture provenance metadata in Text Encoding Initiative (TEI) headers for ingestion and future script generation
 
-This Execution Plan (ExecPlan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This Execution Plan (ExecPlan) is a living document. The sections `Constraints`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 No `PLANS.md` file is present in the repository root.
 

--- a/docs/execplans/2-2-6-chrono-runtime-estimator.md
+++ b/docs/execplans/2-2-6-chrono-runtime-estimator.md
@@ -1,9 +1,8 @@
 # Implement Chrono runtime estimation
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: COMPLETE
 
@@ -782,8 +781,8 @@ git add episodic/qa tests docs
 git commit -F "$COMMIT_MSG_FILE"
 ```
 
-Create the commit message in a temporary file from `mktemp -d`, then commit
-with `git commit -F`; do not pass the message with `git commit -m`.
+Create the commit message in a temporary file from `mktemp -d`, then commit with
+`git commit -F`; do not pass the message with `git commit -m`.
 
 For the follow-on strict TEI P5 work, first create the ADR and upstream
 `tei-rapporteur` requests before changing Chrono:

--- a/docs/execplans/2-2-6-define-reusable-reference-document-model.md
+++ b/docs/execplans/2-2-6-define-reusable-reference-document-model.md
@@ -1,9 +1,8 @@
 # Define reusable reference-document model and align profile/template contracts
 
-This Execution Plan (ExecPlan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This Execution Plan (ExecPlan) is a living document. The sections `Constraints`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 No `PLANS.md` file is present in the repository root.
 

--- a/docs/execplans/2-2-6-reusable-reference-document-repository-docs.md
+++ b/docs/execplans/2-2-6-reusable-reference-document-repository-docs.md
@@ -309,6 +309,6 @@ No new dependencies are required.
 
 ## Revision note
 
-Extended the completed plan with series-aligned host/guest profile semantics
-and `effective_from_episode_id` applicability rules, then updated the design
+Extended the completed plan with series-aligned host/guest profile semantics and
+`effective_from_episode_id` applicability rules, then updated the design
 document, roadmap, and reusable-reference ER diagram accordingly.

--- a/docs/execplans/2-2-6-series-profile-and-episode-template-models.md
+++ b/docs/execplans/2-2-6-series-profile-and-episode-template-models.md
@@ -1,9 +1,8 @@
 # Implement series profile and episode template models, Representational State Transfer (REST) endpoints, and change history
 
-This Execution Plan (ExecPlan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This Execution Plan (ExecPlan) is a living document. The sections `Constraints`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 No `PLANS.md` file is present in the repository root.
 
@@ -119,10 +118,9 @@ Success is observable when:
   based on repository state and checked-in documentation.
 
 - Observation: as of 2026-02-20, `docs/roadmap.md` tracks this capability under
-  item `2.2.8`, while this ExecPlan filename was requested as `2-2-6`.
-  Evidence: `docs/roadmap.md` section `2.2 Key activities`. Impact:
-  implementation must mark the matching text entry done rather than relying
-  only on numeric labels.
+  item `2.2.8`, while this ExecPlan filename was requested as `2-2-6`. Evidence:
+  `docs/roadmap.md` section `2.2 Key activities`. Impact: implementation must
+  mark the matching text entry done rather than relying only on numeric labels.
 
 - Observation: creating history entries in the same transaction as new profile
   and template rows requires explicit `flush()` before history insertion in

--- a/docs/execplans/2-2-7-rest-endpoints-for-reference-documents.md
+++ b/docs/execplans/2-2-7-rest-endpoints-for-reference-documents.md
@@ -1,9 +1,8 @@
 # Implement REST endpoints for reusable reference documents
 
-This Execution Plan (ExecPlan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This Execution Plan (ExecPlan) is a living document. The sections `Constraints`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 No `PLANS.md` file is present in the repository root.
 

--- a/docs/execplans/2-3-1-generate-show-notes-from-template-expansions.md
+++ b/docs/execplans/2-3-1-generate-show-notes-from-template-expansions.md
@@ -853,10 +853,11 @@ does not modify existing code. If a stage fails:
 2. Rerun the targeted tests for that stage.
 3. Rerun the full Stage H gate sequence before closing the work.
 
-If TEI enrichment via `tei_rapporteur` proves infeasible, stop implementation and
-escalate immediately. Record the capability gap in the ADR and decision log, then
-implement the missing TEI parsing support in `tei_rapporteur` before resuming.
-TEI parsing must continue to use TEI-P5 handling through `tei_rapporteur` only.
+If TEI enrichment via `tei_rapporteur` proves infeasible, stop implementation
+and escalate immediately. Record the capability gap in the ADR and decision
+log, then implement the missing TEI parsing support in `tei_rapporteur` before
+resuming. TEI parsing must continue to use TEI-P5 handling through
+`tei_rapporteur` only.
 
 ## Artefacts and notes
 

--- a/docs/execplans/2-3-1-generate-show-notes-from-template-expansions.md
+++ b/docs/execplans/2-3-1-generate-show-notes-from-template-expansions.md
@@ -853,9 +853,10 @@ does not modify existing code. If a stage fails:
 2. Rerun the targeted tests for that stage.
 3. Rerun the full Stage H gate sequence before closing the work.
 
-If TEI enrichment via `tei_rapporteur` proves infeasible, the fallback is to use
-`xml.etree.ElementTree` for XML manipulation and validate well-formedness with
-`ET.fromstring(...)`. Document the gap in the ADR and in the decision log.
+If TEI enrichment via `tei_rapporteur` proves infeasible, stop implementation and
+escalate immediately. Record the capability gap in the ADR and decision log, then
+implement the missing TEI parsing support in `tei_rapporteur` before resuming.
+TEI parsing must continue to use TEI-P5 handling through `tei_rapporteur` only.
 
 ## Artefacts and notes
 

--- a/docs/execplans/2-3-1-generate-show-notes-from-template-expansions.md
+++ b/docs/execplans/2-3-1-generate-show-notes-from-template-expansions.md
@@ -1,9 +1,8 @@
 # Generate show notes from template expansions
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: COMPLETED
 
@@ -195,8 +194,8 @@ implementation details. If future upstream regressions appear, start with PR
 
 - Decision: represent show notes in TEI as a `<div type="notes">` container
   with `<list>` and `<item>` children. Rationale: TEI P5 guidelines use `<div>`
-  with a `@type` attribute to denote functional divisions of text. A `<list>`
-  of `<item>` elements is the natural TEI idiom for enumerating topics.
+  with a `@type` attribute to denote functional divisions of text. A `<list>` of
+  `<item>` elements is the natural TEI idiom for enumerating topics.
   Timestamps and locators attach as attributes on `<item>`. tei-rapporteur
   `ffb25c6` added code support for `<div>`, `<list>`, `<item>`, and `<label>`
   at the Rust core, parser, emitter, and PyO3 projection layers; `016ef253`
@@ -529,8 +528,8 @@ structure metadata. The prompt instructs the model to extract key topics and
 optional timestamps, and to return a JSON object with an `entries` array.
 
 The `generate(...)` method builds the prompt, constructs an `LLMRequest` with
-the configured model, system prompt, provider operation, and token budget,
-calls `self.llm.generate(request)`, and parses the response via
+the configured model, system prompt, provider operation, and token budget, calls
+`self.llm.generate(request)`, and parses the response via
 `_result_from_response(...)`.
 
 The default system prompt should read:
@@ -854,9 +853,9 @@ does not modify existing code. If a stage fails:
 2. Rerun the targeted tests for that stage.
 3. Rerun the full Stage H gate sequence before closing the work.
 
-If TEI enrichment via `tei_rapporteur` proves infeasible, the fallback is to
-use `xml.etree.ElementTree` for XML manipulation and validate well-formedness
-with `ET.fromstring(...)`. Document the gap in the ADR and in the decision log.
+If TEI enrichment via `tei_rapporteur` proves infeasible, the fallback is to use
+`xml.etree.ElementTree` for XML manipulation and validate well-formedness with
+`ET.fromstring(...)`. Document the gap in the ADR and in the decision log.
 
 ## Artefacts and notes
 

--- a/docs/execplans/2-3-2-generate-chapter-markers-aligned-to-script-segments.md
+++ b/docs/execplans/2-3-2-generate-chapter-markers-aligned-to-script-segments.md
@@ -1,9 +1,8 @@
 # Generate chapter markers aligned to script segments
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: COMPLETE
 
@@ -309,17 +308,17 @@ between show-notes and chapter-marker modules, so
 `episodic/generation/tei_payload.py` now owns mapping/list/string validation
 plus body block and div detection helpers.
 
-Inline follow-up review was verified against the current branch before
-editing. The users' guide configuration note and empty-result equality test
-were already present. Remaining work split the large chapter-marker test module
-into DTO, generator/parser, and TEI enrichment files; removed the private
-pytest-asyncio runner dependency from the chapter-marker BDD step; and kept the
-ADR ExecPlan footnote marker contiguous for GitHub rendering.
+Inline follow-up review was verified against the current branch before editing.
+The users' guide configuration note and empty-result equality test were already
+present. Remaining work split the large chapter-marker test module into DTO,
+generator/parser, and TEI enrichment files; removed the private pytest-asyncio
+runner dependency from the chapter-marker BDD step; and kept the ADR ExecPlan
+footnote marker contiguous for GitHub rendering.
 
 The full gate sequence was then rerun on the segment-alignment follow-up tree.
 An initial `make test` run hit a transient async fixture timeout in
 `tests/test_profile_template_service.py::TestEpisodeTemplateService::test_update_episode_template_revision_conflict_raises`;
- that single test passed when rerun directly. A subsequent full `make test` run
+that single test passed when rerun directly. A subsequent full `make test` run
 passed with 485 tests and 3 skipped. Final validation passed:
 
 - `make check-fmt`

--- a/docs/execplans/2-3-3-generate-guest-bios-from-reference-document-bindings.md
+++ b/docs/execplans/2-3-3-generate-guest-bios-from-reference-document-bindings.md
@@ -1,9 +1,8 @@
 # Generate guest bios from reference document bindings
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: COMPLETE
 
@@ -175,9 +174,9 @@ enrichment.
   parsed `tei_rapporteur` payloads.
 - [x] 2026-05-14: Ran focused validation for milestone 2/3 with `set -o
   pipefail`, including `uv run pytest tests/test_guest_bios.py
-  tests/test_guest_bios_properties.py -q`, `make check-fmt`, `make
-  typecheck`, `make lint`, `make markdownlint`, and `make
-  nixie`. Ran `coderabbit review --agent`; it completed with zero findings.
+  tests/test_guest_bios_properties.py -q`, `make check-fmt`, `make typecheck`, `
+  make lint`, `make markdownlint`, and `make nixie`. Ran `coderabbit review
+  --agent`; it completed with zero findings.
 - [x] 2026-05-14: Added
   `generate_guest_bios_from_reference_bindings(...)` to resolve existing
   reference bindings through the canonical unit of work, project only
@@ -227,8 +226,8 @@ enrichment.
 ### TEI personography is richer than the roadmap target
 
 Firecrawl research against the official TEI P5 guidelines found that `<person>`
-can describe identifiable people and can contain person-related children such
-as `<persName>`, `<occupation>`, `<affiliation>`, and `<note>`. That model is
+can describe identifiable people and can contain person-related children such as
+`<persName>`, `<occupation>`, `<affiliation>`, and `<note>`. That model is
 suitable for a formal personography or participant description, but the roadmap
 item asks for biographical summaries "within TEI body".
 
@@ -265,10 +264,10 @@ parser/emitter dependency.
 
 - Decision: represent guest biographies in the TEI body as a
   `<div type="guest-bios">` containing a `<list>` of `<item>` entries unless
-  the representation prototype fails. Rationale: this follows ADR 004's
-  accepted `<div type="..."><list><item>...</item></list></div>` enrichment
-  convention and satisfies the roadmap requirement to format biographies inside
-  the TEI body. Date/Author: 2026-05-10 / ExecPlan draft.
+  the representation prototype fails. Rationale: this follows ADR 004's accepted
+  `<div type="..."><list><item>...</item></list></div>` enrichment convention
+  and satisfies the roadmap requirement to format biographies inside the TEI
+  body. Date/Author: 2026-05-10 / ExecPlan draft.
 - Decision: carry the source reference-document revision through generated
   biography results and TEI output using TEI linking attributes already
   supported by the local body model, preferring `@corresp` where possible.
@@ -340,10 +339,9 @@ Create `episodic/generation/guest_bios.py` following the structure of
 - `GuestBiosResponseFormatError`, raised for malformed LLM output.
 
 Implement strict JSON parsing. The LLM response should be constrained to a
-single object with a `guests` list, where each item has at least
-`display_name`, `bio`, and `reference_document_revision_id`. Reject missing,
-blank, duplicate, or unknown revision identifiers, so the generator cannot
-silently invent guests.
+single object with a `guests` list, where each item has at least `display_name`,
+`bio`, and `reference_document_revision_id`. Reject missing, blank, duplicate,
+or unknown revision identifiers, so the generator cannot silently invent guests.
 
 Use `LLMPort` only. Build prompts from a projection of TEI script context,
 episode template structure, and resolved guest profile content. Keep the prompt

--- a/docs/execplans/2-3-3-generate-guest-bios-from-reference-document-bindings.md
+++ b/docs/execplans/2-3-3-generate-guest-bios-from-reference-document-bindings.md
@@ -174,8 +174,8 @@ enrichment.
   parsed `tei_rapporteur` payloads.
 - [x] 2026-05-14: Ran focused validation for milestone 2/3 with `set -o
   pipefail`, including `uv run pytest tests/test_guest_bios.py
-  tests/test_guest_bios_properties.py -q`, `make check-fmt`, `make typecheck`, `
-  make lint`, `make markdownlint`, and `make nixie`. Ran `coderabbit review
+  tests/test_guest_bios_properties.py -q`, `make check-fmt`, `make typecheck`,
+  `make lint`, `make markdownlint`, and `make nixie`. Ran `coderabbit review
   --agent`; it completed with zero findings.
 - [x] 2026-05-14: Added
   `generate_guest_bios_from_reference_bindings(...)` to resolve existing

--- a/docs/execplans/2-4-1-structured-output-planning-and-tool-calling-execution.md
+++ b/docs/execplans/2-4-1-structured-output-planning-and-tool-calling-execution.md
@@ -1,9 +1,8 @@
 # Implement structured-output planning and tool-calling execution
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: COMPLETE
 
@@ -232,7 +231,7 @@ and roadmap item `2.4.1` is marked done.
   conceptually, stating that planning uses structured output and execution uses
   tool calling. Evidence:
   `docs/episodic-podcast-generation-system-design.md#langgraph-integration-principles`
-   on 2026-04-16. Impact: the ADR and implementation should align to that
+  on 2026-04-16. Impact: the ADR and implementation should align to that
   existing design language rather than invent new terms.
 
 - Observation: `docs/users-guide.md` and `docs/developers-guide.md` mention

--- a/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md
+++ b/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md
@@ -1,9 +1,8 @@
 # Add LangGraph suspend-and-resume orchestration
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: COMPLETE
 
@@ -143,9 +142,8 @@ Success is observable in these behaviours:
   accounting boundary, Vidai Mock behavioural test pattern, and the existing
   `2.4.1` ExecPlan.
 - [x] (2026-05-07 23:54Z) Inspected the existing orchestration seam in
-  `episodic/orchestration/generation.py`,
-  `episodic/orchestration/langgraph.py`, `episodic/orchestration/_dto.py`, and
-  `episodic/orchestration/_protocols.py`.
+  `episodic/orchestration/generation.py`, `episodic/orchestration/langgraph.py`,
+  `episodic/orchestration/_dto.py`, and `episodic/orchestration/_protocols.py`.
 - [x] (2026-05-07 23:54Z) Drafted this pre-implementation ExecPlan for roadmap
   item `2.4.2`.
 - [x] (2026-05-08 00:04Z) Ran planning-change validation gates:
@@ -197,8 +195,8 @@ Success is observable in these behaviours:
   leaving Python files unchanged. The explicit required gates pass.
 - [x] (2026-05-08 01:16Z) Stage G partial: `make check-fmt`,
   `make typecheck`, `make lint`, `make test`, `make markdownlint`, and
-  `make nixie` passed before marking the roadmap item done. `make test`
-  reported `446 passed, 3 skipped`.
+  `make nixie` passed before marking the roadmap item done. `make test` reported
+  `446 passed, 3 skipped`.
 - [x] Stage G: run all validation gates, mark roadmap item `2.4.2` done, and
   commit the implementation.
 
@@ -218,11 +216,11 @@ Success is observable in these behaviours:
 
 - Observation: `workflow_checkpoints` exists in the design document but not in
   the current SQLAlchemy model set. Evidence:
-  `docs/episodic-podcast-generation-system-design.md` describes the table,
-  while `episodic/canonical/storage/models.py` currently exposes canonical
-  tables such as `approval_events` and `episode_templates`. Impact: the
-  implementation probably needs a small migration and repository adapter
-  dedicated to checkpoint records.
+  `docs/episodic-podcast-generation-system-design.md` describes the table, while
+  `episodic/canonical/storage/models.py` currently exposes canonical tables
+  such as `approval_events` and `episode_templates`. Impact: the implementation
+  probably needs a small migration and repository adapter dedicated to
+  checkpoint records.
 
 - Observation: `langgraph` is already declared as a runtime dependency.
   Evidence: `pyproject.toml` contains `langgraph>=1.1,<2.0`. Impact: the

--- a/docs/execplans/2-4-3-configure-celery-queue-routing.md
+++ b/docs/execplans/2-4-3-configure-celery-queue-routing.md
@@ -569,7 +569,10 @@ request gates and must not be the only proof of routing correctness.
   3 skipped`.
 - [x] (2026-05-24T16:46:52Z) Ran final CodeRabbit review after deterministic
   gates; CodeRabbit reported no findings.
-- [ ] Commit, push, and update the draft pull request.
+- [x] (2026-05-24T16:49:45Z) Committed the documentation and roadmap close-out,
+  pushed branch `2-4-3-configure-celery-queue-routing`, and updated draft pull
+  request #106 with the implementation summary, validation results, CodeRabbit
+  status, execplan link, and Lody session reference.
 
 ## Surprises & Discoveries
 

--- a/docs/execplans/2-4-3-configure-celery-queue-routing.md
+++ b/docs/execplans/2-4-3-configure-celery-queue-routing.md
@@ -4,7 +4,7 @@ This ExecPlan (execution plan) is a living document. The sections `Constraints`,
  `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
 and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
-Status: IN PROGRESS
+Status: COMPLETE
 
 ## Purpose / big picture
 
@@ -548,11 +548,28 @@ request gates and must not be the only proof of routing correctness.
   `make check-fmt`, `make typecheck`, `make lint`, `make test`,
   `make markdownlint`, and `make nixie` all passed. The test run again passed
   with `664 passed, 3 skipped`.
-- [ ] Review whether Milestone 3 orchestration-facing workload intent is
-  required in this slice.
-- [ ] Update documentation and roadmap state.
-- [ ] Run final gates, CodeRabbit review, commit, push, and update the draft
-  pull request.
+- [x] (2026-05-24T16:19:43Z) Reviewed Milestone 3 orchestration-facing
+  workload intent. `GenerationOrchestrationRequest`, `TaskResumePort`, and
+  `resume_generation_orchestration(...)` remain provider-neutral and do not
+  dispatch Celery work yet, so this slice does not add a new route-intent DTO
+  or Vidai Mock scenario.
+- [x] (2026-05-24T16:19:43Z) Updated the design document, users' guide,
+  developers' guide, ADR-003, and ADR-007 to describe strict route-table
+  validation, full queue/exchange route metadata, and the worker-adapter
+  boundary.
+- [x] (2026-05-24T16:30:15Z) Ran documentation gates and CodeRabbit for the
+  documentation milestone. `make markdownlint` and `make nixie` passed, and
+  CodeRabbit reported no findings.
+- [x] (2026-05-24T16:30:15Z) Marked roadmap item `2.4.3` done after the
+  worker and documentation milestones had passed deterministic gates and
+  CodeRabbit review.
+- [x] (2026-05-24T16:46:52Z) Ran final gates: `make check-fmt`,
+  `make typecheck`, `make lint`, `make test`, `make markdownlint`, and
+  `make nixie` all passed. The final test run passed with `664 passed,
+  3 skipped`.
+- [x] (2026-05-24T16:46:52Z) Ran final CodeRabbit review after deterministic
+  gates; CodeRabbit reported no findings.
+- [ ] Commit, push, and update the draft pull request.
 
 ## Surprises & Discoveries
 
@@ -627,8 +644,30 @@ request gates and must not be the only proof of routing correctness.
   structural fields; there is no generated route parser or classifier whose
   behaviour ranges over arbitrary inputs.
 
+- Decision: Do not add orchestration-facing workload intent in this roadmap
+  slice. Rationale: the current LangGraph orchestration exposes request,
+  checkpoint, and resume ports but does not dispatch Celery tasks; adding a DTO
+  now would be speculative and would broaden the worker-boundary task beyond
+  workload isolation.
+
 ## Outcomes & Retrospective
 
-This section remains empty while the ExecPlan is in draft. During
-implementation, record what shipped, what changed from the plan, which gates
-passed, and any follow-up work that remains.
+Roadmap item `2.4.3` shipped as a worker-boundary hardening slice. The Celery
+topology still exposes one topic exchange, `episodic.tasks`, and the two
+durable queues `episodic.io` and `episodic.cpu`; route construction now
+validates task names and workload values before producing Celery route
+metadata. Representative scaffold tasks have an explicit task-name tuple and
+workload map, and task routes include queue, exchange, exchange type, and
+routing key.
+
+The implementation deliberately did not add LangGraph-to-Celery dispatch or a
+new orchestration workload-intent DTO because the current orchestration layer
+does not enqueue Celery work yet. This preserves the documented hexagonal
+boundary: orchestration stays provider-neutral, and the worker adapter owns
+Celery mechanics. Vidai Mock was not used because no LLM-backed behavioural
+route path changed.
+
+Validation completed with `make check-fmt`, `make typecheck`, `make lint`,
+`make test`, `make markdownlint`, and `make nixie`. CodeRabbit reviewed the
+worker milestone, the documentation milestone, and the final state; all
+findings were cleared, and the final review reported no findings.

--- a/docs/execplans/2-4-3-configure-celery-queue-routing.md
+++ b/docs/execplans/2-4-3-configure-celery-queue-routing.md
@@ -4,7 +4,7 @@ This ExecPlan (execution plan) is a living document. The sections `Constraints`,
  `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
 and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
-Status: DRAFT
+Status: IN PROGRESS
 
 ## Purpose / big picture
 
@@ -524,7 +524,35 @@ request gates and must not be the only proof of routing correctness.
 - [x] (2026-05-19T19:13:40Z) Committed this ExecPlan, pushed the branch, and
   opened draft pull request
   [#106](https://github.com/leynos/episodic/pull/106) for plan review.
-- [ ] Await explicit plan approval before implementation.
+- [x] (2026-05-24T00:00:00Z) Received explicit approval to proceed with the
+  planned implementation.
+- [x] (2026-05-24T00:00:00Z) Implemented Milestone 1 fail-first
+  route-contract tests and ran `make test` with output captured in
+  `/tmp/test-red-episodic-2-4-3-configure-celery-queue-routing.out`. The run
+  failed as expected with four failures covering missing exchange metadata,
+  missing `SCAFFOLD_TASK_NAMES`, and missing malformed route-table validation.
+- [x] (2026-05-24T15:59:35Z) Implemented Milestone 2 strict route
+  classification and metadata. The worker route builder now validates task
+  names and `WorkloadClass` values, scaffold task names are explicit, route
+  metadata includes `queue`, `exchange`, `exchange_type`, and `routing_key`,
+  and the BDD scenario asserts both exchange and queue targeting.
+- [x] (2026-05-24T15:59:35Z) Ran deterministic gates before CodeRabbit:
+  `make check-fmt`, `make typecheck`, `make lint`, `make test`,
+  `make markdownlint`, and `make nixie` all passed. The post-implementation
+  test run passed with `664 passed, 3 skipped`.
+- [x] (2026-05-24T16:11:21Z) Ran CodeRabbit for the implementation milestone.
+  CodeRabbit reported two minor findings asking for clearer assertion failure
+  messages in `tests/test_worker_routing_contract.py`; both were valid and
+  were applied.
+- [x] (2026-05-24T16:17:32Z) Re-ran gates after applying CodeRabbit findings:
+  `make check-fmt`, `make typecheck`, `make lint`, `make test`,
+  `make markdownlint`, and `make nixie` all passed. The test run again passed
+  with `664 passed, 3 skipped`.
+- [ ] Review whether Milestone 3 orchestration-facing workload intent is
+  required in this slice.
+- [ ] Update documentation and roadmap state.
+- [ ] Run final gates, CodeRabbit review, commit, push, and update the draft
+  pull request.
 
 ## Surprises & Discoveries
 
@@ -561,6 +589,12 @@ request gates and must not be the only proof of routing correctness.
   while the focused rerun and full rerun both passed. Impact: record it as a
   transient validation anomaly rather than a plan regression.
 
+- Observation: adding the fail-first unit coverage to
+  `tests/test_worker_service_scaffold.py` pushed that file over the Pylint
+  module length limit. Impact: the route-table tests were moved into
+  `tests/test_worker_routing_contract.py`, leaving scaffold execution tests in
+  the original module.
+
 ## Decision Log
 
 - Decision: Keep this ExecPlan in draft status and do not implement routing
@@ -587,6 +621,11 @@ request gates and must not be the only proof of routing correctness.
   parsed route inputs are introduced. Rationale: property tests add useful
   rigour for invariants over ranges of inputs, but a fixed constant route table
   is better covered by precise unit and behavioural tests.
+
+- Decision: Do not add property tests for this implementation milestone.
+  Rationale: the change keeps a fixed, explicit route table and validates only
+  structural fields; there is no generated route parser or classifier whose
+  behaviour ranges over arbitrary inputs.
 
 ## Outcomes & Retrospective
 

--- a/docs/execplans/2-4-3-configure-celery-queue-routing.md
+++ b/docs/execplans/2-4-3-configure-celery-queue-routing.md
@@ -1,16 +1,16 @@
 # Configure Celery queue routing for workload isolation
 
 This ExecPlan (execution plan) is a living document. The sections `Constraints`,
- `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
 and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 Status: COMPLETE
 
 ## Purpose / big picture
 
-Roadmap item `2.4.3` configures Celery queue routing, so the generation platform
-can isolate I/O-bound and CPU-bound work. I/O-bound work is work that spends
-most of its time waiting on network or storage operations, such as Large
+Roadmap item `2.4.3` configures Celery queue routing, so the generation
+platform can isolate I/O-bound and CPU-bound work. I/O-bound work is work that
+spends most of its time waiting on network or storage operations, such as Large
 Language Model (LLM) calls, tool calls, database calls, or resume callbacks.
 CPU-bound work is work that spends most of its time using processor cycles,
 such as local parsing, scoring, transcript analysis, or other deterministic
@@ -480,10 +480,10 @@ Use Vidai Mock for any behavioural test that proves route intent through an
 LLM-backed generation flow. Do not use Vidai Mock for pure topology, runtime,
 or Celery app configuration tests.
 
-Use property tests only when an introduced route resolver, parser, or classifier
-has a meaningful invariant over a range of inputs. A fixed mapping from
-constant task names to constant workload classes does not need property tests
-unless it gains generated input handling.
+Use property tests only when an introduced route resolver, parser, or
+classifier has a meaningful invariant over a range of inputs. A fixed mapping
+from constant task names to constant workload classes does not need property
+tests unless it gains generated input handling.
 
 Do not require live RabbitMQ for default validation. If an optional
 broker-backed target is added later, it must be separate from the default pull
@@ -514,16 +514,16 @@ request gates and must not be the only proof of routing correctness.
   `make check-fmt`, `make typecheck`, `make lint`, `make test`,
   `make markdownlint`, and `make nixie`. The first `make test` run hit one
   transient async fixture timeout after 660 passes; the focused failing test
-  passed on rerun, and the full `make test` rerun passed with `661 passed,
-  3 skipped`.
+  passed on rerun, and the full `make test` rerun passed with
+  `661 passed, 3 skipped`.
 - [x] (2026-05-19T18:48:27Z) Ran `coderabbit review --agent` for the planning
   milestone and applied all eight minor/trivial prose findings.
 - [x] (2026-05-19T19:00:12Z) Ran a CodeRabbit confirmation pass, applied two
   additional minor prose findings, and reran `make markdownlint` plus
   `make nixie` successfully.
 - [x] (2026-05-19T19:13:40Z) Committed this ExecPlan, pushed the branch, and
-  opened draft pull request
-  [#106](https://github.com/leynos/episodic/pull/106) for plan review.
+  opened draft pull request [#106](https://github.com/leynos/episodic/pull/106)
+  for plan review.
 - [x] (2026-05-24T00:00:00Z) Received explicit approval to proceed with the
   planned implementation.
 - [x] (2026-05-24T00:00:00Z) Implemented Milestone 1 fail-first
@@ -542,8 +542,8 @@ request gates and must not be the only proof of routing correctness.
   test run passed with `664 passed, 3 skipped`.
 - [x] (2026-05-24T16:11:21Z) Ran CodeRabbit for the implementation milestone.
   CodeRabbit reported two minor findings asking for clearer assertion failure
-  messages in `tests/test_worker_routing_contract.py`; both were valid and
-  were applied.
+  messages in `tests/test_worker_routing_contract.py`; both were valid and were
+  applied.
 - [x] (2026-05-24T16:17:32Z) Re-ran gates after applying CodeRabbit findings:
   `make check-fmt`, `make typecheck`, `make lint`, `make test`,
   `make markdownlint`, and `make nixie` all passed. The test run again passed
@@ -565,8 +565,8 @@ request gates and must not be the only proof of routing correctness.
   CodeRabbit review.
 - [x] (2026-05-24T16:46:52Z) Ran final gates: `make check-fmt`,
   `make typecheck`, `make lint`, `make test`, `make markdownlint`, and
-  `make nixie` all passed. The final test run passed with `664 passed,
-  3 skipped`.
+  `make nixie` all passed. The final test run passed with
+  `664 passed, 3 skipped`.
 - [x] (2026-05-24T16:46:52Z) Ran final CodeRabbit review after deterministic
   gates; CodeRabbit reported no findings.
 - [x] (2026-05-24T16:49:45Z) Committed the documentation and roadmap close-out,

--- a/docs/execplans/2-4-3-configure-celery-queue-routing.md
+++ b/docs/execplans/2-4-3-configure-celery-queue-routing.md
@@ -521,8 +521,9 @@ request gates and must not be the only proof of routing correctness.
 - [x] (2026-05-19T19:00:12Z) Ran a CodeRabbit confirmation pass, applied two
   additional minor prose findings, and reran `make markdownlint` plus
   `make nixie` successfully.
-- [ ] Commit this ExecPlan, push the branch, and open a draft pull request for
-  plan review.
+- [x] (2026-05-19T19:13:40Z) Committed this ExecPlan, pushed the branch, and
+  opened draft pull request
+  [#106](https://github.com/leynos/episodic/pull/106) for plan review.
 - [ ] Await explicit plan approval before implementation.
 
 ## Surprises & Discoveries

--- a/docs/execplans/2-4-3-configure-celery-queue-routing.md
+++ b/docs/execplans/2-4-3-configure-celery-queue-routing.md
@@ -1,0 +1,594 @@
+# Configure Celery queue routing for workload isolation
+
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+ `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+Status: DRAFT
+
+## Purpose / big picture
+
+Roadmap item `2.4.3` configures Celery queue routing, so the generation platform
+can isolate I/O-bound and CPU-bound work. I/O-bound work is work that spends
+most of its time waiting on network or storage operations, such as Large
+Language Model (LLM) calls, tool calls, database calls, or resume callbacks.
+CPU-bound work is work that spends most of its time using processor cycles,
+such as local parsing, scoring, transcript analysis, or other deterministic
+batch computation.
+
+After this change, enqueueable worker tasks have an explicit workload
+classification. I/O-bound tasks route to the durable `episodic.io` queue with
+routing keys under `episodic.io.#`, and operators can run those workers with a
+high-concurrency greenlet pool such as `gevent` or `eventlet`. CPU-bound tasks
+route to the durable `episodic.cpu` queue with routing keys under
+`episodic.cpu.#`, and operators can run those workers with the Celery `prefork`
+pool. A maintainer can inspect the Celery application configuration and see
+that every registered worker task used by this roadmap slice is mapped to a
+queue intentionally rather than falling through to the default I/O route.
+
+This plan does not implement cost-ledger persistence from roadmap item `2.4.4`,
+budget enforcement from later roadmap items, or a mandatory live RabbitMQ
+integration harness. The default validation remains brokerless and
+contract-level, matching Architecture Decision Record (ADR) 003. A later
+roadmap slice may add live RabbitMQ dispatch coverage on top of the same
+topology without changing the boundary.
+
+Success is observable in these behaviours:
+
+1. `episodic/worker/topology.py` remains the single source of truth for the
+   topic exchange, workload classes, durable queues, routing-key families, and
+   task-route metadata.
+2. `episodic/worker/runtime.py` builds a Celery app whose `task_queues`,
+   `task_routes`, default queue and worker launch profiles preserve the
+   documented I/O versus CPU split.
+3. Any production or representative worker task introduced by this roadmap
+   item is explicitly classified as I/O-bound or CPU-bound before it can be
+   routed.
+4. Unit tests fail before the implementation when a route is missing,
+   malformed, duplicated, or assigned to the wrong workload class, and pass
+   after the implementation.
+5. Behavioural tests using `rstest-bdd` or the repository's Python BDD pattern
+   show an operator inspecting the worker routing and seeing distinct I/O and
+   CPU queue contracts. If an orchestration-facing behavioural path uses LLM
+   calls, it uses Vidai Mock rather than a live provider.
+6. Property tests using `proptest` for Rust code, or Hypothesis for Python
+   code, cover route-key invariants if the implementation introduces a
+   non-trivial route resolver or parser over a range of task names or workload
+   labels.
+7. Documentation records the route contract for users, maintainers, and design
+   readers. The roadmap entry is marked done only after implementation,
+   documentation, validation, CodeRabbit review and commit gates succeed.
+
+## Constraints
+
+- Implementation must not start until this ExecPlan is explicitly approved.
+- Preserve hexagonal architecture boundaries. Domain and application code must
+  not import Celery, Kombu, RabbitMQ client types, Falcon resources, SQLAlchemy
+  adapters, or concrete LLM provider clients.
+- Keep queue topology and broker mechanics inside the worker adapter boundary:
+  `episodic/worker/topology.py`, `episodic/worker/runtime.py`, and narrowly
+  scoped worker task registration modules.
+- LangGraph orchestration code may emit typed workload intent through ports or
+  data transfer objects (DTOs), but route resolution and Celery configuration
+  remain adapter concerns.
+- Celery tasks must stay single-responsibility and idempotent. Task bodies
+  should use typed payload DTOs and injected dependencies rather than reaching
+  directly into storage, HTTP, LLM, or queue adapters.
+- Do not add a mandatory live RabbitMQ dependency to the default validation
+  path. Broker-backed dispatch tests may be added only as an optional explicit
+  target if the repository already has stable infrastructure for it.
+- Do not add new runtime dependencies without escalation. The plan should use
+  Celery, Kombu, existing test tools, Vidai Mock where applicable, and existing
+  repository patterns.
+- Use official Celery semantics for routing and worker launch documentation:
+  `task_routes`, `task_queues`, routing keys, `-Q` queue selection, `--pool`,
+  `--concurrency`, and `--autoscale`.
+- Use Vidai Mock only for behavioural tests that exercise inference or
+  orchestration flows requiring deterministic LLM responses. Pure routing and
+  topology tests must not start Vidai Mock.
+- Keep roadmap scope limited to workload isolation. Do not implement
+  cost-accounting persistence, pricing catalogues, budget breach alerts, public
+  generation-run APIs, or deeper audit ledger work in this change.
+- Update `docs/episodic-podcast-generation-system-design.md`,
+  `docs/users-guide.md`, `docs/developers-guide.md`, relevant ADRs, and
+  `docs/roadmap.md` when implementation lands.
+- Run validation commands sequentially, not in parallel:
+  `make check-fmt`, `make typecheck`, `make lint`, and `make test`. For
+  documentation changes, also run `make markdownlint` and `make nixie`. Capture
+  long command output with `tee` under `/tmp`.
+- Run `coderabbit review --agent` after each major implementation milestone
+  and clear all concerns before moving to the next milestone.
+- Commit each approved, validated logical change with a file-based commit
+  message using `git commit -F`.
+
+## Tolerances (exception triggers)
+
+- Scope: stop and escalate if implementation requires more than 16 changed
+  files or 900 net new lines before validation passes.
+- Interface: stop and escalate if an incompatible public signature change is
+  required for existing worker factories, orchestration DTOs, `LLMPort`,
+  checkpoint ports, Falcon resources, or canonical repository ports.
+- Dependency: stop and escalate if routing cannot be implemented without a new
+  runtime package, a new broker service in default tests, or a new external
+  test service beyond Vidai Mock.
+- Boundary: stop and escalate if practical implementation requires domain,
+  canonical, or application services to import Celery, Kombu, RabbitMQ,
+  SQLAlchemy adapters, concrete OpenAI clients, or Falcon resources.
+- Ambiguity: stop and present options if unknown task behaviour could mean
+  either strict fail-fast classification or fallback-to-default routing because
+  that choice materially affects workload isolation.
+- Orchestration coupling: stop and escalate if route intent cannot be added
+  without redesigning LangGraph execution or changing checkpoint persistence
+  semantics from roadmap item `2.4.2`.
+- Testing: stop and escalate if focused routing tests still fail after three
+  implementation attempts, or if full `make test` still fails after two
+  unrelated-failure triage passes.
+- Infrastructure: stop and escalate if a live RabbitMQ harness becomes
+  necessary to prove the acceptance criteria.
+- CodeRabbit: stop and escalate if `coderabbit review --agent` reports a
+  concern that requires changing approved scope or cannot be cleared locally.
+
+## Risks
+
+- Risk: unclassified tasks may silently fall back to the default I/O queue,
+  defeating workload isolation. Severity: high. Likelihood: medium. Mitigation:
+  require explicit task-to-workload mappings for every registered worker task
+  in scope, and test route map completeness.
+
+- Risk: worker launch profiles may describe the intended pools, while
+  operators can still start workers with mismatched `-Q`, `--pool`, or
+  `--concurrency` command-line options. Severity: medium. Likelihood: medium.
+  Mitigation: document launch commands and keep `WorkerLaunchProfile` as the
+  canonical operator contract; do not pretend code can enforce external process
+  flags unless a launch wrapper is explicitly added.
+
+- Risk: broadening routing from diagnostic tasks to workflow tasks could
+  introduce Celery imports into orchestration or domain code. Severity: high.
+  Likelihood: medium. Mitigation: confine Celery and Kombu to worker runtime
+  and topology modules; pass workload intent through typed ports, DTOs, or
+  dependency seams.
+
+- Risk: testing with eager Celery execution can prove route metadata and task
+  registration, but not a full RabbitMQ publish/consume round trip. Severity:
+  medium. Likelihood: high. Mitigation: keep the acceptance claim precise,
+  document the brokerless scope, and leave a later live-dispatch follow-up if
+  needed.
+
+- Risk: greenlet pools such as `gevent` and `eventlet` may have feature
+  limitations compared with `prefork`, including timeout behaviour. Severity:
+  medium. Likelihood: medium. Mitigation: route only I/O-bound work to greenlet
+  pools by default, and document that CPU-bound work uses prefork.
+
+- Risk: property tests over routing keys may overconstrain valid Advanced
+  Message Queuing Protocol (AMQP) topic patterns. Severity: low. Likelihood:
+  medium. Mitigation: keep invariants aligned with the repository's accepted
+  taxonomy, not every possible AMQP routing pattern.
+
+- Risk: Vidai Mock could be applied to pure routing tests unnecessarily,
+  slowing the suite and obscuring failures. Severity: low. Likelihood: medium.
+  Mitigation: use Vidai Mock only when the route decision is observed through
+  an LLM-backed orchestration scenario.
+
+## Relevant documentation and skills
+
+Use these repository documents while implementing the plan:
+
+- `docs/roadmap.md`, especially roadmap item `2.4.3`.
+- `docs/episodic-podcast-generation-system-design.md`, especially
+  "LangGraph Integration Principles", "Control and data plane separation",
+  "Execution patterns for long-running tasks", and "Orchestration ports and
+  adapters".
+- `docs/agentic-systems-with-langgraph-and-celery.md`, especially the sections
+  on RabbitMQ routing, I/O-bound worker pools, CPU-bound worker pools, and
+  suspend-and-resume task patterns.
+- `docs/langgraph-and-celery-in-hexagonal-architecture.md`, especially the
+  sections warning against Celery tasks bypassing ports.
+- `docs/async-sqlalchemy-with-pg-and-falcon.md`,
+  `docs/testing-async-falcon-endpoints.md`, and
+  `docs/testing-sqlalchemy-with-pytest-and-py-pglite.md` if a routing change
+  touches persistence, HTTP, or integration fixtures. The expected
+  implementation should not require those surfaces.
+- `docs/users-guide.md` for operator-visible worker configuration.
+- `docs/developers-guide.md` for maintainer-facing task registration and
+  routing conventions.
+- `docs/adr/adr-003-celery-worker-scaffold.md` for the accepted worker
+  topology and brokerless test scope.
+- `docs/adr/adr-007-durable-generation-checkpoints.md` because it currently
+  treats Celery routing as later work.
+
+Apply these Codex skills while implementing the plan:
+
+- `leta` for code navigation and refactoring.
+- `hexagonal-architecture` for boundary checks around ports and adapters.
+- `execplans` for maintaining this living plan.
+- `vidai-mock` only for LLM-backed behavioural tests.
+- `rust-router` and the smallest relevant Rust skill if the implementation
+  touches Rust code. The likely implementation is Python only.
+- `commit-message` for file-based commits.
+- `pr-creation` and `en-gb-oxendict-style` for pull request preparation.
+
+External references consulted for this plan:
+
+- Celery's routing guide documents `task_routes`, `task_queues`, routing keys,
+  named queues, and `celery worker -Q queue_a,queue_b` queue selection.
+- Celery's concurrency guide identifies `prefork` as the default and preferred
+  pool for CPU-bound tasks, and `gevent` or `eventlet` as I/O-oriented greenlet
+  pools with feature limitations.
+- Celery's worker guide documents `--concurrency`, `--autoscale`,
+  `--max-tasks-per-child`, `--max-memory-per-child`, and queue selection with
+  `-Q`.
+
+## Repository orientation
+
+The existing worker scaffold is already close to the target shape.
+`episodic/worker/topology.py` defines `WorkerTopology`, `WorkerQueueSpec`,
+`WorkloadClass`, and `DEFAULT_WORKER_TOPOLOGY`. The default topology uses one
+durable topic exchange, `episodic.tasks`, and two durable queues: `episodic.io`
+with binding key `episodic.io.#`, and `episodic.cpu` with binding key
+`episodic.cpu.#`.
+
+`episodic/worker/runtime.py` defines `WorkerRuntimeConfig`,
+`WorkerLaunchProfile`, `load_runtime_config(...)`,
+`build_worker_launch_profiles(...)`, `create_celery_app(...)`, and
+`create_celery_app_from_env()`. The runtime validates an AMQP broker URL,
+configures JSON serialization, disables missing queue creation, sets the
+default queue, registers known task routes, and exposes pool/concurrency
+profiles.
+
+`episodic/worker/tasks.py` defines representative diagnostic task names,
+payload/result DTOs, `WorkerDependencies`, `SCAFFOLD_TASK_WORKLOADS`, and
+`register_scaffold_tasks(...)`. Existing tests cover the diagnostic route
+contract, but future implementation should tighten the contract so new routed
+tasks cannot be registered without an explicit workload classification.
+
+The orchestration package currently owns LangGraph control flow, checkpoint
+DTOs, ports, and result aggregation under `episodic/orchestration/`. Any route
+intent added there must remain provider-neutral. Do not import Celery or Kombu
+from orchestration modules.
+
+## Implementation plan
+
+### Milestone 1: confirm the current routing contract and write fail-first tests
+
+Before changing production code, inspect the current symbols with Leta:
+
+```bash
+leta show episodic/worker/topology.py:WorkerTopology
+leta show episodic/worker/topology.py:WorkerQueueSpec
+leta show episodic/worker/runtime.py:create_celery_app
+leta show episodic/worker/runtime.py:build_worker_launch_profiles
+leta show episodic/worker/tasks.py:register_scaffold_tasks
+```
+
+Then add focused tests that express the final behaviour. Use the existing
+`tests/test_worker_service_scaffold.py` style for unit tests and the existing
+`tests/features/worker_service_scaffold.feature` plus
+`tests/steps/test_worker_service_scaffold_steps.py` style for behavioural
+tests. These tests should fail before the implementation if the current
+scaffold still allows the gap being closed.
+
+Plan the following unit tests:
+
+1. Every task registered by the worker module has exactly one explicit
+   workload classification.
+2. Route metadata for each classified task includes queue, exchange and
+   routing key values that match the queue binding family for the workload.
+3. Unknown workloads or malformed task names fail predictably instead of
+   producing an accidental default route.
+4. `task_create_missing_queues` remains false, and the configured queues are
+   exactly the durable topology queues.
+5. Worker launch profiles continue to map I/O workloads to `gevent` or another
+   configured I/O pool with high concurrency and CPU workloads to `prefork`
+   with lower concurrency.
+
+Plan the following behavioural tests:
+
+1. An operator creates the worker app from environment configuration and sees
+   I/O tasks routed to `episodic.io` with `episodic.io.*` routing keys.
+2. The same operator sees CPU tasks routed to `episodic.cpu` with
+   `episodic.cpu.*` routing keys.
+3. Invalid route metadata fails during app construction or topology
+   construction with a clear error.
+
+If a non-trivial route-key builder or parser is introduced, add a property test
+that checks generated route keys are non-empty, contain no empty topic
+segments, stay within the accepted `episodic.io.*` or `episodic.cpu.*`
+families, and never map one task to two workloads. If the implementation is a
+small constant mapping with existing validation, document in this plan why
+property tests would not add useful rigour.
+
+Run the focused tests and record the expected red result in `Progress`. Use
+`tee` for output:
+
+```bash
+make test 2>&1 | tee /tmp/test-episodic-2-4-3-configure-celery-queue-routing.out
+```
+
+Stop at this milestone if the failing tests reveal that the roadmap task
+requires choosing between strict unknown-task rejection and default fallback
+routing.
+
+### Milestone 2: implement explicit route classification and safe route metadata
+
+Implement the smallest worker-boundary change that makes the fail-first tests
+pass. The likely code paths are:
+
+- `episodic/worker/tasks.py` for task names, typed task payloads and explicit
+  task-to-workload mappings.
+- `episodic/worker/topology.py` for route-building validation, queue binding
+  invariants and any helper that resolves a task's workload to route metadata.
+- `episodic/worker/runtime.py` for wiring the stricter route map into Celery
+  app configuration and worker launch profiles.
+- `episodic/worker/__init__.py` if a new helper or DTO becomes part of the
+  worker module's public surface.
+
+Prefer a route table that is explicit and auditable over pattern-matching task
+names. If a helper is needed, name it in worker language, such as
+`build_task_routes` or `route_for_task`, and keep it independent of domain
+entities. Make sure the helper returns Celery-compatible route metadata without
+forcing callers outside the worker boundary to import Celery.
+
+Do not broaden the default queue as a substitute for classification. If the
+implementation keeps a default I/O queue for Celery compatibility, tests, and
+documentation must say that the default is not a licence for unclassified
+production tasks.
+
+Run focused tests after the implementation:
+
+```bash
+make test 2>&1 | tee /tmp/test-episodic-2-4-3-configure-celery-queue-routing.out
+```
+
+Then run:
+
+```bash
+coderabbit review --agent 2>&1 | tee /tmp/coderabbit-episodic-2-4-3-configure-celery-queue-routing.out
+```
+
+Clear any CodeRabbit concerns before continuing.
+
+### Milestone 3: connect orchestration-facing workload intent only if needed
+
+Inspect whether the generation orchestration introduced by roadmap item `2.4.2`
+needs to dispatch route-aware Celery work in this slice. Use Leta on the
+orchestration symbols before editing:
+
+```bash
+leta show episodic/orchestration/_dto.py:GenerationOrchestrationRequest
+leta show episodic/orchestration/_protocols.py:TaskResumePort
+leta show episodic/orchestration/langgraph.py:resume_generation_orchestration
+```
+
+If no orchestration task dispatch exists yet, do not invent a full dispatch
+adapter. Instead, document that `2.4.3` hardens the worker routing contract and
+leaves actual LangGraph-to-Celery dispatch to the next roadmap item that adds
+real asynchronous generation tasks.
+
+If orchestration does need to express route intent in this slice, add a small
+provider-neutral DTO or enum that says whether a step is I/O-bound or
+CPU-bound. The worker adapter may translate that intent into Celery route
+metadata. The orchestration module must not import Celery, Kombu or RabbitMQ
+types.
+
+Use Vidai Mock only if the route intent is observed through an LLM-backed
+generation behavioural scenario. Start with the existing
+`tests/steps/test_generation_orchestration_steps.py` pattern rather than
+creating a separate mock inference harness.
+
+Run focused orchestration or BDD tests with `tee`, then run CodeRabbit again if
+this milestone changes production code.
+
+### Milestone 4: update documentation and decision records
+
+Update documentation after code behaviour is stable:
+
+- `docs/episodic-podcast-generation-system-design.md` should describe the
+  finalized worker route contract, the I/O and CPU routing-key families, and
+  the boundary rule that orchestration emits workload intent while worker
+  adapters own Celery configuration.
+- `docs/users-guide.md` should describe operator-visible worker configuration:
+  queue names, routing keys, recommended worker launch options, and the fact
+  that default validation does not require live RabbitMQ.
+- `docs/developers-guide.md` should explain how maintainers add a new routed
+  task: define a typed payload, classify the task, add tests, and avoid adapter
+  leakage.
+- `docs/adr/adr-003-celery-worker-scaffold.md` should be updated if the
+  scaffold route contract becomes stricter or if representative tasks are
+  joined by production workflow tasks.
+- `docs/adr/adr-007-durable-generation-checkpoints.md` should stop describing
+  Celery routing as entirely future work once this item lands.
+- Add a new ADR only if implementation makes a substantive new decision beyond
+  ADR-003, such as strict unknown-task rejection, a new route-intent DTO, or a
+  launch wrapper contract.
+- `docs/roadmap.md` should be marked done only at the end, after validation
+  and CodeRabbit review pass.
+
+Run documentation validation:
+
+```bash
+make markdownlint 2>&1 | tee /tmp/markdownlint-episodic-2-4-3-configure-celery-queue-routing.out
+make nixie 2>&1 | tee /tmp/nixie-episodic-2-4-3-configure-celery-queue-routing.out
+```
+
+Run CodeRabbit again after the documentation milestone and clear all concerns.
+
+### Milestone 5: run full gates, commit, push and open the draft pull request
+
+Run the required gates sequentially:
+
+```bash
+make check-fmt 2>&1 | tee /tmp/check-fmt-episodic-2-4-3-configure-celery-queue-routing.out
+make typecheck 2>&1 | tee /tmp/typecheck-episodic-2-4-3-configure-celery-queue-routing.out
+make lint 2>&1 | tee /tmp/lint-episodic-2-4-3-configure-celery-queue-routing.out
+make test 2>&1 | tee /tmp/test-episodic-2-4-3-configure-celery-queue-routing.out
+make markdownlint 2>&1 | tee /tmp/markdownlint-episodic-2-4-3-configure-celery-queue-routing.out
+make nixie 2>&1 | tee /tmp/nixie-episodic-2-4-3-configure-celery-queue-routing.out
+```
+
+If all gates pass, mark roadmap item `2.4.3` done, update this ExecPlan's
+living sections, run the relevant documentation gates again if
+`docs/roadmap.md` changed, and commit. Use the `commit-message` skill and a
+temporary message file:
+
+```bash
+git status --short
+git diff --check
+git add <changed files>
+git diff --cached
+git commit -F "$COMMIT_MSG_FILE"
+```
+
+Push the branch so it tracks `origin/2-4-3-configure-celery-queue-routing`,
+then open a draft pull request. The pull request title must include `(2.4.3)`,
+and the summary must mention this ExecPlan:
+`docs/execplans/2-4-3-configure-celery-queue-routing.md`.
+
+Run:
+
+```bash
+echo ${LODY_SESSION_ID}
+```
+
+Include the session link in the pull request body's final `## References`
+section as:
+
+```plaintext
+https://lody.ai/leynos/sessions/${LODY_SESSION_ID}
+```
+
+## Validation strategy
+
+The implementation uses red-green-refactor discipline. Tests are written or
+updated first, then production code is changed, then documentation is aligned.
+
+The minimum validation set is:
+
+```bash
+make check-fmt
+make typecheck
+make lint
+make test
+make markdownlint
+make nixie
+```
+
+Use focused pytest invocations only while iterating, but final acceptance
+requires the full gates above. Commands must run sequentially, with output
+captured to `/tmp/*-episodic-2-4-3-configure-celery-queue-routing.out`.
+
+Use Vidai Mock for any behavioural test that proves route intent through an
+LLM-backed generation flow. Do not use Vidai Mock for pure topology, runtime,
+or Celery app configuration tests.
+
+Use property tests only when an introduced route resolver, parser, or classifier
+has a meaningful invariant over a range of inputs. A fixed mapping from
+constant task names to constant workload classes does not need property tests
+unless it gains generated input handling.
+
+Do not require live RabbitMQ for default validation. If an optional
+broker-backed target is added later, it must be separate from the default pull
+request gates and must not be the only proof of routing correctness.
+
+## Progress
+
+- [x] (2026-05-19T18:20:50Z) Loaded the `leta`,
+  `hexagonal-architecture`, `execplans`, `firecrawl-mcp`, `vidai-mock`,
+  `commit-message`, `pr-creation`, `en-gb-oxendict-style`, and `rust-router`
+  skills relevant to planning this task.
+- [x] (2026-05-19T18:20:50Z) Created a Leta workspace for this repository with
+  `leta workspace add`.
+- [x] (2026-05-19T18:20:50Z) Confirmed the branch was
+  `feat/celery-routing-execplan` and renamed it locally to
+  `2-4-3-configure-celery-queue-routing`.
+- [x] (2026-05-19T18:20:50Z) Reviewed `AGENTS.md`, `docs/roadmap.md`, the
+  existing `2.4.2` ExecPlan, the worker scaffold, worker tests, and the
+  relevant design and ADR context.
+- [x] (2026-05-19T18:20:50Z) Used Firecrawl to consult official Celery routing,
+  concurrency, and worker documentation for route and pool terminology.
+- [x] (2026-05-19T18:20:50Z) Used a Wyvern agent team to review likely
+  implementation scope, architecture and documentation impacts, and validation
+  strategy.
+- [x] (2026-05-19T18:20:50Z) Drafted this pre-implementation ExecPlan for
+  roadmap item `2.4.3`.
+- [x] (2026-05-19T18:48:27Z) Validated this planning-only Markdown change with
+  `make check-fmt`, `make typecheck`, `make lint`, `make test`,
+  `make markdownlint`, and `make nixie`. The first `make test` run hit one
+  transient async fixture timeout after 660 passes; the focused failing test
+  passed on rerun, and the full `make test` rerun passed with `661 passed,
+  3 skipped`.
+- [x] (2026-05-19T18:48:27Z) Ran `coderabbit review --agent` for the planning
+  milestone and applied all eight minor/trivial prose findings.
+- [x] (2026-05-19T19:00:12Z) Ran a CodeRabbit confirmation pass, applied two
+  additional minor prose findings, and reran `make markdownlint` plus
+  `make nixie` successfully.
+- [ ] Commit this ExecPlan, push the branch, and open a draft pull request for
+  plan review.
+- [ ] Await explicit plan approval before implementation.
+
+## Surprises & Discoveries
+
+- Observation: the existing worker scaffold already defines `episodic.io` and
+  `episodic.cpu` queues, workload launch profiles, and eager-mode behavioural
+  tests. Impact: implementation should harden and extend the route contract
+  rather than replace the scaffold.
+
+- Observation: `create_celery_app(...)` currently configures the default queue
+  as the I/O queue. Impact: implementation must decide and document whether
+  unclassified production tasks fail fast, or whether Celery's default remains
+  only a compatibility fallback.
+
+- Observation: ADR-003 deliberately keeps worker behavioural coverage
+  brokerless. Impact: this roadmap item should not require live RabbitMQ unless
+  the user explicitly approves a broader integration-test slice.
+
+- Observation: official Celery documentation supports explicit `task_routes`
+  and `task_queues`, queue selection with `-Q`, `prefork` for CPU-bound work,
+  and `gevent` or `eventlet` for I/O-bound work. Impact: the repository's
+  design terminology matches Celery's documented operational model.
+
+- Observation: the Wyvern agents could not inspect the MCP context pack even
+  though it was created in this parent session. Impact: future agent teams may
+  need direct file references as well as context pack identifiers.
+
+- Observation: `make fmt` rewrote many existing Markdown files outside this
+  planning task. Impact: those formatter-only side effects were restored
+  because the worktree was clean before the command, and this branch should
+  carry only the new ExecPlan.
+
+- Observation: the first full `make test` run reported one timeout in
+  `test_list_endpoints_reject_invalid_pagination` during async fixture setup,
+  while the focused rerun and full rerun both passed. Impact: record it as a
+  transient validation anomaly rather than a plan regression.
+
+## Decision Log
+
+- Decision: Keep this ExecPlan in draft status and do not implement routing
+  until explicit approval is received. Rationale: the `execplans` skill
+  requires an approval gate, and the user explicitly said the plan must be
+  approved before implementation.
+
+- Decision: Treat default validation as brokerless and contract-level.
+  Rationale: ADR-003 already accepted eager-mode routing tests for the worker
+  scaffold, and the roadmap item can prove route configuration without a live
+  RabbitMQ dependency.
+
+- Decision: Use strict route classification as the preferred implementation
+  direction while preserving escalation if default fallback semantics are
+  required. Rationale: workload isolation is weakened if new tasks silently
+  route to the I/O queue by default.
+
+- Decision: Use Vidai Mock only for orchestration-facing behavioural tests that
+  need deterministic inference responses. Rationale: topology and Celery
+  configuration are pure routing concerns and should not depend on an inference
+  simulator.
+
+- Decision: Plan for Hypothesis or property-test coverage only if generated or
+  parsed route inputs are introduced. Rationale: property tests add useful
+  rigour for invariants over ranges of inputs, but a fixed constant route table
+  is better covered by precise unit and behavioural tests.
+
+## Outcomes & Retrospective
+
+This section remains empty while the ExecPlan is in draft. During
+implementation, record what shipped, what changed from the plan, which gates
+passed, and any follow-up work that remains.

--- a/docs/execplans/3-2-1-llm-port-adapter.md
+++ b/docs/execplans/3-2-1-llm-port-adapter.md
@@ -1,9 +1,8 @@
 # Implement the Large Language Model (LLM) `LLMPort` adapter with retries, token budgeting, and template guardrails
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 No `PLANS.md` file is present in the repository root.
 

--- a/docs/execplans/femtologging-april-2026-migration.md
+++ b/docs/execplans/femtologging-april-2026-migration.md
@@ -1,9 +1,8 @@
 # Migrate episodic to femtologging v0.1.0 API at SHA 691a73962df8f99308a82348d99c4f707c245e63
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision log`, and `Outcomes & retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision log`,
+and `Outcomes & retrospective` must be kept up to date as work proceeds.
 
 Status: COMPLETE
 

--- a/docs/execplans/roadmap-normalization.md
+++ b/docs/execplans/roadmap-normalization.md
@@ -1,9 +1,8 @@
 # Normalize the development roadmap to Phases / Steps / Tasks structure
 
-This ExecPlan (execution plan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`,
-`Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work
-proceeds.
+This ExecPlan (execution plan) is a living document. The sections `Constraints`,
+`Tolerances`, `Risks`, `Progress`, `Surprises & Discoveries`, `Decision Log`,
+and `Outcomes & Retrospective` must be kept up to date as work proceeds.
 
 No `PLANS.md` file is present in the repository root.
 

--- a/docs/execplans/update-to-tei-rapporteur-with-type-hints.md
+++ b/docs/execplans/update-to-tei-rapporteur-with-type-hints.md
@@ -1,7 +1,7 @@
 # Update tei-rapporteur pin and remove local Text Encoding Initiative (TEI) typing shims
 
-This execution plan (ExecPlan) is a living document. The sections
-`Constraints`, `Tolerances`, `Risks`, `Progress`, `Surprises and discoveries`,
+This execution plan (ExecPlan) is a living document. The sections `Constraints`,
+`Tolerances`, `Risks`, `Progress`, `Surprises and discoveries`,
 `Decision log`, and `Outcomes and retrospective` must be kept up to date as
 work proceeds.
 

--- a/docs/execplans/upgrade-python-to-3-14-adopt-custom-task-factory-support.md
+++ b/docs/execplans/upgrade-python-to-3-14-adopt-custom-task-factory-support.md
@@ -133,10 +133,10 @@ Validation summary:
 
 ## Context and orientation
 
-Python 3.14 extends task-creation plumbing so keyword arguments can flow
-through `asyncio.create_task()` and `TaskGroup.create_task()` into custom loop
-task factories. Episodic currently uses async orchestration in canonical
-ingestion but lacks central task instrumentation.
+Python 3.14 extends task-creation plumbing so keyword arguments can flow through
+`asyncio.create_task()` and `TaskGroup.create_task()` into custom loop task
+factories. Episodic currently uses async orchestration in canonical ingestion
+but lacks central task instrumentation.
 
 Relevant files:
 
@@ -158,9 +158,9 @@ instances correctly. Include negative tests for unsupported keys or defaults.
 
 Stage C implements utilities and migration. Add a shared helper for task
 creation that forwards metadata kwargs, then migrate one code path (for
-example, source normalization fan-out in ingestion service) to
-`TaskGroup`/create_task with metadata. Keep result ordering and exception
-behaviour explicit.
+example, source normalization fan-out in ingestion service) to `TaskGroup`
+/create_task with metadata. Keep result ordering and exception behaviour
+explicit.
 
 Stage D validates and documents. Run full gates and add short developer
 guidance for when to use task metadata and when to avoid it.

--- a/docs/langgraph-and-celery-in-hexagonal-architecture.md
+++ b/docs/langgraph-and-celery-in-hexagonal-architecture.md
@@ -432,7 +432,7 @@ within a Hexagonal Architecture if used with discipline:
 
 Normative orchestration guardrails are defined in
 [Orchestration guardrails](episodic-podcast-generation-system-design.md#orchestration-guardrails)
- and serve as the source of truth for port-only dependencies, checkpoint
+and serve as the source of truth for port-only dependencies, checkpoint
 payload boundaries, and idempotency requirements. This document focuses on
 boundary risks and alignment, while implementation details should defer to the
 system design guardrails.

--- a/docs/reference-binding-resolution.md
+++ b/docs/reference-binding-resolution.md
@@ -130,8 +130,8 @@ async with SqlAlchemyUnitOfWork(session_factory) as uow:
     )
 ```
 
-Legacy keyword arguments such as `ingestion_job_id`, `canonical_episode_id`,
-and `created_at` are no longer accepted directly by
+Legacy keyword arguments such as `ingestion_job_id`, `canonical_episode_id`, and
+`created_at` are no longer accepted directly by
 `snapshot_resolved_bindings()`. Callers must pass a `SnapshotContext` instance
 instead.
 

--- a/docs/reliable-testing-in-rust-via-dependency-injection.md
+++ b/docs/reliable-testing-in-rust-via-dependency-injection.md
@@ -2,8 +2,8 @@
 
 Writing robust, reliable, and parallelizable tests requires an intentional
 approach to handling external dependencies such as environment variables, the
-filesystem, or the system clock. Functions that directly call `std::env::var`
-or `SystemTime::now()` are difficult to test because they depend on global,
+filesystem, or the system clock. Functions that directly call `std::env::var` or
+`SystemTime::now()` are difficult to test because they depend on global,
 non-deterministic state.
 
 This leads to several problems:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -256,7 +256,7 @@ metering. Completion enables reliable, auditable generation workflows.
   - Define idempotency keys for each workflow step.
   - See
     [LangGraph Integration Principles](episodic-podcast-generation-system-design.md#langgraph-integration-principles).
-- [ ] 2.4.3. Configure Celery queue routing for workload isolation.
+- [x] 2.4.3. Configure Celery queue routing for workload isolation.
   - Route I/O-bound tasks to high-concurrency pools.
   - Route CPU-bound tasks to prefork pools.
 - [ ] 2.4.4. Instrument cost accounting with per-call usage metering.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -162,9 +162,9 @@ generation runs via the API. Success is observable when generated scripts
 achieve defined quality thresholds, pass brand guideline checks, and cost
 ledgers report per-episode spend with budget breach alerts. See
 [Content Generation Orchestrator](episodic-podcast-generation-system-design.md#content-generation-orchestrator)
- and
+and
 [Quality Assurance Stack](episodic-podcast-generation-system-design.md#quality-assurance-stack)
- for design context.
+for design context.
 
 ### 2.1. LLM adapter and guardrails
 
@@ -637,7 +637,6 @@ design source-to-script vertical slice], and the [TUI API source-to-script
 vertical slice].
 
 [system design source-to-script vertical slice]: episodic-podcast-generation-system-design.md#source-to-script-vertical-slice
-
 [TUI API source-to-script vertical slice]: episodic-tui-api-design.md#source-to-script-vertical-slice
 
 - [ ] 4.3.1. Implement source and presenter-profile intake for script
@@ -836,7 +835,7 @@ boundaries enforce clean architecture, and observability instruments all layers
 with logging, metrics, and distributed tracing. See
 [infrastructure-design.md](infrastructure-design.md) and
 [Architectural Summary](episodic-podcast-generation-system-design.md#architectural-summary)
- for design context.
+for design context.
 
 ### 6.1. Infrastructure provisioning
 

--- a/docs/rust-doctest-dry-guide.md
+++ b/docs/rust-doctest-dry-guide.md
@@ -14,8 +14,8 @@ the power and the inherent limitations of doctests.
 ### 1.1 The "Separate Crate" Paradigm
 
 At its heart, `rustdoc` treats each documentation test not as a snippet of code
-running within the library's own context, but as an entirely separate,
-temporary crate.[^1] When a developer executes
+running within the library's own context, but as an entirely separate, temporary
+crate.[^1] When a developer executes
 
 `cargo test --doc`, `rustdoc` initiates a multi-stage process for every code
 block found in the documentation comments[^3]:
@@ -404,10 +404,10 @@ builds.[^13]
 pub struct UnixSocket;
 ```
 
-This `any` directive ensures the struct is compiled either when the target OS
-is `unix` OR when `rustdoc` is running. This correctly makes the item visible
-in the generated HTML. However, it is crucial to understand that this **does
-not** make the doctest for `UnixSocket` pass on non-Unix platforms.
+This `any` directive ensures the struct is compiled either when the target OS is
+`unix` OR when `rustdoc` is running. This correctly makes the item visible in
+the generated HTML. However, it is crucial to understand that this **does not**
+make the doctest for `UnixSocket` pass on non-Unix platforms.
 
 This distinction highlights the "cfg duality." The `#[cfg(doc)]` attribute
 controls the *table of contents* of the documentation; it determines which
@@ -579,8 +579,8 @@ real-world challenges when working with doctests.
 
   `#[test]` function in a temporary file or test module. This allows the
   developer to leverage the full power of the IDE. Once the code is working
-  correctly, it can be copied into the doc comment, and the necessary
-  formatting (`///`, `#`, etc.) can be applied.[^15]
+  correctly, it can be copied into the doc comment, and the necessary formatting
+  (`///`, `#`, etc.) can be applied.[^15]
 
 ## Conclusion and Recommendations
 
@@ -645,7 +645,7 @@ July 15, 2025, <https://doc.rust-lang.org/rustdoc/documentation-tests.html>
 [^11]: Compile_fail doc test ignored in cfg(test) - help - The Rust Programming
 Language Forum, accessed on July 15, 2025,
 <https://users.rust-lang.org/t/compile-fail-doc-test-ignored-in-cfg-test/124927>
- accessed on July 15, 2025,
+accessed on July 15, 2025,
 <https://users.rust-lang.org/t/test-setup-for-doctests/50426>
 [^12]: quote_doctest - Rust - [Docs.rs](http://Docs.rs), accessed on July 15,
 2025, <https://docs.rs/quote-doctest>
@@ -654,7 +654,7 @@ Language Forum, accessed on July 15, 2025,
 [^14]: rust - How can I conditionally execute a module-level doctest based …,
 accessed on July 15, 2025,
 <https://stackoverflow.com/questions/50312190/how-can-i-conditionally-execute-a-module-level-doctest-based-on-a-feature-flag>
- have doctests?, accessed on July 15, 2025,
+have doctests?, accessed on July 15, 2025,
 <https://stackoverflow.com/questions/38292741/how-would-one-achieve-conditional-compilation-with-rust-projects-that-have-docte>
 [^15]: How do you write your doc tests? : r/rust - Reddit, accessed on July 15,
 2025,

--- a/docs/rust-doctest-dry-guide.md
+++ b/docs/rust-doctest-dry-guide.md
@@ -652,10 +652,11 @@ accessed on July 15, 2025,
 [^13]: Advanced features - The rustdoc boOK - Rust Documentation, accessed on
        July 15, 2025, <https://doc.rust-lang.org/rustdoc/advanced-features.html>
 [^14]: rust - How can I conditionally execute a module-level doctest based …,
-accessed on July 15, 2025,
-<https://stackoverflow.com/questions/50312190/how-can-i-conditionally-execute-a-module-level-doctest-based-on-a-feature-flag>
-have doctests?, accessed on July 15, 2025,
-<https://stackoverflow.com/questions/38292741/how-would-one-achieve-conditional-compilation-with-rust-projects-that-have-docte>
+       accessed on July 15, 2025,
+       <https://stackoverflow.com/questions/50312190/how-can-i-conditionally-execute-a-module-level-doctest-based-on-a-feature-flag>;
+       How would one achieve conditional compilation with Rust projects that
+       have doctests?, accessed on July 15, 2025,
+       <https://stackoverflow.com/questions/38292741/how-would-one-achieve-conditional-compilation-with-rust-projects-that-have-doctests>
 [^15]: How do you write your doc tests? : r/rust - Reddit, accessed on July 15,
 2025,
 <https://www.reddit.com/r/rust/comments/ke438a/how_do_you_write_your_doc_tests/>

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -1346,7 +1346,7 @@ provided by `rstest`:
 
 | Attribute                  | Core Purpose                                                                                 |
 | -------------------------- | -------------------------------------------------------------------------------------------- |
-| #[rstest]                  | Marks a function as an rstest test; enables fixture injection and parameterization.          |
+| #[rstest]                  | Marks a function as a rstest test; enables fixture injection and parameterization.           |
 | #[fixture]                 | Defines a function that provides a test fixture (setup data or services).                    |
 | #[case(…)]                 | Defines a single parameterized test case with specific input values.                         |
 | #[values(…)]               | Defines a list of values for an argument, generating tests for each value or combination.    |

--- a/docs/rust-testing-with-rstest-fixtures.md
+++ b/docs/rust-testing-with-rstest-fixtures.md
@@ -911,9 +911,9 @@ By encapsulating temporary resource management within fixtures, tests become
 cleaner and less prone to errors related to resource setup or cleanup. The RAII
 (Resource Acquisition Is Initialization) pattern, common in Rust and
 exemplified by `tempfile::TempDir` (which cleans up the directory when
-dropped), works effectively with `rstest`'s fixture model. When a regular
-(non-`#[once]`) fixture returns a `TempDir` object, or an object that owns it,
-the resource is typically cleaned up after the test finishes, as the fixture's
+dropped), works effectively with `rstest`'s fixture model. When a regular (non-
+`#[once]`) fixture returns a `TempDir` object, or an object that owns it, the
+resource is typically cleaned up after the test finishes, as the fixture's
 return value goes out of scope. This localizes resource management logic to the
 fixture, keeping the test focused on its assertions. For temporary resources,
 regular (per-test) fixtures are generally preferred over `#[once]` fixtures to
@@ -1344,20 +1344,20 @@ provided by `rstest`:
 
 **Table 2: Key** `rstest` **Attributes Quick Reference**
 
-| Attribute                    | Core Purpose                                                                                 |
-| ---------------------------- | -------------------------------------------------------------------------------------------- |
-| #[rstest]                    | Marks a function as an rstest test; enables fixture injection and parameterization.          |
-| #[fixture]                   | Defines a function that provides a test fixture (setup data or services).                    |
-| #[case(…)]                   | Defines a single parameterized test case with specific input values.                         |
-| #[values(…)]                 | Defines a list of values for an argument, generating tests for each value or combination.    |
-| #[once]                      | Marks a fixture to be initialized only once and shared (as a static reference) across tests. |
-| #[future]                    | Simplifies async argument types by removing impl Future boilerplate.                         |
-| #[awt]                       | (Function or argument level) Automatically .awaits future arguments in async tests.          |
-| #[from(original_name)]       | Allows renaming an injected fixture argument in the test function.                           |
-| #[with(…)]                   | Overrides default arguments of a fixture for a specific test.                                |
-| #[default(…)]                | Provides default values for arguments within a fixture function.                             |
-| #[timeout(…)]                | Sets a timeout for an asynchronous test.                                                     |
-| #[files("glob_pattern",…)]   | Injects file paths (or contents, with mode=) matching a glob pattern as test arguments.      |
+| Attribute                  | Core Purpose                                                                                 |
+| -------------------------- | -------------------------------------------------------------------------------------------- |
+| #[rstest]                  | Marks a function as an rstest test; enables fixture injection and parameterization.          |
+| #[fixture]                 | Defines a function that provides a test fixture (setup data or services).                    |
+| #[case(…)]                 | Defines a single parameterized test case with specific input values.                         |
+| #[values(…)]               | Defines a list of values for an argument, generating tests for each value or combination.    |
+| #[once]                    | Marks a fixture to be initialized only once and shared (as a static reference) across tests. |
+| #[future]                  | Simplifies async argument types by removing impl Future boilerplate.                         |
+| #[awt]                     | (Function or argument level) Automatically .awaits future arguments in async tests.          |
+| #[from(original_name)]     | Allows renaming an injected fixture argument in the test function.                           |
+| #[with(…)]                 | Overrides default arguments of a fixture for a specific test.                                |
+| #[default(…)]              | Provides default values for arguments within a fixture function.                             |
+| #[timeout(…)]              | Sets a timeout for an asynchronous test.                                                     |
+| #[files("glob_pattern",…)] | Injects file paths (or contents, with mode=) matching a glob pattern as test arguments.      |
 
 By mastering `rstest`, Rust developers can significantly elevate the quality
 and efficiency of their testing practices, leading to more reliable and

--- a/docs/tei-rapporteur-users-guide.md
+++ b/docs/tei-rapporteur-users-guide.md
@@ -9,13 +9,13 @@ available today and how to exercise it.
 - `tei-core` now models the top-level `TeiDocument` together with its
   `TeiHeader` and body-aware `TeiText`. The text model records ordered
   paragraphs (`P`), utterances with optional speaker references, and structural
-  divisions (`Div`) containing paragraphs, utterances, lists
-  (`List`/`Item`/`Label`), and nested subdivisions. Each `Div` keeps a required
-  `@type` (`DivType`), an optional `@subtype`, an optional `@xml:id`, and an
-  optional `Head` wrapper for a single leading `<head>` element in the Episodic
-  profile. Each block stores a sequence of `Inline` nodes, allowing clients to
-  mix plain text with emphasized `<hi>` spans and `<pause/>` cues without
-  hand-rolling XML. Plain strings flow through `P::from_text_segments`,
+  divisions (`Div`) containing paragraphs, utterances, lists (`List`/`Item`/
+  `Label`), and nested subdivisions. Each `Div` keeps a required `@type`
+  (`DivType`), an optional `@subtype`, an optional `@xml:id`, and an optional
+  `Head` wrapper for a single leading `<head>` element in the Episodic profile.
+  Each block stores a sequence of `Inline` nodes, allowing clients to mix plain
+  text with emphasized `<hi>` spans and `<pause/>` cues without hand-rolling
+  XML. Plain strings flow through `P::from_text_segments`,
   `Utterance::from_text_segments`, `Item::from_text_segments`,
   `Label::from_text`, and `Head::from_text`; the older `new` constructors
   remain as deprecated shims for existing callers where applicable.

--- a/docs/testing-async-falcon-endpoints.md
+++ b/docs/testing-async-falcon-endpoints.md
@@ -308,14 +308,14 @@ While httpx.AsyncClient is suitable for many testing scenarios, Falcon provides
 falcon.testing.ASGIConductor for more fine-grained control over the ASGI
 application lifecycle.[^2] This tool is particularly valuable when testing
 streaming protocols like Server-Sent Events (SSE) or WebSockets, and for
-verifying the behaviour of ASGI middleware lifespan events (process\_startup
-and process\_shutdown).[^3] The ASGIConductor uses coroutines for its
-operations, which means it integrates naturally with async def test functions.
-However, this also implies that pytest-asyncio is not merely a convenience but
-a strict prerequisite for using ASGIConductor within a pytest environment.
-pytest itself does not natively execute async def tests or manage the await
-calls; pytest-asyncio provides the event loop and necessary wrappers to enable
-this functionality. Falcon's documentation explicitly directs users to
+verifying the behaviour of ASGI middleware lifespan events (process\_startup and
+process\_shutdown).[^3] The ASGIConductor uses coroutines for its operations,
+which means it integrates naturally with async def test functions. However,
+this also implies that pytest-asyncio is not merely a convenience but a strict
+prerequisite for using ASGIConductor within a pytest environment. pytest itself
+does not natively execute async def tests or manage the await calls;
+pytest-asyncio provides the event loop and necessary wrappers to enable this
+functionality. Falcon's documentation explicitly directs users to
 pytest-asyncio when using ASGIConductor with pytest.
 
 ### Using ASGIConductor as a context manager

--- a/docs/users-guide.md
+++ b/docs/users-guide.md
@@ -294,12 +294,22 @@ observability in production.
 Current queue model:
 
 - `episodic.tasks` topic exchange
-- `episodic.io` queue for I/O-bound workloads
-- `episodic.cpu` queue for CPU-bound workloads
+- `episodic.io` queue for I/O-bound workloads, bound with `episodic.io.#`
+- `episodic.cpu` queue for CPU-bound workloads, bound with `episodic.cpu.#`
+
+Representative tasks route explicitly:
+
+- `episodic.worker.io_diagnostic` uses queue `episodic.io`, exchange
+  `episodic.tasks`, exchange type `topic`, and routing key
+  `episodic.io.diagnostic`.
+- `episodic.worker.cpu_diagnostic` uses queue `episodic.cpu`, exchange
+  `episodic.tasks`, exchange type `topic`, and routing key
+  `episodic.cpu.diagnostic`.
 
 The current scaffold provides representative diagnostic tasks so routing and
 runtime wiring can be verified before later roadmap items add workflow-specific
-jobs.
+jobs. The default validation path is contract-level and eager-mode; it does not
+require a live RabbitMQ broker.
 
 ### Quality & Compliance
 

--- a/episodic/worker/__init__.py
+++ b/episodic/worker/__init__.py
@@ -12,6 +12,7 @@ from .runtime import (
 from .tasks import (
     CPU_DIAGNOSTIC_TASK_NAME,
     IO_DIAGNOSTIC_TASK_NAME,
+    SCAFFOLD_TASK_NAMES,
     CpuDiagnosticRequest,
     CpuDiagnosticResult,
     IoDiagnosticRequest,
@@ -24,6 +25,7 @@ __all__ = [
     "CPU_DIAGNOSTIC_TASK_NAME",
     "DEFAULT_WORKER_TOPOLOGY",
     "IO_DIAGNOSTIC_TASK_NAME",
+    "SCAFFOLD_TASK_NAMES",
     "CpuDiagnosticRequest",
     "CpuDiagnosticResult",
     "IoDiagnosticRequest",

--- a/episodic/worker/runtime.py
+++ b/episodic/worker/runtime.py
@@ -1,10 +1,25 @@
-"""Celery runtime composition root for the worker scaffold."""
+"""Celery runtime composition root for the worker scaffold.
 
+This module is the composition root that boots the Celery worker application.
+It reads environment configuration via :func:`load_runtime_config`, delegates
+queue and route taxonomy to :mod:`episodic.worker.topology`, and registers typed
+task seams from :mod:`episodic.worker.tasks` via
+:func:`~episodic.worker.tasks.register_scaffold_tasks`.
+
+:func:`_build_task_routes` materialises the route table from
+:class:`~episodic.worker.topology.WorkerTopology` and logs validation context
+so that startup failures carry enough diagnostic information to identify the
+offending task name or workload classification.
+
+:func:`create_celery_app_from_env` is the Celery runtime entrypoint; it
+chains :func:`load_runtime_config` and :func:`create_celery_app`.
+"""
+
+import collections.abc as cabc  # noqa: TC003
 import dataclasses as dc
 import enum
 import importlib
 import os
-import typing as typ
 from urllib.parse import urlparse
 
 from celery import Celery
@@ -15,9 +30,6 @@ from .tasks import SCAFFOLD_TASK_WORKLOADS, WorkerDependencies, register_scaffol
 from .topology import DEFAULT_WORKER_TOPOLOGY, WorkerTopology, WorkloadClass
 
 logger = get_logger(__name__)
-
-if typ.TYPE_CHECKING:
-    import collections.abc as cabc
 
 
 class WorkerPool(enum.StrEnum):
@@ -273,19 +285,20 @@ def create_celery_app(
     register_scaffold_tasks(app, worker_dependencies)
     return app
 
-def _build_task_routes(topology: WorkerTopology) -> dict[str, dict[str, str]]:
+def _build_task_routes(
+    topology: WorkerTopology,
+    task_workloads: cabc.Mapping[str, WorkloadClass] = SCAFFOLD_TASK_WORKLOADS,
+) -> dict[str, dict[str, str]]:
     """Build task routes and log route-table validation context."""
-    logger.info(
-        f"Building Celery worker task routes for {len(SCAFFOLD_TASK_WORKLOADS)} tasks."
-    )
+    logger.info(f"Building Celery worker task routes for {len(task_workloads)} tasks.")
     try:
-        task_routes = topology.task_routes(SCAFFOLD_TASK_WORKLOADS)
+        task_routes = topology.task_routes(task_workloads)
     except (TypeError, ValueError) as exc:
         validation_error = str(exc)
         logger.exception(
             "Celery worker task route validation failed for "
-            f"tasks={tuple(SCAFFOLD_TASK_WORKLOADS)!r}, "
-            f"workloads={tuple(SCAFFOLD_TASK_WORKLOADS.values())!r}: "
+            f"tasks={tuple(task_workloads)!r}, "
+            f"workloads={tuple(task_workloads.values())!r}: "
             f"{validation_error}"
         )
         raise

--- a/episodic/worker/runtime.py
+++ b/episodic/worker/runtime.py
@@ -285,6 +285,7 @@ def create_celery_app(
     register_scaffold_tasks(app, worker_dependencies)
     return app
 
+
 def _build_task_routes(
     topology: WorkerTopology,
     task_workloads: cabc.Mapping[str, WorkloadClass] | None = None,
@@ -329,6 +330,8 @@ def _build_task_routes(
         len(task_routes),
     )
     return task_routes
+
+
 def create_celery_app_from_env() -> Celery:
     """Build the Celery worker scaffold from environment configuration."""
     return create_celery_app(load_runtime_config())

--- a/episodic/worker/runtime.py
+++ b/episodic/worker/runtime.py
@@ -287,9 +287,10 @@ def create_celery_app(
 
 def _build_task_routes(
     topology: WorkerTopology,
-    task_workloads: cabc.Mapping[str, WorkloadClass] = SCAFFOLD_TASK_WORKLOADS,
+    task_workloads: cabc.Mapping[str, WorkloadClass] | None = None,
 ) -> dict[str, dict[str, str]]:
     """Build task routes and log route-table validation context."""
+    task_workloads = task_workloads or SCAFFOLD_TASK_WORKLOADS
 
     def _log_info(message: str, *args: object) -> None:
         try:

--- a/episodic/worker/runtime.py
+++ b/episodic/worker/runtime.py
@@ -291,7 +291,8 @@ def _build_task_routes(
     task_workloads: cabc.Mapping[str, WorkloadClass] | None = None,
 ) -> dict[str, dict[str, str]]:
     """Build task routes and log route-table validation context."""
-    task_workloads = task_workloads or SCAFFOLD_TASK_WORKLOADS
+    if task_workloads is None:
+        task_workloads = SCAFFOLD_TASK_WORKLOADS
 
     def _log_info(message: str, *args: object) -> None:
         try:

--- a/episodic/worker/runtime.py
+++ b/episodic/worker/runtime.py
@@ -9,8 +9,12 @@ from urllib.parse import urlparse
 
 from celery import Celery
 
+from episodic.logging import get_logger
+
 from .tasks import SCAFFOLD_TASK_WORKLOADS, WorkerDependencies, register_scaffold_tasks
 from .topology import DEFAULT_WORKER_TOPOLOGY, WorkerTopology, WorkloadClass
+
+logger = get_logger(__name__)
 
 if typ.TYPE_CHECKING:
     import collections.abc as cabc
@@ -249,6 +253,7 @@ def create_celery_app(
         "episodic.worker", broker=config.broker_url, backend=config.result_backend
     )
     default_queue = topology.queue_for(topology.default_workload)
+    task_routes = _build_task_routes(topology)
     app.conf.update(
         broker_url=config.broker_url,
         result_backend=config.result_backend,
@@ -263,12 +268,29 @@ def create_celery_app(
         task_default_routing_key=default_queue.diagnostic_routing_key,
         task_create_missing_queues=False,
         task_queues=topology.kombu_queues(),
-        task_routes=topology.task_routes(SCAFFOLD_TASK_WORKLOADS),
+        task_routes=task_routes,
     )
     register_scaffold_tasks(app, worker_dependencies)
     return app
 
-
+def _build_task_routes(topology: WorkerTopology) -> dict[str, dict[str, str]]:
+    """Build task routes and log route-table validation context."""
+    logger.info(
+        f"Building Celery worker task routes for {len(SCAFFOLD_TASK_WORKLOADS)} tasks."
+    )
+    try:
+        task_routes = topology.task_routes(SCAFFOLD_TASK_WORKLOADS)
+    except (TypeError, ValueError) as exc:
+        validation_error = str(exc)
+        logger.exception(
+            "Celery worker task route validation failed for "
+            f"tasks={tuple(SCAFFOLD_TASK_WORKLOADS)!r}, "
+            f"workloads={tuple(SCAFFOLD_TASK_WORKLOADS.values())!r}: "
+            f"{validation_error}"
+        )
+        raise
+    logger.info(f"Built Celery worker task routes for {len(task_routes)} tasks.")
+    return task_routes
 def create_celery_app_from_env() -> Celery:
     """Build the Celery worker scaffold from environment configuration."""
     return create_celery_app(load_runtime_config())

--- a/episodic/worker/runtime.py
+++ b/episodic/worker/runtime.py
@@ -290,19 +290,43 @@ def _build_task_routes(
     task_workloads: cabc.Mapping[str, WorkloadClass] = SCAFFOLD_TASK_WORKLOADS,
 ) -> dict[str, dict[str, str]]:
     """Build task routes and log route-table validation context."""
-    logger.info(f"Building Celery worker task routes for {len(task_workloads)} tasks.")
+
+    def _log_info(message: str, *args: object) -> None:
+        try:
+            logger.info(message, *args)
+        except TypeError:
+            logger.info(message % args)
+
+    _log_info(
+        "Building Celery worker task routes for %s tasks.",
+        len(task_workloads),
+    )
     try:
         task_routes = topology.task_routes(task_workloads)
     except (TypeError, ValueError) as exc:
         validation_error = str(exc)
-        logger.exception(
-            "Celery worker task route validation failed for "
-            f"tasks={tuple(task_workloads)!r}, "
-            f"workloads={tuple(task_workloads.values())!r}: "
-            f"{validation_error}"
-        )
+        log_exception = logger.exception
+        try:
+            log_exception(
+                (
+                    "Celery worker task route validation failed for "
+                    "tasks=%r, workloads=%r: %s"
+                ),
+                tuple(task_workloads),
+                tuple(task_workloads.values()),
+                validation_error,
+            )
+        except TypeError:
+            log_exception(
+                "Celery worker task route validation failed for tasks="
+                f"{tuple(task_workloads)!r}, workloads="
+                f"{tuple(task_workloads.values())!r}: {validation_error}",
+            )
         raise
-    logger.info(f"Built Celery worker task routes for {len(task_routes)} tasks.")
+    _log_info(
+        "Built Celery worker task routes for %s tasks.",
+        len(task_routes),
+    )
     return task_routes
 def create_celery_app_from_env() -> Celery:
     """Build the Celery worker scaffold from environment configuration."""

--- a/episodic/worker/tasks.py
+++ b/episodic/worker/tasks.py
@@ -44,6 +44,7 @@ if typ.TYPE_CHECKING:
 IO_DIAGNOSTIC_TASK_NAME = "episodic.worker.io_diagnostic"
 CPU_DIAGNOSTIC_TASK_NAME = "episodic.worker.cpu_diagnostic"
 MAX_CPU_DIAGNOSTIC_ITERATIONS = 1_000_000
+SCAFFOLD_TASK_NAMES = (IO_DIAGNOSTIC_TASK_NAME, CPU_DIAGNOSTIC_TASK_NAME)
 SCAFFOLD_TASK_WORKLOADS = {
     IO_DIAGNOSTIC_TASK_NAME: WorkloadClass.IO_BOUND,
     CPU_DIAGNOSTIC_TASK_NAME: WorkloadClass.CPU_BOUND,
@@ -240,4 +241,4 @@ def register_scaffold_tasks(
     # the Celery app, so deleting the local names avoids accidental direct calls to
     # those local functions instead of using the registered tasks.
     del run_io_diagnostic, run_cpu_diagnostic
-    return (IO_DIAGNOSTIC_TASK_NAME, CPU_DIAGNOSTIC_TASK_NAME)
+    return SCAFFOLD_TASK_NAMES

--- a/episodic/worker/tasks.py
+++ b/episodic/worker/tasks.py
@@ -1,34 +1,13 @@
 """Representative Celery task seams for the worker scaffold.
 
-CPU-bound tasks run on the `episodic.cpu` queue in Celery `prefork` worker
-processes. Tasks whose inner work can be split into pure-Python items may also
-fan out inside one worker process through the optional interpreter-pool adapter:
+This module defines routing inputs (`SCAFFOLD_TASK_NAMES` and
+`SCAFFOLD_TASK_WORKLOADS`) and task registrations that align with the worker
+runtime contract in :mod:`episodic.worker.topology` and
+:func:`~episodic.worker.runtime.create_celery_app`.
 
-```python
-import os
-
-from episodic.concurrent_interpreters import (
-    build_cpu_task_executor_from_environment,
-)
-
-executor = build_cpu_task_executor_from_environment(os.environ)
-try:
-    results = await executor.map_ordered(pure_python_fn, items)
-finally:
-    shutdown = getattr(executor, "shutdown", None)
-    if shutdown is not None:
-        shutdown()
-```
-
-Set `EPISODIC_USE_INTERPRETER_POOL=1` to enable subinterpreter parallelism for
-that inner fan-out path, with the implementation and
-`EPISODIC_INTERPRETER_POOL_MAX_WORKERS` tuning knob documented in
-`episodic/concurrent_interpreters.py`. Callers that gate fan-out by batch size
-should keep that threshold as task-level policy, as
-`DefaultWeightingStrategy` does with `EPISODIC_INTERPRETER_POOL_MIN_ITEMS`.
-Treat the executor as owned by the task-level fan-out operation or an explicit
-worker-scoped owner; do not hide a long-lived interpreter pool in unrelated
-global task state.
+CPU-bound tasks run on the `episodic.cpu` queue in Celery `prefork` workers.
+Tasks whose inner work can be split into pure-Python items may fan out inside a
+single worker process through the optional interpreter-pool adapter.
 """
 
 import collections.abc as cabc

--- a/episodic/worker/tasks.py
+++ b/episodic/worker/tasks.py
@@ -1,8 +1,7 @@
 """Representative Celery task seams for the worker scaffold.
 
-This module defines routing inputs (`SCAFFOLD_TASK_NAMES` and
-`SCAFFOLD_TASK_WORKLOADS`) and task registrations that align with the worker
-runtime contract in :mod:`episodic.worker.topology` and
+The task names and workload map in this module exercise the routing contract
+defined by :mod:`episodic.worker.topology` and registered by
 :func:`~episodic.worker.runtime.create_celery_app`.
 
 CPU-bound tasks run on the `episodic.cpu` queue in Celery `prefork` workers.

--- a/episodic/worker/topology.py
+++ b/episodic/worker/topology.py
@@ -112,6 +112,9 @@ def _validate_dotted_parts(task_parts: list[str]) -> None:
     if any(not part for part in task_parts):
         msg = "Worker task names must be non-empty dotted names."
         raise ValueError(msg)
+    if any(any(char.isspace() for char in part) for part in task_parts):
+        msg = "Worker task names must be non-empty dotted names."
+        raise ValueError(msg)
 
 
 def _validate_task_name(task_name: str) -> None:

--- a/episodic/worker/topology.py
+++ b/episodic/worker/topology.py
@@ -97,18 +97,30 @@ def _validate_non_empty_str(attr_path: str, value: str) -> None:
         raise ValueError(msg)
 
 
-def _validate_task_name(task_name: str) -> None:
-    """Raise ValueError if a task name cannot be routed deliberately."""
+def _validate_task_name_is_str(task_name: object) -> None:
+    """Raise TypeError if task_name is not a str instance."""
     if not isinstance(task_name, str):
         msg = "Worker task names must be non-empty dotted names."
         raise TypeError(msg)
-    task_parts = task_name.split(".")
-    if task_name != task_name.strip() or len(task_parts) < MIN_DOTTED_TASK_NAME_PARTS:
+
+
+def _validate_dotted_parts(task_parts: list[str]) -> None:
+    """Raise ValueError if there are too few parts or any part is empty."""
+    if len(task_parts) < MIN_DOTTED_TASK_NAME_PARTS:
         msg = "Worker task names must be non-empty dotted names."
         raise ValueError(msg)
     if any(not part for part in task_parts):
         msg = "Worker task names must be non-empty dotted names."
         raise ValueError(msg)
+
+
+def _validate_task_name(task_name: str) -> None:
+    """Raise ValueError if a task name cannot be routed deliberately."""
+    _validate_task_name_is_str(task_name)
+    if task_name != task_name.strip():
+        msg = "Worker task names must be non-empty dotted names."
+        raise ValueError(msg)
+    _validate_dotted_parts(task_name.split("."))
 
 
 def _validate_task_workload(workload: WorkloadClass) -> None:

--- a/episodic/worker/topology.py
+++ b/episodic/worker/topology.py
@@ -1,4 +1,9 @@
-"""Typed queue topology for the Celery worker scaffold."""
+"""Typed queue topology and routing contract for the Celery worker scaffold.
+
+The task registry in :mod:`episodic.worker.tasks` supplies task-to-workload
+classifications; this module turns those classifications into Celery queues,
+exchanges, and route metadata consumed by the worker runtime composition root.
+"""
 
 import collections.abc as cabc  # noqa: TC003
 import dataclasses as dc

--- a/episodic/worker/topology.py
+++ b/episodic/worker/topology.py
@@ -104,15 +104,17 @@ def _validate_task_name_is_str(task_name: object) -> None:
         raise TypeError(msg)
 
 
+def _part_is_invalid(part: str) -> bool:
+    """Return True if a dotted-name segment is empty or contains whitespace."""
+    return not part or any(char.isspace() for char in part)
+
+
 def _validate_dotted_parts(task_parts: list[str]) -> None:
-    """Raise ValueError if there are too few parts or any part is empty."""
+    """Raise ValueError if there are too few parts or any part is invalid."""
     if len(task_parts) < MIN_DOTTED_TASK_NAME_PARTS:
         msg = "Worker task names must be non-empty dotted names."
         raise ValueError(msg)
-    if any(not part for part in task_parts):
-        msg = "Worker task names must be non-empty dotted names."
-        raise ValueError(msg)
-    if any(any(char.isspace() for char in part) for part in task_parts):
+    if any(_part_is_invalid(part) for part in task_parts):
         msg = "Worker task names must be non-empty dotted names."
         raise ValueError(msg)
 

--- a/episodic/worker/topology.py
+++ b/episodic/worker/topology.py
@@ -7,6 +7,8 @@ import types
 
 from kombu import Exchange, Queue
 
+MIN_DOTTED_TASK_NAME_PARTS = 2
+
 
 class WorkloadClass(enum.StrEnum):
     """Canonical workload classes for routed Celery tasks."""
@@ -87,6 +89,27 @@ def _validate_non_empty_str(attr_path: str, value: str) -> None:
     if not value.strip():
         msg = f"{attr_path} must be a non-empty string."
         raise ValueError(msg)
+
+
+def _validate_task_name(task_name: str) -> None:
+    """Raise ValueError if a task name cannot be routed deliberately."""
+    if not isinstance(task_name, str):
+        msg = "Worker task names must be non-empty dotted names."
+        raise TypeError(msg)
+    task_parts = task_name.split(".")
+    if task_name != task_name.strip() or len(task_parts) < MIN_DOTTED_TASK_NAME_PARTS:
+        msg = "Worker task names must be non-empty dotted names."
+        raise ValueError(msg)
+    if any(not part for part in task_parts):
+        msg = "Worker task names must be non-empty dotted names."
+        raise ValueError(msg)
+
+
+def _validate_task_workload(workload: WorkloadClass) -> None:
+    """Raise TypeError if a task workload was not classified explicitly."""
+    if not isinstance(workload, WorkloadClass):
+        msg = "Worker task workloads must be WorkloadClass values."
+        raise TypeError(msg)
 
 
 def _validate_unique_queue_names(queues: tuple[WorkerQueueSpec, ...]) -> None:
@@ -173,9 +196,13 @@ class WorkerTopology:
         """Build Celery route metadata from task-name to workload mapping."""
         routes: dict[str, dict[str, str]] = {}
         for task_name, workload in task_workloads.items():
+            _validate_task_name(task_name)
+            _validate_task_workload(workload)
             queue = self.queue_for(workload)
             routes[task_name] = {
                 "queue": queue.name,
+                "exchange": self.exchange_name,
+                "exchange_type": self.exchange_type,
                 "routing_key": queue.diagnostic_routing_key,
             }
         return routes

--- a/episodic/worker/topology.py
+++ b/episodic/worker/topology.py
@@ -2,7 +2,8 @@
 
 The task registry in :mod:`episodic.worker.tasks` supplies task-to-workload
 classifications; this module turns those classifications into Celery queues,
-exchanges, and route metadata consumed by the worker runtime composition root.
+exchanges, and route metadata consumed by
+:func:`episodic.worker.runtime.create_celery_app`.
 """
 
 import collections.abc as cabc  # noqa: TC003

--- a/tests/features/worker_service_scaffold.feature
+++ b/tests/features/worker_service_scaffold.feature
@@ -5,8 +5,8 @@ Feature: Celery worker scaffold
     When the Celery worker app is created from environment configuration
     And an operator inspects the worker routing
     And the operator dispatches the representative diagnostic tasks
-    Then the I/O-bound task targets the I/O queue and succeeds
-    And the CPU-bound task targets the CPU queue and succeeds
+    Then the I/O-bound task targets the I/O exchange and queue and succeeds
+    And the CPU-bound task targets the CPU exchange and queue and succeeds
     And the worker launch profiles map I/O and CPU workloads to distinct pools
 
   Scenario: App creation fails without broker config

--- a/tests/steps/test_worker_service_scaffold_steps.py
+++ b/tests/steps/test_worker_service_scaffold_steps.py
@@ -153,7 +153,7 @@ def _assert_task_contract(
     assert assertion.actual_result == assertion.expected_result
 
 
-@then("the I/O-bound task targets the I/O queue and succeeds")
+@then("the I/O-bound task targets the I/O exchange and queue and succeeds")
 def then_io_task_targets_io_queue(
     worker_service_scaffold_context: WorkerServiceScaffoldContext,
 ) -> None:
@@ -166,6 +166,8 @@ def then_io_task_targets_io_queue(
             task_name=IO_DIAGNOSTIC_TASK_NAME,
             expected_route={
                 "queue": "episodic.io",
+                "exchange": "episodic.tasks",
+                "exchange_type": "topic",
                 "routing_key": "episodic.io.diagnostic",
             },
             actual_result=worker_service_scaffold_context.io_result,
@@ -178,7 +180,7 @@ def then_io_task_targets_io_queue(
     )
 
 
-@then("the CPU-bound task targets the CPU queue and succeeds")
+@then("the CPU-bound task targets the CPU exchange and queue and succeeds")
 def then_cpu_task_targets_cpu_queue(
     worker_service_scaffold_context: WorkerServiceScaffoldContext,
 ) -> None:
@@ -191,6 +193,8 @@ def then_cpu_task_targets_cpu_queue(
             task_name=CPU_DIAGNOSTIC_TASK_NAME,
             expected_route={
                 "queue": "episodic.cpu",
+                "exchange": "episodic.tasks",
+                "exchange_type": "topic",
                 "routing_key": "episodic.cpu.diagnostic",
             },
             actual_result=worker_service_scaffold_context.cpu_result,

--- a/tests/test_worker_routing_contract.py
+++ b/tests/test_worker_routing_contract.py
@@ -130,22 +130,20 @@ def test_create_celery_app_logs_task_route_validation_failures(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Log invalid route-table context before propagating startup failures."""
-    from episodic.worker import WorkloadClass, create_celery_app, load_runtime_config
+    from episodic.worker import WorkloadClass
     from episodic.worker import runtime as runtime_module
 
     logger = _FakeWorkerLogger(infos=[], exceptions=[])
     monkeypatch.setattr(runtime_module, "logger", logger)
-    monkeypatch.setattr(
-        runtime_module,
-        "SCAFFOLD_TASK_WORKLOADS",
-        {typ.cast("str", 42): WorkloadClass.IO_BOUND},
-    )
 
     with pytest.raises(
         TypeError,
         match=r"Worker task names must be non-empty dotted names\.",
     ):
-        create_celery_app(load_runtime_config(_runtime_environ()))
+        runtime_module._build_task_routes(
+            runtime_module.DEFAULT_WORKER_TOPOLOGY,
+            {typ.cast("str", 42): WorkloadClass.IO_BOUND},
+        )
 
     assert logger.infos == ["Building Celery worker task routes for 1 tasks."]
     assert len(logger.exceptions) == 1

--- a/tests/test_worker_routing_contract.py
+++ b/tests/test_worker_routing_contract.py
@@ -1,0 +1,66 @@
+"""Tests for explicit Celery worker routing contracts."""
+
+import typing as typ
+
+import pytest
+
+
+def test_scaffold_task_workload_mapping_matches_registered_task_names() -> None:
+    """Require each registered scaffold task to have one explicit workload."""
+    from episodic.worker.tasks import SCAFFOLD_TASK_NAMES, SCAFFOLD_TASK_WORKLOADS
+
+    workload_task_names = set(SCAFFOLD_TASK_WORKLOADS)
+    registered_task_names = set(SCAFFOLD_TASK_NAMES)
+
+    assert workload_task_names == registered_task_names, (
+        "scaffold task workloads must match scaffold task names: "
+        f"workloads={workload_task_names!r}, registered={registered_task_names!r}"
+    )
+
+
+def test_task_routes_include_exchange_metadata_for_each_task() -> None:
+    """Expose complete Celery route metadata for each classified task."""
+    from episodic.worker import (
+        CPU_DIAGNOSTIC_TASK_NAME,
+        DEFAULT_WORKER_TOPOLOGY,
+        IO_DIAGNOSTIC_TASK_NAME,
+    )
+    from episodic.worker.tasks import SCAFFOLD_TASK_WORKLOADS
+
+    routes = DEFAULT_WORKER_TOPOLOGY.task_routes(SCAFFOLD_TASK_WORKLOADS)
+
+    assert routes[IO_DIAGNOSTIC_TASK_NAME] == {
+        "queue": "episodic.io",
+        "exchange": "episodic.tasks",
+        "exchange_type": "topic",
+        "routing_key": "episodic.io.diagnostic",
+    }, f"I/O task routing contract failed for {IO_DIAGNOSTIC_TASK_NAME}: {routes!r}"
+    assert routes[CPU_DIAGNOSTIC_TASK_NAME] == {
+        "queue": "episodic.cpu",
+        "exchange": "episodic.tasks",
+        "exchange_type": "topic",
+        "routing_key": "episodic.cpu.diagnostic",
+    }, f"CPU task routing contract failed for {CPU_DIAGNOSTIC_TASK_NAME}: {routes!r}"
+
+
+def test_task_routes_reject_malformed_task_names_and_workloads() -> None:
+    """Reject malformed task route tables instead of producing fallback routes."""
+    from episodic.worker import DEFAULT_WORKER_TOPOLOGY, WorkloadClass
+
+    malformed_task_workloads = {
+        "": WorkloadClass.IO_BOUND,
+        "episodic.worker.cpu_diagnostic": WorkloadClass.CPU_BOUND,
+    }
+    with pytest.raises(
+        ValueError,
+        match=r"Worker task names must be non-empty dotted names\.",
+    ):
+        DEFAULT_WORKER_TOPOLOGY.task_routes(malformed_task_workloads)
+
+    with pytest.raises(
+        TypeError,
+        match=r"Worker task workloads must be WorkloadClass values\.",
+    ):
+        DEFAULT_WORKER_TOPOLOGY.task_routes({
+            "episodic.worker.io_diagnostic": typ.cast("WorkloadClass", "io_bound"),
+        })

--- a/tests/test_worker_routing_contract.py
+++ b/tests/test_worker_routing_contract.py
@@ -47,15 +47,25 @@ def test_task_routes_reject_malformed_task_names_and_workloads() -> None:
     """Reject malformed task route tables instead of producing fallback routes."""
     from episodic.worker import DEFAULT_WORKER_TOPOLOGY, WorkloadClass
 
-    malformed_task_workloads = {
-        "": WorkloadClass.IO_BOUND,
-        "episodic.worker.cpu_diagnostic": WorkloadClass.CPU_BOUND,
-    }
-    with pytest.raises(
-        ValueError,
-        match=r"Worker task names must be non-empty dotted names\.",
-    ):
-        DEFAULT_WORKER_TOPOLOGY.task_routes(malformed_task_workloads)
+    malformed_task_names = (
+        "",
+        "singlepart",
+        "a..b",
+        ".leading",
+        "trailing.",
+        " valid.name ",
+        "\tname.part",
+    )
+    for malformed_task_name in malformed_task_names:
+        malformed_task_workloads = {
+            malformed_task_name: WorkloadClass.IO_BOUND,
+            "episodic.worker.cpu_diagnostic": WorkloadClass.CPU_BOUND,
+        }
+        with pytest.raises(
+            ValueError,
+            match=r"Worker task names must be non-empty dotted names\.",
+        ):
+            DEFAULT_WORKER_TOPOLOGY.task_routes(malformed_task_workloads)
 
     with pytest.raises(
         TypeError,

--- a/tests/test_worker_routing_contract.py
+++ b/tests/test_worker_routing_contract.py
@@ -77,6 +77,7 @@ def test_task_routes_reject_malformed_task_names_and_workloads() -> None:
         "trailing.",
         " valid.name ",
         "\tname.part",
+        "episodic.worker. io",
     )
     for malformed_task_name in malformed_task_names:
         malformed_task_workloads = {

--- a/tests/test_worker_routing_contract.py
+++ b/tests/test_worker_routing_contract.py
@@ -1,8 +1,30 @@
 """Tests for explicit Celery worker routing contracts."""
 
+import dataclasses as dc
 import typing as typ
 
 import pytest
+
+
+@dc.dataclass(slots=True)
+class _FakeWorkerLogger:
+    """Capture worker runtime log messages."""
+
+    infos: list[str]
+    exceptions: list[str]
+
+    def info(self, message: str) -> None:
+        self.infos.append(message)
+
+    def exception(self, message: str) -> None:
+        self.exceptions.append(message)
+
+
+def _runtime_environ() -> dict[str, str]:
+    return {
+        "EPISODIC_CELERY_BROKER_URL": "amqp://guest:guest@localhost:5672//",
+        "EPISODIC_CELERY_ALWAYS_EAGER": "true",
+    }
 
 
 def test_scaffold_task_workload_mapping_matches_registered_task_names() -> None:
@@ -69,8 +91,63 @@ def test_task_routes_reject_malformed_task_names_and_workloads() -> None:
 
     with pytest.raises(
         TypeError,
+        match=r"Worker task names must be non-empty dotted names\.",
+    ):
+        DEFAULT_WORKER_TOPOLOGY.task_routes({
+            typ.cast("str", 42): WorkloadClass.IO_BOUND,
+        })
+
+    with pytest.raises(
+        TypeError,
         match=r"Worker task workloads must be WorkloadClass values\.",
     ):
         DEFAULT_WORKER_TOPOLOGY.task_routes({
             "episodic.worker.io_diagnostic": typ.cast("WorkloadClass", "io_bound"),
         })
+
+
+def test_create_celery_app_logs_task_route_materialisation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Log route-table materialisation for worker startup diagnosis."""
+    from episodic.worker import create_celery_app, load_runtime_config
+    from episodic.worker import runtime as runtime_module
+
+    logger = _FakeWorkerLogger(infos=[], exceptions=[])
+    monkeypatch.setattr(runtime_module, "logger", logger)
+
+    create_celery_app(load_runtime_config(_runtime_environ()))
+
+    assert logger.infos == [
+        "Building Celery worker task routes for 2 tasks.",
+        "Built Celery worker task routes for 2 tasks.",
+    ]
+    assert not logger.exceptions
+
+
+def test_create_celery_app_logs_task_route_validation_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Log invalid route-table context before propagating startup failures."""
+    from episodic.worker import WorkloadClass, create_celery_app, load_runtime_config
+    from episodic.worker import runtime as runtime_module
+
+    logger = _FakeWorkerLogger(infos=[], exceptions=[])
+    monkeypatch.setattr(runtime_module, "logger", logger)
+    monkeypatch.setattr(
+        runtime_module,
+        "SCAFFOLD_TASK_WORKLOADS",
+        {typ.cast("str", 42): WorkloadClass.IO_BOUND},
+    )
+
+    with pytest.raises(
+        TypeError,
+        match=r"Worker task names must be non-empty dotted names\.",
+    ):
+        create_celery_app(load_runtime_config(_runtime_environ()))
+
+    assert logger.infos == ["Building Celery worker task routes for 1 tasks."]
+    assert len(logger.exceptions) == 1
+    assert "tasks=(42,)" in logger.exceptions[0]
+    assert "workloads=(<WorkloadClass.IO_BOUND: 'io_bound'>,)" in logger.exceptions[0]
+    assert "Worker task names must be non-empty dotted names." in logger.exceptions[0]


### PR DESCRIPTION
## Summary

This branch implements roadmap task `(2.4.3)`, configuring Celery queue routing for workload isolation. It hardens the worker topology contract so representative I/O-bound and CPU-bound tasks route through explicit queue, exchange, exchange type, and routing key metadata, with fail-fast validation for malformed task names and invalid workload classes.

Roadmap task: `(2.4.3)`
Execplan: [docs/execplans/2-4-3-configure-celery-queue-routing.md](https://github.com/leynos/episodic/blob/2-4-3-configure-celery-queue-routing/docs/execplans/2-4-3-configure-celery-queue-routing.md)

## Review Walkthrough

- Start with [docs/execplans/2-4-3-configure-celery-queue-routing.md](https://github.com/leynos/episodic/blob/2-4-3-configure-celery-queue-routing/docs/execplans/2-4-3-configure-celery-queue-routing.md) for the completed implementation record, decisions, and validation history.
- Review `episodic/worker/topology.py` and `episodic/worker/tasks.py` for the route metadata and scaffold task-name contract.
- Review `tests/test_worker_routing_contract.py` plus the worker scaffold behavioural feature for the queue-routing coverage.
- Review the users' guide, developers' guide, design document, ADR updates, and roadmap checkbox for the externally and internally visible documentation changes.

## Validation

- `make check-fmt`: passed.
- `make typecheck`: passed.
- `make lint`: passed.
- `make test`: passed with `664 passed, 3 skipped`.
- `make markdownlint`: passed.
- `make nixie`: passed.
- `coderabbit review --agent`: implementation findings were applied; documentation and final reviews reported no findings.

## Notes

The execplan was explicitly approved before implementation. This slice does not add LangGraph-to-Celery dispatch or a new orchestration workload-intent DTO because the current orchestration layer remains provider-neutral and does not enqueue Celery work yet.

## References

- Lody session: https://lody.ai/leynos/sessions/817e23cc-2ed9-4b5b-a72c-2e13ad1213dd
