### PR TITLE
Bump shared-actions pins to 18bed1ca

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       # the work and the CodeScene upload for the same commit.
       - name: Generate coverage
         if: github.event_name == 'pull_request'
-        uses: leynos/shared-actions/.github/actions/generate-coverage@dfddcb6cf53a2583e55bf0c3536c01ed1f67dc16
+        uses: leynos/shared-actions/.github/actions/generate-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           output-path: coverage.xml
           format: cobertura
@@ -122,7 +122,7 @@ jobs:
         env:
           CS_ACCESS_TOKEN: ${{ secrets.CS_ACCESS_TOKEN }}
         if: env.CS_ACCESS_TOKEN != '' && github.event_name == 'pull_request'
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           format: cobertura
           mode: check

--- a/.github/workflows/coverage-main.yml
+++ b/.github/workflows/coverage-main.yml
@@ -64,7 +64,7 @@ jobs:
         run: make build
 
       - name: Generate coverage
-        uses: leynos/shared-actions/.github/actions/generate-coverage@dfddcb6cf53a2583e55bf0c3536c01ed1f67dc16
+        uses: leynos/shared-actions/.github/actions/generate-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           output-path: coverage.xml
           format: cobertura
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload coverage data to CodeScene
         if: env.CS_ACCESS_TOKEN != ''
-        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+        uses: leynos/shared-actions/.github/actions/upload-codescene-coverage@18bed1ca49a6de3d8882bd72635a32ae3f023d57
         with:
           format: cobertura
           path: coverage.xml

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -28,6 +28,6 @@ jobs:
       # The token is not used for any external cloud auth.
       id-token: write
     if: ${{ github.event_name == 'workflow_dispatch' || github.actor == 'dependabot[bot]' }}
-    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@dfddcb6cf53a2583e55bf0c3536c01ed1f67dc16
+    uses: leynos/shared-actions/.github/workflows/dependabot-automerge.yml@18bed1ca49a6de3d8882bd72635a32ae3f023d57
     with:
       pull-request-number: ${{ inputs.pull-request-number || github.event.pull_request.number }}

--- a/.github/workflows/mutation-testing.yml
+++ b/.github/workflows/mutation-testing.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
       id-token: write # OIDC workflow-source resolution
-    uses: leynos/shared-actions/.github/workflows/mutation-mutmut.yml@927edd45ae77be4251a8a18ca9eb5613a2e32cbd
+    uses: leynos/shared-actions/.github/workflows/mutation-mutmut.yml@18bed1ca49a6de3d8882bd72635a32ae3f023d57
     with:
       # Flat package layout: the mutable source lives in episodic/, not src/.
       paths: "episodic/"


### PR DESCRIPTION
## Summary

- Move every `leynos/shared-actions` reusable workflow and action ref
  to `18bed1ca49a6de3d8882bd72635a32ae3f023d57`, the current
  shared-actions main HEAD.
- Picks up the coverage-ratchet baseline-advance fix and symmetric
  +/-1pp dead-band (shared-actions#353), plus routine follow-ups
  (#354, #356 whitaker-installer 0.2.6, #344).

## Review walkthrough

- `.github/workflows/mutation-testing.yml`: `mutation-mutmut.yml`
  reusable workflow pin bumped.
- `.github/workflows/coverage-main.yml`: `generate-coverage`,
  `upload-codescene-coverage` action pins bumped.
- `.github/workflows/ci.yml`: `generate-coverage`,
  `upload-codescene-coverage` action pins bumped.
- `.github/workflows/dependabot-automerge.yml`: reusable workflow pin
  bumped.
- No other refs, inputs, or logic changed.

## Validation

- [x] `grep -rE 'leynos/shared-actions/[^@]+@[0-9a-f]{40}'
      .github/workflows/` shows only the new pin.
- [x] `uv run pytest tests/test_mutation_workflow_contract.py -q`
      (shape-only contract test) passes: 6 passed.
- [ ] CI green on this PR.
