### PR TITLE
Correct artifact to artefact in developer docs

### DIFF
--- a/docs/execplans/1-4-3-reference-binding-resolution.md
+++ b/docs/execplans/1-4-3-reference-binding-resolution.md
@@ -723,9 +723,9 @@ are true:
 - If scope or dependency tolerances are exceeded, stop and update this ExecPlan
   before continuing.
 
-## Artifacts and notes
+## Artefacts and notes
 
-Expected evidence artifacts:
+Expected evidence artefacts:
 
 - `/tmp/impl-1-4-3-git-status.log`
 - `/tmp/impl-1-4-3-episode-schema.log`

--- a/docs/execplans/1-5-2-scaffold-celery-workers-with-rabbit-mq-integration.md
+++ b/docs/execplans/1-5-2-scaffold-celery-workers-with-rabbit-mq-integration.md
@@ -462,7 +462,7 @@ If live broker testing is attempted and proves unstable, stop at the tolerance
 boundary, document the issue in `Decision Log`, and request direction rather
 than improvising a broad infrastructure detour.
 
-## Artifacts and notes
+## Artefacts and notes
 
 Implementation should preserve a concise record of:
 

--- a/docs/execplans/2-2-1-relational-schema-design.md
+++ b/docs/execplans/2-2-1-relational-schema-design.md
@@ -275,7 +275,7 @@ ingestion job that created it. Reference document revisions belong to a parent
 reference document owned by a series profile. This design supports versioned
 reference content, multi-source episode assembly, and full ingestion provenance.
 
-## Artifacts and notes
+## Artefacts and notes
 
 - `/tmp/make-fmt.log` records formatting output.
 - `/tmp/make-markdownlint.log` records Markdown lint results.

--- a/docs/execplans/2-2-2-migration-tooling-with-alembic.md
+++ b/docs/execplans/2-2-2-migration-tooling-with-alembic.md
@@ -477,7 +477,7 @@ fails, the developer creates or corrects the migration and reruns
 If tests fail, fix the issue and rerun the relevant `make` target. Log files in
 `/tmp` are overwritten on each run.
 
-## Artifacts and notes
+## Artefacts and notes
 
 - `/tmp/make-check-fmt.log` — formatting check output.
 - `/tmp/make-typecheck.log` — type check output.

--- a/docs/execplans/2-2-3-repository-and-unit-of-work-layers.md
+++ b/docs/execplans/2-2-3-repository-and-unit-of-work-layers.md
@@ -458,7 +458,7 @@ are discarded after each test. If tests fail, fix the issue and rerun
 
 Documentation edits are idempotent and may be repeated safely.
 
-## Artifacts and notes
+## Artefacts and notes
 
 - `/tmp/make-fmt.log` -- formatting output.
 - `/tmp/make-check-fmt.log` -- formatting check output.

--- a/docs/execplans/2-2-4-multi-source-ingestion-service.md
+++ b/docs/execplans/2-2-4-multi-source-ingestion-service.md
@@ -651,7 +651,7 @@ are discarded after each test. If tests fail, fix the issue and rerun
 
 Documentation edits are idempotent and may be repeated safely.
 
-## Artifacts and notes
+## Artefacts and notes
 
 - `/tmp/make-fmt.log` — formatting output.
 - `/tmp/make-check-fmt.log` — formatting check output.

--- a/docs/execplans/2-2-5-capture-provenance-metadata.md
+++ b/docs/execplans/2-2-5-capture-provenance-metadata.md
@@ -384,9 +384,9 @@ Acceptance criteria:
 - If provenance key naming changes mid-implementation, update all tests and
   docs in the same change to keep consistency.
 
-## Artifacts and notes
+## Artefacts and notes
 
-Expected log artifacts:
+Expected log artefacts:
 
 - `/tmp/2-2-5-target-unit-before.log`
 - `/tmp/2-2-5-target-bdd-before.log`

--- a/docs/execplans/2-2-6-chrono-runtime-estimator.md
+++ b/docs/execplans/2-2-6-chrono-runtime-estimator.md
@@ -892,7 +892,7 @@ segments with normalized text and locator/provenance metadata. Chrono should
 depend on that surface instead of depending on lower-level parser events unless
 the ADR explicitly chooses an event-level integration.
 
-## Artifacts and notes
+## Artefacts and notes
 
 This plan was drafted before implementation. Validation evidence for the plan
 branch:

--- a/docs/execplans/2-2-6-define-reusable-reference-document-model.md
+++ b/docs/execplans/2-2-6-define-reusable-reference-document-model.md
@@ -404,7 +404,7 @@ Quality acceptance:
   backward-compatible fields and document deprecation path instead of removing
   keys.
 
-## Artifacts and notes
+## Artefacts and notes
 
 Capture and keep concise evidence:
 

