### PR TITLE
Stop pinning the mutation workflow's caller SHA in contract tests

### DIFF
--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -96,6 +96,42 @@ uv run scripts/generate_typos_config.py
 Keep upstream API spellings in inline or fenced code where practical. The
 spelling gate deliberately ignores code spans and fenced code blocks.
 
+## Workflow pins and Dependabot
+
+Dependabot owns the upgrade of GitHub Actions and reusable workflows,
+including calls into `leynos/shared-actions`. Contract tests that assert a
+caller's exact commit SHA create a lockstep dependency: every time Dependabot
+opens a bump PR, the test fails until a human edits the pinned constant to
+match. That defeats the purpose of automated dependency updates and turns a
+routine bump into a manual chore.
+
+Contract tests may still verify the *shape* of a reusable-workflow caller.
+They must not verify the specific SHA value.
+
+- Do assert the workflow references the correct reusable workflow path.
+- Do assert the ref is pinned to a full 40-character commit SHA, not a
+  mutable branch such as `main` or `rolling`.
+- Do assert the expected `on:` triggers, least-privilege `permissions:`, and
+  the inputs the caller relies on.
+- Do not hard-code the current SHA value as an expected string. Match it with
+  a pattern instead.
+- Do not fail a test purely because Dependabot bumped the pinned SHA.
+
+```python
+import re
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def test_uses_pinned_full_sha(caller_step):
+    ref = caller_step["uses"].split("@")[-1]
+    assert SHA_RE.match(ref), f"expected a 40-hex commit SHA, got {ref!r}"
+```
+
+If a workflow's behaviour genuinely depends on a feature only present from a
+particular commit onwards, express that as a comment or a changelog note, not
+as a test assertion on the SHA string.
+
 ## Falcon HTTP runtime
 
 The canonical HTTP adapter has two layers:

--- a/tests/test_mutation_workflow_contract.py
+++ b/tests/test_mutation_workflow_contract.py
@@ -3,13 +3,16 @@
 The executable logic lives in the ``leynos/shared-actions`` reusable
 workflow, which carries its own unit and integration tests; episodic's
 caller is declarative configuration. These tests parse the caller with
