### PR TITLE
Wire CodeScene coverage upload via the shared actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,15 @@ jobs:
   lint-test:
     runs-on: ubuntu-latest
     env:
-      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
-      CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 }}
       CARGO_HTTP_MULTIPLEXING: "false"
       CARGO_NET_RETRY: "10"
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
+        with:
+          # Full history so a future `cs-coverage check` can reach the
+          # pull request's merge base (see the deferred gate note below).
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
@@ -75,42 +77,44 @@ jobs:
       - name: Run typechecker
         run: make typecheck
 
-      - name: Run tests with coverage
+      - name: Check vidaimock is available
         run: |
           if ! command -v vidaimock >/dev/null 2>&1; then
             echo "ERROR: vidaimock binary not found in PATH"
             exit 1
           fi
-          uv pip install slipcover pytest-forked
-          uv run python -m slipcover \
-            --source=./episodic \
-            --omit="*/unittests/*,*/.venv/*" \
-            --branch \
-            --out coverage.xml \
-            -m pytest --forked -v
 
-      - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+      # On push to main, coverage (and its CodeScene upload) is handled
+      # by coverage-main.yml, so this job just runs the plain suite here.
+      - name: Run tests
+        if: github.event_name != 'pull_request'
+        run: make test
+
+      # Coverage runs on pull requests only. Pushes to main upload their
+      # own coverage (and advance the ratchet baseline) via
+      # coverage-main.yml, so generating it here as well would duplicate
+      # the work and the CodeScene upload for the same commit.
+      #
+      # The `mode: check` gate step is deliberately not wired in yet:
+      # CodeScene project 76628 has no coverage-gates configuration, so
+      # `cs-coverage check` fails every run with "HTTP call succeeded,
+      # but the received project-config isn't valid. Lacks the gates
+      # configuration." — a CodeScene-side per-project setting, not a CI
+      # defect (ddlint#287 and chutoro#156 hit the byte-identical error).
+      # Add the check step in a fast-follow PR once coverage-main.yml has
+      # uploaded to main at least once and the gate is confirmed to
+      # resolve, or once CodeScene confirms the project's coverage gate
+      # is enabled.
+      - name: Generate coverage
+        if: github.event_name == 'pull_request'
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
         with:
-          name: coverage
-          path: coverage.xml
-
-      - name: Install CodeScene Coverage CLI
-        if: env.CS_ACCESS_TOKEN != ''
-        run: |
-          curl -fsSL https://downloads.codescene.io/enterprise/cli/install-cs-coverage-tool.sh | bash -s -- -y
-          if [ -n "${CODESCENE_CLI_SHA256:-}" ]; then
-            echo "${CODESCENE_CLI_SHA256}  install-cs-coverage-tool.sh" | sha256sum -c -
-          fi
-
-      - name: Upload coverage to CodeScene
-        if: env.CS_ACCESS_TOKEN != ''
-        run: |
-          if [ ! -f coverage.xml ]; then
-            echo "coverage.xml not found!"
-            exit 1
-          fi
-          cs-coverage upload \
-            --format "cobertura" \
-            --metric "line-coverage" \
-            coverage.xml
+          output-path: coverage.xml
+          format: cobertura
+          # The suite's coverage run previously used slipcover with
+          # pytest-forked (serial, one process per test, no xdist); keep
+          # it serial to stay behaviour-preserving. A follow-up can drop
+          # this pin to adopt pytest-xdist once the suite is confirmed
+          # xdist-clean under coverage instrumentation.
+          pytest-workers: ''
+          with-ratchet: 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ jobs:
     env:
       CARGO_HTTP_MULTIPLEXING: "false"
       CARGO_NET_RETRY: "10"
+      # The Makefile exports this for its own uv invocations, but the
+      # shared generate-coverage action runs uv directly and rebuilds
+      # the tei-rapporteur PyO3 extension, which needs the stable-ABI
+      # escape hatch under Python 3.14 (PyO3 0.23 supports up to 3.13).
+      PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -28,6 +28,10 @@ jobs:
       CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 || '' }}
       CARGO_HTTP_MULTIPLEXING: "false"
       CARGO_NET_RETRY: "10"