--- a/docs/execplans/2-2-6-reusable-reference-document-repository-docs.md
+++ b/docs/execplans/2-2-6-reusable-reference-document-repository-docs.md
@@ -284,7 +284,7 @@ Acceptance is documentation behaviour, not runtime behaviour.
   re-apply wording aligned to the comparison rule: ingestion-bound
   `SourceDocument` versus reusable `ReferenceDocument`.
 
-## Artifacts and notes
+## Artefacts and notes
 
 During implementation, capture concise evidence here:
 

--- a/docs/execplans/2-2-6-series-profile-and-episode-template-models.md
+++ b/docs/execplans/2-2-6-series-profile-and-episode-template-models.md
@@ -133,7 +133,7 @@ Success is observable when:
 - Decision: keep this ExecPlan aligned to the requested filename
   `docs/execplans/2-2-6-series-profile-and-episode-template-models.md` while
   grounding completion against the current roadmap text. Rationale: preserves
-  requested artifact naming without risking checklist drift. Date/Author:
+  requested artefact naming without risking checklist drift. Date/Author:
   2026-02-20 / Codex.
 
 - Decision: treat REST endpoints as inbound adapters over domain services, not
@@ -369,7 +369,7 @@ Acceptance requires all of the following:
   stop, log the issue in `Decision Log`, and re-baseline from failing tests
   before resuming.
 
-## Artifacts and notes
+## Artefacts and notes
 
 When implementation starts, capture concise excerpts from:
 

--- a/docs/execplans/2-2-7-rest-endpoints-for-reference-documents.md
+++ b/docs/execplans/2-2-7-rest-endpoints-for-reference-documents.md
@@ -480,9 +480,9 @@ are true:
 - If scope or dependency tolerances are exceeded, stop and update this ExecPlan
   before continuing.
 
-## Artifacts and notes
+## Artefacts and notes
 
-Expected evidence artifacts:
+Expected evidence artefacts:
 
 - `/tmp/impl-2-2-7-git-status.log`
 - `/tmp/impl-2-2-7-roadmap-spec-scan.log`

--- a/docs/execplans/2-3-2-generate-chapter-markers-aligned-to-script-segments.md
+++ b/docs/execplans/2-3-2-generate-chapter-markers-aligned-to-script-segments.md
@@ -548,7 +548,7 @@ with a clear `pytest.skip(...)` message, matching the existing show-notes
 behavioural test pattern. Do not replace Vidai Mock with a different inference
 harness.
 
-## Artifacts and notes
+## Artefacts and notes
 
 The closest existing implementation artefacts are:
 

--- a/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md
+++ b/docs/execplans/2-4-2-add-lang-graph-suspend-and-resume-orchestration.md
@@ -598,7 +598,7 @@ or database commands without explicit approval. If a checkpoint is persisted
 but the graph resume fails, keep the checkpoint in a non-resumed state with
 diagnostic metadata so a later retry can resume or mark it failed.
 
-## Artifacts and notes
+## Artefacts and notes
 
 Useful existing entrypoints:
 

--- a/docs/execplans/2-4-4-cost-accounting-and-usage-metering.md
+++ b/docs/execplans/2-4-4-cost-accounting-and-usage-metering.md
@@ -1245,7 +1245,7 @@ respectively). If a behavioural scenario is interrupted mid-run, rerunning it
 produces the same ledger row count because every insert is keyed by a
 deterministic idempotency key.
 
-## Artifacts and notes
+## Artefacts and notes
 
 Key transcripts and snapshots produced during implementation are stored under
 `/tmp/<action>-episodic-<branch>.out` for review per the agent guidance in

--- a/docs/execplans/2-6-1-generation-run-port-and-domain-model.md
+++ b/docs/execplans/2-6-1-generation-run-port-and-domain-model.md
@@ -1055,7 +1055,7 @@ All operations are local; no remote-state mutation occurs in this plan. There
 is no destructive change to the database, the CI configuration, or the
 published documentation.
 
-## Artifacts and notes
+## Artefacts and notes
 
 Expected transcripts and short examples will be inlined as each stage
 completes. The minimum capture is one short *pass* transcript per gate and one

--- a/docs/execplans/4-1-2-finalize-rest-surfaces.md
+++ b/docs/execplans/4-1-2-finalize-rest-surfaces.md
@@ -1150,7 +1150,7 @@ an accidental import from `episodic.api` into `episodic.canonical`. Run
 `uv run hecate check` directly to see the offending edge (the verbose output
 includes the diagnostic identifier `ARCH001` and the source/target group names).
 
-## Artifacts and notes
+## Artefacts and notes
 
 Evidence artefacts to retain:
 

--- a/docs/execplans/femtologging-april-2026-migration.md
+++ b/docs/execplans/femtologging-april-2026-migration.md
@@ -510,9 +510,9 @@ The migration is complete only when all of the following are true:
   `Surprises & Discoveries`.
 - Preserve all `/tmp/femtologging-migration-*.log` files as the evidence trail.
 
