### PR TITLE
Track request correlation integration (4.1.3)

### DIFF
--- a/docs/episodic-podcast-generation-system-design.md
+++ b/docs/episodic-podcast-generation-system-design.md
@@ -1931,6 +1931,19 @@ forwarded to custom loop task factories when present. This keeps business logic
 independent of event-loop internals while enabling centralized diagnostics for
 concurrent ingestion flows.
 
+The public HTTP boundary still needs a dedicated request-correlation workstream
+before the source-to-script API can satisfy its end-to-end observability
+contract. The Falcon ASGI composition root should install `falcon-correlate`'s
+`CorrelationIDMiddlewareASGI` before authorization so each request either
+accepts a trusted incoming correlation header or generates a new UUIDv7
+correlation ID. The same active ID should be echoed on responses, available
+through `req.context.correlation_id`, copied into Celery publish and worker
+contexts, and injected into owned `httpx.AsyncClient` traffic such as the
+OpenAI-compatible LLM adapter. Runtime configuration must cover the header
+name, trusted ingress source ranges, incoming-ID validation, and
+response-header echoing so deployments can align the application contract with
+their gateway topology.
+
 During persistence, `ingest_sources` enriches the TEI header payload with
 provenance automatically. Source priorities are derived from final source
 weights (descending, preserving source input order on equal weights), ingestion

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -603,6 +603,27 @@ Completion enables stable API consumption by clients.
   - Implement pagination, filtering, and role enforcement.
   - Ensure consistent error contracts across all endpoints.
   - See [Error contract](episodic-tui-api-design.md#error-contract).
+- [ ] 4.1.3. Integrate request correlation across HTTP, tasks, and outbound
+  provider calls. Requires 1.5.1 and 1.5.2.
+  - Add `falcon-correlate` as an application dependency once a pinned release
+    or Git revision is selected.
+  - Wire `CorrelationIDMiddlewareASGI` into the Falcon composition root before
+    authorization middleware so denial, error, and resource logs share the same
+    request identifier.
+  - Expose runtime configuration for the correlation header name, trusted proxy
+    or ingress source ranges, incoming-ID validation, and response-header
+    echoing.
+  - Configure Celery correlation propagation in the worker composition root so
+    published tasks and worker-side logs inherit the active request
+    correlation ID.
+  - Wrap owned `httpx.AsyncClient` instances, including the OpenAI-compatible
+    LLM adapter client, with `falcon-correlate` transport support so provider
+    calls receive the active correlation header.
+  - Add Falcon ASGI, Celery eager-mode, and outbound `httpx.MockTransport`
+    tests proving generated IDs are visible on `req.context`, response
+    headers, task context, and provider request headers.
+  - Document the operator-facing header contract and local debugging workflow
+    in the users' guide and developers' guide.
 
 ### 4.2. Episode and approval workflow endpoints
 


### PR DESCRIPTION
## Summary

This branch records the request-correlation integration gap that blocks episodic from relying on `falcon-correlate` for end-to-end correlation IDs. It adds the roadmap and system-design coverage needed to prioritise Falcon ASGI request IDs, Celery propagation, and outbound provider-call propagation as one coherent workstream.

Roadmap task: (4.1.3)
Execplan: none; this is a design and roadmap alignment branch, not an execplan implementation.
Issue: none.

## Review walkthrough

- Start with [docs/roadmap.md](https://github.com/leynos/episodic/blob/726de725284ace70c0dc3f1412d32d8558ba1500/docs/roadmap.md#L606) to review the new `4.1.3` workstream and its acceptance criteria for dependency pinning, Falcon middleware wiring, Celery propagation, `httpx` transport support, tests, and operator documentation.
- Then review [docs/episodic-podcast-generation-system-design.md](https://github.com/leynos/episodic/blob/726de725284ace70c0dc3f1412d32d8558ba1500/docs/episodic-podcast-generation-system-design.md#L1934) to see how the design now frames the public HTTP boundary and downstream propagation requirements.

## Validation

- `make markdownlint`: passed.
- `make nixie`: passed.
- `make all` in a fresh `/tmp/falcon-correlate-audit` clone of `leynos/falcon-correlate` at `78b505a`: passed with `417 passed, 11 skipped`.

## Notes

- `make fmt` was attempted in episodic, but its Markdown formatter rewrote unrelated files and then failed on unrelated line-length findings. Those unrelated formatter rewrites were restored, leaving this branch scoped to the two documentation files above.
- The branch does not integrate `falcon-correlate` into runtime code. It makes that follow-up implementation explicit so it can be prioritised.