+      # See the note in ci.yml: the shared generate-coverage action runs
+      # uv directly and rebuilds the tei-rapporteur PyO3 extension, which
+      # needs the stable-ABI escape hatch under Python 3.14.
+      PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -1,0 +1,79 @@
+name: Coverage (main)
+
+# CodeScene accepts `cs-coverage upload` only for analysed branches, so
+# main-branch coverage is uploaded here on push; pull requests only run
+# the coverage generation (and, in a future fast-follow, the
+# changed-line `cs-coverage check` gate) in ci.yml instead. This
+# workflow also advances the coverage ratchet baseline: caches saved on
+# main are readable by every pull-request run, so the baseline written
+# here is the one PR ratchet checks compare against.
+#
+# workflow_dispatch is required, not optional: merges performed by the
+# automerge workflow's GITHUB_TOKEN do not fire push-event workflows at
+# all, so automerged changes to main only get coverage via a manual
+# dispatch re-run.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  coverage-upload:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN || '' }}
+      CODESCENE_CLI_SHA256: ${{ vars.CODESCENE_CLI_SHA256 || '' }}
+      CARGO_HTTP_MULTIPLEXING: "false"
+      CARGO_NET_RETRY: "10"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.14'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Install VidaiMock
+        env:
+          VIDAIMOCK_VERSION: "0.1.3"
+          VIDAIMOCK_SHA256: "214032f365b7f6d8e43fc32fbdb73a2f5d1ccec963c20807eb0675260af16665"
+        run: |
+          curl -fsSL -o vidaimock-linux-x64.tar.gz \
+            "https://github.com/vidaiUK/VidaiMock/releases/download/v${VIDAIMOCK_VERSION}/vidaimock-linux-x64.tar.gz"
+          echo "${VIDAIMOCK_SHA256}  vidaimock-linux-x64.tar.gz" | sha256sum -c -
+          tar -xzf vidaimock-linux-x64.tar.gz
+          mkdir -p "$HOME/.local/bin"
+          mv vidaimock/vidaimock "$HOME/.local/bin/"
+          chmod +x "$HOME/.local/bin/vidaimock"
+          rm -rf vidaimock vidaimock-linux-x64.tar.gz
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/vidaimock" --version
+
+      - name: Install code
+        run: make build
+
+      - name: Generate coverage
+        uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          output-path: coverage.xml
+          format: cobertura
+          # Keep the run serial to match the pull-request coverage job;
+          # see the note in ci.yml.
+          pytest-workers: ''
+          with-ratchet: 'true'
+
+      - name: Upload coverage data to CodeScene
+        if: env.CS_ACCESS_TOKEN != ''
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: cobertura
+          path: coverage.xml
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ env.CODESCENE_CLI_SHA256 }}

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@d28e04c9ea359650a85d697d1ab3d0be0b5674e7
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-mutmut.yml@5dce6e093f70f0f09a0c6f5d06eea4efb695a52c
+    uses: leynos/shared-actions/.github/workflows/mutation-mutmut.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
     with:
       # Flat package layout: the mutable source lives in episodic/, not src/.
       paths: "episodic/"

--- a/tests/test_mutation_workflow_contract.py
+++ b/tests/test_mutation_workflow_contract.py
@@ -19,7 +19,7 @@ WORKFLOW_PATH = REPOSITORY_ROOT / ".github" / "workflows" / "mutation-testing.ym
 
 #: The commit SHA the caller pins ``mutation-mutmut.yml`` to. Bump the
 #: workflow and this test together.
-PINNED_SHA = "5dce6e093f70f0f09a0c6f5d06eea4efb695a52c"
+PINNED_SHA = "927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
 
 EXPECTED_USES = (
     "leynos/shared-actions/.github/workflows/mutation-mutmut.yml@" + PINNED_SHA


### PR DESCRIPTION
## Summary

- Replace the bespoke slipcover + `cs-coverage upload` steps in
  [`ci.yml`](https://github.com/leynos/episodic/blob/codescene-coverage-gate/.github/workflows/ci.yml)
  with the shared `generate-coverage` action (`format: cobertura`,
  serial pytest to preserve the previous `pytest --forked` behaviour,
  ratchet enabled), guarded to pull-request runs only; push-to-main
  runs the plain suite instead.
- Add
  [`coverage-main.yml`](https://github.com/leynos/episodic/blob/codescene-coverage-gate/.github/workflows/coverage-main.yml)
  to upload coverage from `main` on push (and on manual
  `workflow_dispatch`) and advance the ratchet baseline that the pull
  request job compares against.
- Bump every `leynos/shared-actions/...@<sha>` reference in the repo
  (mutation testing, Dependabot automerge, and the new coverage
  actions) to `927edd45ae77be4251a8a18ca9eb5613a2e32cbd`, and update
  [`tests/test_mutation_workflow_contract.py`](https://github.com/leynos/episodic/blob/codescene-coverage-gate/tests/test_mutation_workflow_contract.py)
  to match the new pin.

CodeScene project 76628 (episodic) currently posts only the
`CodeScene Code Health Review` check, not a coverage check — its
project configuration has no `gates` section yet (confirmed via a
read-only probe of the CodeScene API), so `cs-coverage check` would
fail unconditionally. The pull-request `mode: check` gate is therefore
deliberately left out for now; `ci.yml` documents the deferral inline,
following the pattern used in ddlint#287. The
`CodeScene Code Coverage` check that appears on this and future pull
requests is **not** a required check — it will not block merges, and
reviewers should not expect to find it in the branch protection
ruleset.

## Review walkthrough

- `.github/workflows/ci.yml`: coverage generation now runs only on
  `pull_request` events (via the shared action); a new "Run tests"
  step covers the push-to-main path with the plain suite. The old
  "Install CodeScene Coverage CLI" / "Upload coverage to CodeScene"
  steps and the now-unused job-level `CS_ACCESS_TOKEN` /
  `CODESCENE_CLI_SHA256` env vars are removed.
- `.github/workflows/coverage-main.yml`: new workflow, mirrors
  `ci.yml`'s build/VidaiMock setup, generates coverage serially with
  the ratchet on, and uploads to CodeScene when the secret is present.
- `.github/workflows/mutation-testing.yml` and
  `.github/workflows/dependabot-automerge.yml`: pin bump only.
- `tests/test_mutation_workflow_contract.py`: pin bump only, to keep
  the contract test aligned with the workflow it pins.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open(...))"` on all four
  changed/added workflow files.
- `uv run python -m pytest tests/test_mutation_workflow_contract.py -q`
  — 6 passed.
- The repo's full test/build suite was not run locally per the
  rollout's cheap-validation policy (heavyweight suite, shared
  machine); CI on this PR is the first full-suite run under the new
  coverage step.

**Secrets**: `CS_ACCESS_TOKEN` is *not yet set* in either the Actions
or Dependabot secret store for this repo. Per the rollout's sequencing
guidance, it will be set immediately before merging this PR — setting
it earlier would make every other currently open pull request's
`cs-coverage upload` step (which this PR removes) fail, since
CodeScene only accepts uploads from `main`.