-## Artifacts and notes
+## Artefacts and notes
 
-Expected evidence artifacts:
+Expected evidence artefacts:
 
 - `/tmp/femtologging-migration-git-status.log`
 - `/tmp/femtologging-migration-scan.log`

--- a/docs/execplans/langgraph-design-enhancements.md
+++ b/docs/execplans/langgraph-design-enhancements.md
@@ -195,7 +195,7 @@ the offending Markdown and re-run the relevant `make` target using the same
 `set -o pipefail` and `tee` pattern. The log files in `/tmp` provide the last
 failure context and can be overwritten safely.
 
-## Artifacts and notes
+## Artefacts and notes
 
 - `/tmp/make-fmt.log` records formatting output.
 - `/tmp/make-markdownlint.log` records Markdown lint results.

--- a/docs/execplans/nile-valley-integration.md
+++ b/docs/execplans/nile-valley-integration.md
@@ -278,7 +278,7 @@ repository quality gates pass.
       path can be driven through `make local-k8s-up` while preserving
       Docker/`k3d` defaults.
 - [x] (2026-06-13T15:55:00Z) Full validation passed after fixing the rootless
-      Podman `act` artifact server binding: `make check-fmt`, `make typecheck`,
+      Podman `act` artefact server binding: `make check-fmt`, `make typecheck`,
       `make lint`, `make test` (`704 passed, 1 skipped`), `make markdownlint`,
       and `make nixie`.
 - [x] (2026-06-13T16:20:00Z) CodeRabbit review found only assertion-message
@@ -751,10 +751,10 @@ repository quality gates pass.
   preview on rootless Podman" section.
 
 - Observation (2026-06-13): when the Podman socket is live, the repository's
-  `act` workflow tests also need an artifact server reachable from rootless job
+  `act` workflow tests also need an artefact server reachable from rootless job
   containers. Evidence:
   `/tmp/workflow-act-rootless-artifacts-episodic-nile-valley-integration-rerun.out`
-  passed after binding the artifact server to `0.0.0.0` with a concrete free
+  passed after binding the artefact server to `0.0.0.0` with a concrete free
   port instead of advertising port `0`. Impact: the helper still skips on hosts
   without a usable Podman socket, but a live rootless Podman host now exercises
   the workflow tests successfully.
@@ -1320,7 +1320,7 @@ If a quality gate fails after formatting or docs changes, update this ExecPlan
 with the failure and remediation before continuing. If a tolerance threshold is
 hit, stop implementation and ask for direction.
 
-## Artifacts and notes
+## Artefacts and notes
 
 Primary project files to inspect before implementation:
 

--- a/docs/execplans/roadmap-normalization.md
+++ b/docs/execplans/roadmap-normalization.md
@@ -368,9 +368,9 @@ PATH=/root/.bun/bin:$PATH make markdownlint && make nixie
 All edits are to a single Markdown file. If a stage fails, revert to the
 previous committed state and retry. No destructive operations are involved.
 
-## Artifacts and notes
+## Artefacts and notes
 
-Evidence artifacts (to be captured during implementation):
+Evidence artefacts (to be captured during implementation):
 
 - `/tmp/roadmap-norm-make-fmt.log`
 - `/tmp/roadmap-norm-make-markdownlint.log`

--- a/docs/execplans/update-to-tei-rapporteur-with-type-hints.md
+++ b/docs/execplans/update-to-tei-rapporteur-with-type-hints.md
@@ -275,9 +275,9 @@ All steps are re-runnable. If a step fails:
 - If upstream typed API differs, pause at the tolerance gate and record
   options in `Decision log` before proceeding.
 
-## Artifacts and notes
+## Artefacts and notes
 
-Expected execution artifacts:
+Expected execution artefacts:
 
 - `/tmp/update-tei-typecheck-before.log`
 - `/tmp/update-tei-uv-lock.log`

--- a/docs/execplans/upgrade-python-to-3-14-adopt-compression-zstd.md
+++ b/docs/execplans/upgrade-python-to-3-14-adopt-compression-zstd.md
@@ -13,7 +13,7 @@ Status: COMPLETE
 After this change, Episodic will use Python 3.14 standard-library Zstandard
 compression for large text payloads where storage and transfer costs matter,
 beginning with canonical Text Encoding Initiative (TEI)-adjacent payloads and
-future orchestration artifacts. The observable outcome is reduced payload size
+future orchestration artefacts. The observable outcome is reduced payload size
 while preserving exact round-trip content semantics for domain consumers.
 
 Success is visible when payloads can be compressed and decompressed losslessly,
@@ -167,7 +167,7 @@ first-party compression without an extra dependency.
 
 Stage A defines policy. Decide initial compression targets, minimum size
 thresholds, and where metadata indicating compression state will be stored.
