### PR TITLE
Add the CodeScene mode: check coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v4
         with:
-          # Full history so a future `cs-coverage check` can reach the
-          # pull request's merge base (see the deferred gate note below).
+          # Full history so `cs-coverage check` can reach the pull
+          # request's merge base.
           fetch-depth: 0
 
       - name: Set up Python
@@ -99,17 +99,6 @@ jobs:
       # own coverage (and advance the ratchet baseline) via
       # coverage-main.yml, so generating it here as well would duplicate
       # the work and the CodeScene upload for the same commit.
-      #
-      # The `mode: check` gate step is deliberately not wired in yet:
-      # CodeScene project 76628 has no coverage-gates configuration, so
-      # `cs-coverage check` fails every run with "HTTP call succeeded,
-      # but the received project-config isn't valid. Lacks the gates
-      # configuration." — a CodeScene-side per-project setting, not a CI
-      # defect (ddlint#287 and chutoro#156 hit the byte-identical error).
-      # Add the check step in a fast-follow PR once coverage-main.yml has
-      # uploaded to main at least once and the gate is confirmed to
-      # resolve, or once CodeScene confirms the project's coverage gate
-      # is enabled.
       - name: Generate coverage
         if: github.event_name == 'pull_request'
         uses: leynos/shared-actions/.github/actions/generate-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
@@ -123,3 +112,20 @@ jobs:
           # xdist-clean under coverage instrumentation.
           pytest-workers: ''
           with-ratchet: 'true'
+
+      # CodeScene project 76628's coverage gate has been enabled
+      # CodeScene-side (verified via GET /v2/code-coverage/projects/76628/config
+      # returning a populated `gates` array, matching mxd's working
+      # project), so `cs-coverage check` now has a gates configuration
+      # to evaluate against.
+      - name: Check coverage against CodeScene gates
+        env:
+          CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
+        if: env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        with:
+          format: cobertura
+          mode: check
+          project-url: https://api.codescene.io/v2/projects/76628
+          access-token: ${{ env.CS_ACCESS_TOKEN }}
+          installer-checksum: ${{ vars.CODESCENE_CLI_SHA256 }}


### PR DESCRIPTION
## Summary

- CodeScene project 76628's coverage gate has been enabled CodeScene-side (a
  `GET /v2/code-coverage/projects/76628/config` probe now returns a
  populated `gates` array, matching mxd's working project, instead of the
  empty response that previously blocked `cs-coverage check`).
- Replace the deferred-gate comment in `.github/workflows/ci.yml`'s
  `lint-test` job with the guarded `mode: check` step, so pull requests get
  the changed-line coverage gate in addition to the existing ratchet.
- `coverage-main.yml` is untouched and stays on `mode: upload`.

## Review walkthrough

- [`.github/workflows/ci.yml`](https://github.com/leynos/episodic/blob/codescene-mode-check/.github/workflows/ci.yml):
  the new "Check coverage against CodeScene gates" step runs after
  "Generate coverage", guarded by `env.CS_ACCESS_TOKEN != ''` (already set
  in both secret stores from the earlier onboarding PR) and
  `github.event_name == 'pull_request'`. Uses the same shared-actions pin
  (`927edd4`) as the existing `generate-coverage` and `upload-codescene-coverage`
  steps, `format: cobertura` to match the repo's Python coverage output,
  and `project-url: https://api.codescene.io/v2/projects/76628`.
  `fetch-depth: 0` was already in place on the checkout step so the merge
  base is reachable.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"`
  passes.
- No workflow-contract test in the repo pins `ci.yml`'s structure or
  coverage-step shape, so none needed updating.
- CI on this PR's own head must show the "Check coverage against CodeScene
  gates" step executing (not skipped) and succeeding, and the `CodeScene
  Code Coverage` check completing rather than timing out.