-PyYAML and pin the contract it must uphold, so drift (repointing the
-pin at a branch, widening permissions, or losing the flat-layout
-configuration) fails CI on the pull request rather than surfacing in a
-scheduled or manual run.
+PyYAML and assert the contract it must uphold, so drift (repointing the
+reference at a mutable branch, widening permissions, or losing the
+flat-layout configuration) fails CI on the pull request rather than
+surfacing in a scheduled or manual run. The caller must reference the
+correct reusable workflow at a commit SHA; Dependabot owns the SHA
+value, so these tests assert its shape rather than its exact value.
 """
 
 import pathlib as pl
+import re
 import typing as typ
 
 import yaml
@@ -17,12 +20,8 @@ import yaml
 REPOSITORY_ROOT = pl.Path(__file__).resolve().parents[1]
 WORKFLOW_PATH = REPOSITORY_ROOT / ".github" / "workflows" / "mutation-testing.yml"
 
-#: The commit SHA the caller pins ``mutation-mutmut.yml`` to. Bump the
-#: workflow and this test together.
-PINNED_SHA = "927edd45ae77be4251a8a18ca9eb5613a2e32cbd"
-
-EXPECTED_USES = (
-    "leynos/shared-actions/.github/workflows/mutation-mutmut.yml@" + PINNED_SHA
+USES_RE = re.compile(
+    r"^leynos/shared-actions/\.github/workflows/mutation-mutmut\.yml@[0-9a-f]{40}$"
 )
 
 #: The exact caller configuration: flat package layout, so the mutable
@@ -64,25 +63,15 @@ def _mutation_job(workflow: dict[typ.Any, typ.Any]) -> dict[str, typ.Any]:
     return jobs["mutation"]
 
 
-def test_uses_reference_is_pinned_to_the_documented_sha() -> None:
-    """The job must call the shared workflow at the exact documented SHA."""
+def test_uses_reference_is_pinned_to_a_commit_sha() -> None:
+    """The job must call the correct shared workflow at a full commit SHA."""
     uses = _mutation_job(_load()).get("uses")
     assert uses is not None, "jobs.mutation.uses is missing"
-    path, _, ref = uses.partition("@")
-    assert path == "leynos/shared-actions/.github/workflows/mutation-mutmut.yml", (
-        f"jobs.mutation.uses must reference mutation-mutmut.yml, got {path!r}"
-    )
-    assert len(ref) == 40, (
-        f"jobs.mutation.uses must pin a full 40-character commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert all(c in "0123456789abcdef" for c in ref), (
-        f"jobs.mutation.uses must pin a lowercase hex commit SHA, "
-        f"not a branch or tag: {ref!r}"
-    )
-    assert uses == EXPECTED_USES, (
-        f"jobs.mutation.uses pins {ref!r}; this test documents {PINNED_SHA!r} — "
-        "bump the workflow and this test together"
+    assert USES_RE.match(uses), (
+        "jobs.mutation.uses must reference "
+        "leynos/shared-actions/.github/workflows/mutation-mutmut.yml "
+        f"pinned to a full 40-character lowercase hex commit SHA, "
+        f"not a branch or tag: {uses!r}"
     )
 
 


### PR DESCRIPTION
## Summary

- Replace the exact-SHA equality assertion in the mutation-testing
  workflow contract test with a regex that still requires the correct
  reusable workflow path and a full 40-character commit SHA, but no
  longer pins the value.
- Remove the now-unused `PINNED_SHA`/`EXPECTED_USES` constants and
  their "bump the workflow and this test together" doc comment.
- Document the shape-not-value SHA-pinning convention in
  `docs/developers-guide.md` for future contract tests.

## Why

Dependabot already owns GitHub Actions and reusable workflow upgrades
for this repository (`.github/dependabot.yml` has a `github-actions`
ecosystem entry with `directory: "/"`), but the contract test asserted
an exact caller SHA. Every Dependabot bump PR for the
`mutation-mutmut.yml` caller would fail CI until a human hand-edited
the pinned constant, turning a routine automated bump into a manual
chore. This hands SHA ownership to Dependabot outright while keeping
the structural guard: the caller must still reference the correct
workflow path and pin a full commit SHA, not a mutable branch or tag.

## Review walkthrough

- `tests/test_mutation_workflow_contract.py`: dropped `PINNED_SHA` and
  `EXPECTED_USES`; added a `USES_RE` regex
  (`^leynos/shared-actions/\.github/workflows/mutation-mutmut\.yml@[0-9a-f]{40}$`)
  and renamed the test to `test_uses_reference_is_pinned_to_a_commit_sha`.
  All other assertions (permissions, workflow-level permissions,
  concurrency, triggers, and the `with` block) are untouched.
- `docs/developers-guide.md`: added a "Workflow pins and Dependabot"
  section explaining the policy, with a worked example.

## Validation

- `uv run pytest tests/test_mutation_workflow_contract.py -v` — all 6
  tests pass against the currently pinned SHA
  (`927edd45ae77be4251a8a18ca9eb5613a2e32cbd`), confirming the regex
  matches today's value.
- By construction, the regex matches any 40-character lowercase-hex
  SHA on the correct path, so a future Dependabot bump to a different
  SHA will also pass without editing the test.
- `.github/dependabot.yml` already has the required `github-actions`
  ecosystem entry (`directory: "/"`, weekly schedule); no change
  needed there.
- `make spelling` fails identically on unmodified `main`, in
  execplan/roadmap docs this branch does not touch (pre-existing
  `artifact`→`artefact` en-GB-oxendict drift); not fixed here as it is
  out of scope for this change and not something this branch
  introduces.