-Confirm whether first milestone is schema-additive or purely in-memory artifact
+Confirm whether first milestone is schema-additive or purely in-memory artefact
 compression.
 
 Stage B creates tests first. Add round-trip tests for text payloads,
@@ -232,7 +232,7 @@ Acceptance criteria:
 - Migration rollback path must be documented before applying production schema
   changes.
 
-## Artifacts and notes
+## Artefacts and notes
 
 Capture during implementation:
 

--- a/docs/execplans/upgrade-python-to-3-14-adopt-concurrent-interpreters.md
+++ b/docs/execplans/upgrade-python-to-3-14-adopt-concurrent-interpreters.md
@@ -235,7 +235,7 @@ Acceptance criteria:
   to baseline execution only.
 - Benchmark and test commands are safe to re-run and overwrite logs.
 
-## Artifacts and notes
+## Artefacts and notes
 
 Capture during implementation:
 

--- a/docs/execplans/upgrade-python-to-3-14-adopt-custom-task-factory-support.md
+++ b/docs/execplans/upgrade-python-to-3-14-adopt-custom-task-factory-support.md
@@ -210,7 +210,7 @@ Acceptance criteria:
   isolated hardening.
 - All commands are safe to rerun; logs can be overwritten.
 
-## Artifacts and notes
+## Artefacts and notes
 
 Capture during implementation:
 

--- a/docs/execplans/upgrade-python-to-3-14-lazy-annotations.md
+++ b/docs/execplans/upgrade-python-to-3-14-lazy-annotations.md
@@ -219,7 +219,7 @@ Acceptance criteria:
 - If lint churn becomes broad, limit fixes to annotation-related changes and
   escalate on scope breach.
 
-## Artifacts and notes
+## Artefacts and notes
 
 Capture during implementation:
 

--- a/docs/execplans/upgrade-python-to-3-14-template-strings-in-prompts.md
+++ b/docs/execplans/upgrade-python-to-3-14-template-strings-in-prompts.md
@@ -214,7 +214,7 @@ Acceptance criteria:
   defer additional adapters to follow-up plans.
 - Failed rendering tests should be corrected before wider integration.
 
-## Artifacts and notes
+## Artefacts and notes
 
 Capture during implementation:
 

--- a/docs/execplans/upgrade-python-to-3-14-type-guards-in-openai-client.md
+++ b/docs/execplans/upgrade-python-to-3-14-type-guards-in-openai-client.md
@@ -204,7 +204,7 @@ Acceptance criteria:
 - If SDK changes break guards, update only normalization layer and fixtures.
 - Test commands are deterministic and safe to rerun.
 
-## Artifacts and notes
+## Artefacts and notes
 
 Capture during implementation:
 

--- a/docs/execplans/upgrade-python-to-3-14-uuid7-for-storage-ids.md
+++ b/docs/execplans/upgrade-python-to-3-14-uuid7-for-storage-ids.md
@@ -232,7 +232,7 @@ Acceptance is met when all of the following are true:
 - If full test suite runtime is long, re-run targeted files first to localize
   regressions before repeating `make test`.
 
-## Artifacts and notes
+## Artefacts and notes
 
 Capture the following evidence during implementation:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -723,7 +723,7 @@ and iteration-cap invariants across generated run states.
   - After each generation attempt, run generated TEI through Chrono and record
     `estimated_seconds`, estimator identity, and policy check outcome.
   - Compare against minimum/maximum duration thresholds from configuration.
-  - Emit a signed QA finding artifact and generation event for short/long-draft
+  - Emit a signed QA finding artefact and generation event for short/long-draft
     outcomes that can drive a refinement turn.
   - Add Hypothesis property-based tests for short, in-range, and long Chrono
     duration outcomes across generated TEI segment shapes.


### PR DESCRIPTION
## Summary

Correct `artifact` to the en-GB-oxendict `artefact` across historical
execplan and roadmap documents.

## Why

The `make spelling` gate (en-GB-oxendict typos) fails on `main`: several
developer docs predate the gate and carry the US spelling `artifact`.
Because the spelling step scans all tracked Markdown, this pre-existing
drift fails the required `lint-test` check on every open pull request,
not just ones that touch these files. This applies the tool's own
auto-correction to restore a green gate.

## Review walkthrough

- 30 docs under `docs/` (execplans and `roadmap.md`): 42 prose
  occurrences of `artifact`/`Artifacts` rewritten to
  `artefact`/`Artefacts`. Code spans and fenced blocks are untouched,
  as the spelling gate ignores them.

## Validation

- Generated `typos.toml` and ran the repository's own
  `typos --config typos.toml --force-exclude --write-changes`; the diff
  is exactly the flagged `artifact`->`artefact` corrections.
- No code, tests, or configuration changed.
